### PR TITLE
Return Generated Console Credentials

### DIFF
--- a/models/create_tenant_response.go
+++ b/models/create_tenant_response.go
@@ -23,6 +23,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -35,12 +36,42 @@ type CreateTenantResponse struct {
 	// access key
 	AccessKey string `json:"access_key,omitempty"`
 
+	// console
+	Console *CreateTenantResponseConsole `json:"console,omitempty"`
+
 	// secret key
 	SecretKey string `json:"secret_key,omitempty"`
 }
 
 // Validate validates this create tenant response
 func (m *CreateTenantResponse) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateConsole(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *CreateTenantResponse) validateConsole(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Console) { // not required
+		return nil
+	}
+
+	if m.Console != nil {
+		if err := m.Console.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("console")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -55,6 +86,41 @@ func (m *CreateTenantResponse) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *CreateTenantResponse) UnmarshalBinary(b []byte) error {
 	var res CreateTenantResponse
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// CreateTenantResponseConsole create tenant response console
+//
+// swagger:model CreateTenantResponseConsole
+type CreateTenantResponseConsole struct {
+
+	// access key
+	AccessKey string `json:"access_key,omitempty"`
+
+	// secret key
+	SecretKey string `json:"secret_key,omitempty"`
+}
+
+// Validate validates this create tenant response console
+func (m *CreateTenantResponseConsole) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *CreateTenantResponseConsole) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *CreateTenantResponseConsole) UnmarshalBinary(b []byte) error {
+	var res CreateTenantResponseConsole
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2020,6 +2020,17 @@ func init() {
         "access_key": {
           "type": "string"
         },
+        "console": {
+          "type": "object",
+          "properties": {
+            "access_key": {
+              "type": "string"
+            },
+            "secret_key": {
+              "type": "string"
+            }
+          }
+        },
         "secret_key": {
           "type": "string"
         }
@@ -4842,6 +4853,17 @@ func init() {
     }
   },
   "definitions": {
+    "CreateTenantResponseConsole": {
+      "type": "object",
+      "properties": {
+        "access_key": {
+          "type": "string"
+        },
+        "secret_key": {
+          "type": "string"
+        }
+      }
+    },
     "NodeSelectorTermMatchExpressionsItems0": {
       "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       "type": "object",
@@ -5358,6 +5380,17 @@ func init() {
       "properties": {
         "access_key": {
           "type": "string"
+        },
+        "console": {
+          "type": "object",
+          "properties": {
+            "access_key": {
+              "type": "string"
+            },
+            "secret_key": {
+              "type": "string"
+            }
+          }
         },
         "secret_key": {
           "type": "string"

--- a/swagger.yml
+++ b/swagger.yml
@@ -1817,6 +1817,13 @@ definitions:
         type: string
       secret_key:
         type: string
+      console:
+        type: object
+        properties:
+          access_key:
+            type: string
+          secret_key:
+            type: string
   zone:
     type: object
     required:


### PR DESCRIPTION
Whe Console is configured, we auto generate credentials for Console and store them in a secret but we need to return them to the user so he knows what credentials he/she can use to log in to console.