### PR TITLE
Add imagePullSecretsName field on Add Tenant request

### DIFF
--- a/models/create_tenant_request.go
+++ b/models/create_tenant_request.go
@@ -57,6 +57,9 @@ type CreateTenantRequest struct {
 	// image
 	Image string `json:"image,omitempty"`
 
+	// image pull secrets name
+	ImagePullSecretsName string `json:"imagePullSecretsName,omitempty"`
+
 	// mounth path
 	MounthPath string `json:"mounth_path,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2043,6 +2043,9 @@ func init() {
         "image": {
           "type": "string"
         },
+        "imagePullSecretsName": {
+          "type": "string"
+        },
         "mounth_path": {
           "type": "string"
         },
@@ -5932,6 +5935,9 @@ func init() {
           "$ref": "#/definitions/idpConfiguration"
         },
         "image": {
+          "type": "string"
+        },
+        "imagePullSecretsName": {
           "type": "string"
         },
         "mounth_path": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -1771,12 +1771,14 @@ definitions:
         type: integer
         format: int64
         title: number of tenants accessible to tenant user
+
   updateTenantRequest:
     type: object
     properties:
       image:
         type: string
         pattern: "^((.*?)/(.*?):(.+))$"
+
   createTenantRequest:
     type: object
     required:
@@ -1813,6 +1815,8 @@ definitions:
         type: object
         additionalProperties:
           type: string
+      imagePullSecretsName:
+        type: string
       idp:
         type: object
         $ref: "#/definitions/idpConfiguration"


### PR DESCRIPTION
If a `imagePullSecretsName` is defined on create tenant request, it will be passed to the operator.Tenant instance to be created.