### PR TITLE
Add imagePullSecretsName field on Update Tenant request

### DIFF
--- a/models/create_tenant_request.go
+++ b/models/create_tenant_request.go
@@ -58,7 +58,7 @@ type CreateTenantRequest struct {
 	Image string `json:"image,omitempty"`
 
 	// image pull secrets name
-	ImagePullSecretsName string `json:"imagePullSecretsName,omitempty"`
+	ImagePullSecretsName string `json:"image_pull_secrets_name,omitempty"`
 
 	// mounth path
 	MounthPath string `json:"mounth_path,omitempty"`

--- a/models/update_tenant_request.go
+++ b/models/update_tenant_request.go
@@ -37,6 +37,9 @@ type UpdateTenantRequest struct {
 	// image
 	// Pattern: ^((.*?)/(.*?):(.+))$
 	Image string `json:"image,omitempty"`
+
+	// image pull secrets name
+	ImagePullSecretsName string `json:"image_pull_secrets_name,omitempty"`
 }
 
 // Validate validates this update tenant request

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2043,7 +2043,7 @@ func init() {
         "image": {
           "type": "string"
         },
-        "imagePullSecretsName": {
+        "image_pull_secrets_name": {
           "type": "string"
         },
         "mounth_path": {
@@ -3052,6 +3052,9 @@ func init() {
         "image": {
           "type": "string",
           "pattern": "^((.*?)/(.*?):(.+))$"
+        },
+        "image_pull_secrets_name": {
+          "type": "string"
         }
       }
     },
@@ -5937,7 +5940,7 @@ func init() {
         "image": {
           "type": "string"
         },
-        "imagePullSecretsName": {
+        "image_pull_secrets_name": {
           "type": "string"
         },
         "mounth_path": {
@@ -6880,6 +6883,9 @@ func init() {
         "image": {
           "type": "string",
           "pattern": "^((.*?)/(.*?):(.+))$"
+        },
+        "image_pull_secrets_name": {
+          "type": "string"
         }
       }
     },

--- a/swagger.yml
+++ b/swagger.yml
@@ -1778,6 +1778,9 @@ definitions:
       image:
         type: string
         pattern: "^((.*?)/(.*?):(.+))$"
+      image_pull_secrets_name:
+        type: string
+      
 
   createTenantRequest:
     type: object
@@ -1815,7 +1818,7 @@ definitions:
         type: object
         additionalProperties:
           type: string
-      imagePullSecretsName:
+      image_pull_secrets_name:
         type: string
       idp:
         type: object


### PR DESCRIPTION
If a `imagePullSecretsName` is defined on update tenant request, it will be passed to the operator.Tenant instance to be patched.