### PR TITLE
Add ImageRegistry field to Tenant Create and Tenant Update

### DIFF
--- a/k8s/operator-console/base/console-cluster-role.yaml
+++ b/k8s/operator-console/base/console-cluster-role.yaml
@@ -6,8 +6,18 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - namespaces
       - secrets
+    verbs:
+      - get
+      - watch
+      - create
+      - list
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
       - pods
       - services
       - events

--- a/models/create_tenant_request.go
+++ b/models/create_tenant_request.go
@@ -57,8 +57,8 @@ type CreateTenantRequest struct {
 	// image
 	Image string `json:"image,omitempty"`
 
-	// image pull secrets name
-	ImagePullSecretsName string `json:"imagePullSecretsName,omitempty"`
+	// image registry
+	ImageRegistry *ImageRegistry `json:"image_registry,omitempty"`
 
 	// mounth path
 	MounthPath string `json:"mounth_path,omitempty"`
@@ -95,6 +95,10 @@ func (m *CreateTenantRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateIdp(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateImageRegistry(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -148,6 +152,24 @@ func (m *CreateTenantRequest) validateIdp(formats strfmt.Registry) error {
 		if err := m.Idp.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("idp")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CreateTenantRequest) validateImageRegistry(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ImageRegistry) { // not required
+		return nil
+	}
+
+	if m.ImageRegistry != nil {
+		if err := m.ImageRegistry.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("image_registry")
 			}
 			return err
 		}

--- a/models/image_registry.go
+++ b/models/image_registry.go
@@ -29,28 +29,37 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// UpdateTenantRequest update tenant request
+// ImageRegistry image registry
 //
-// swagger:model updateTenantRequest
-type UpdateTenantRequest struct {
+// swagger:model imageRegistry
+type ImageRegistry struct {
 
-	// image
-	// Pattern: ^((.*?)/(.*?):(.+))$
-	Image string `json:"image,omitempty"`
+	// password
+	// Required: true
+	Password *string `json:"password"`
 
-	// image registry
-	ImageRegistry *ImageRegistry `json:"image_registry,omitempty"`
+	// registry
+	// Required: true
+	Registry *string `json:"registry"`
+
+	// username
+	// Required: true
+	Username *string `json:"username"`
 }
 
-// Validate validates this update tenant request
-func (m *UpdateTenantRequest) Validate(formats strfmt.Registry) error {
+// Validate validates this image registry
+func (m *ImageRegistry) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateImage(formats); err != nil {
+	if err := m.validatePassword(formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.validateImageRegistry(formats); err != nil {
+	if err := m.validateRegistry(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateUsername(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -60,39 +69,35 @@ func (m *UpdateTenantRequest) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *UpdateTenantRequest) validateImage(formats strfmt.Registry) error {
+func (m *ImageRegistry) validatePassword(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Image) { // not required
-		return nil
-	}
-
-	if err := validate.Pattern("image", "body", string(m.Image), `^((.*?)/(.*?):(.+))$`); err != nil {
+	if err := validate.Required("password", "body", m.Password); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (m *UpdateTenantRequest) validateImageRegistry(formats strfmt.Registry) error {
+func (m *ImageRegistry) validateRegistry(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.ImageRegistry) { // not required
-		return nil
+	if err := validate.Required("registry", "body", m.Registry); err != nil {
+		return err
 	}
 
-	if m.ImageRegistry != nil {
-		if err := m.ImageRegistry.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("image_registry")
-			}
-			return err
-		}
+	return nil
+}
+
+func (m *ImageRegistry) validateUsername(formats strfmt.Registry) error {
+
+	if err := validate.Required("username", "body", m.Username); err != nil {
+		return err
 	}
 
 	return nil
 }
 
 // MarshalBinary interface implementation
-func (m *UpdateTenantRequest) MarshalBinary() ([]byte, error) {
+func (m *ImageRegistry) MarshalBinary() ([]byte, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -100,8 +105,8 @@ func (m *UpdateTenantRequest) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary interface implementation
-func (m *UpdateTenantRequest) UnmarshalBinary(b []byte) error {
-	var res UpdateTenantRequest
+func (m *ImageRegistry) UnmarshalBinary(b []byte) error {
+	var res ImageRegistry
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/restapi/admin_tenants_test.go
+++ b/restapi/admin_tenants_test.go
@@ -35,7 +35,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 var opClientTenantDeleteMock func(ctx context.Context, namespace string, tenantName string, options metav1.DeleteOptions) error
@@ -573,6 +575,7 @@ func Test_UpdateTenantAction(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
+		objs    []runtime.Object
 		wantErr bool
 	}{
 		{
@@ -708,8 +711,9 @@ func Test_UpdateTenantAction(t *testing.T) {
 		opClientTenantGetMock = tt.args.mockTenantGet
 		opClientTenantPatchMock = tt.args.mockTenantPatch
 		httpClientGetMock = tt.args.mockHTTPClientGet
+		cnsClient := fake.NewSimpleClientset(tt.objs...)
 		t.Run(tt.name, func(t *testing.T) {
-			if err := updateTenantAction(tt.args.ctx, tt.args.operatorClient, tt.args.httpCl, tt.args.nameSpace, tt.args.params); (err != nil) != tt.wantErr {
+			if err := updateTenantAction(tt.args.ctx, tt.args.operatorClient, cnsClient.CoreV1(), tt.args.httpCl, tt.args.nameSpace, tt.args.params); (err != nil) != tt.wantErr {
 				t.Errorf("deleteTenantAction() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2043,8 +2043,8 @@ func init() {
         "image": {
           "type": "string"
         },
-        "imagePullSecretsName": {
-          "type": "string"
+        "image_registry": {
+          "$ref": "#/definitions/imageRegistry"
         },
         "mounth_path": {
           "type": "string"
@@ -2289,6 +2289,25 @@ func init() {
               "type": "string"
             }
           }
+        }
+      }
+    },
+    "imageRegistry": {
+      "type": "object",
+      "required": [
+        "registry",
+        "username",
+        "password"
+      ],
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "registry": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
         }
       }
     },
@@ -3052,6 +3071,9 @@ func init() {
         "image": {
           "type": "string",
           "pattern": "^((.*?)/(.*?):(.+))$"
+        },
+        "image_registry": {
+          "$ref": "#/definitions/imageRegistry"
         }
       }
     },
@@ -5937,8 +5959,8 @@ func init() {
         "image": {
           "type": "string"
         },
-        "imagePullSecretsName": {
-          "type": "string"
+        "image_registry": {
+          "$ref": "#/definitions/imageRegistry"
         },
         "mounth_path": {
           "type": "string"
@@ -6183,6 +6205,25 @@ func init() {
               "type": "string"
             }
           }
+        }
+      }
+    },
+    "imageRegistry": {
+      "type": "object",
+      "required": [
+        "registry",
+        "username",
+        "password"
+      ],
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "registry": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
         }
       }
     },
@@ -6880,6 +6921,9 @@ func init() {
         "image": {
           "type": "string",
           "pattern": "^((.*?)/(.*?):(.+))$"
+        },
+        "image_registry": {
+          "$ref": "#/definitions/imageRegistry"
         }
       }
     },

--- a/swagger.yml
+++ b/swagger.yml
@@ -1778,7 +1778,23 @@ definitions:
       image:
         type: string
         pattern: "^((.*?)/(.*?):(.+))$"
-
+      image_registry:
+        $ref: "#/definitions/imageRegistry"
+  
+  imageRegistry:
+    type: object
+    required:
+      - registry
+      - username
+      - password
+    properties:
+      registry:
+        type: string
+      username:
+        type: string
+      password:
+        type: string
+        
   createTenantRequest:
     type: object
     required:
@@ -1815,8 +1831,8 @@ definitions:
         type: object
         additionalProperties:
           type: string
-      imagePullSecretsName:
-        type: string
+      image_registry:
+        $ref: "#/definitions/imageRegistry"
       idp:
         type: object
         $ref: "#/definitions/idpConfiguration"


### PR DESCRIPTION
Now both Update and Create Tenant allow the following field:
```
    ...
   "image_registry": {
        "registry": "https://index.docker.io/v1/",
        "username": "username",
        "password": "password"
    },
....
```
Which should create a Secret with the following fields:
```
{
  "auths" : {
    "https:\/\/index.docker.io\/v1\/" : {
      "username" : "username",
      "password" : "password",
      "auth" : "bWluaW9kZXY6ZmVjNzZjYTgtZjczMC00YWRmLWI4YTgtMDIwM2Y5234hlYjlj" # username:password encoded
    }
  }
}
```
```
apiVersion: v1
kind: Secret
metadata:
  name: minio-regcred-cred
  namespace: <namespace>
data:
  .dockerconfigjson: BASE64ENCODEDSECRET/BYTES
type: kubernetes.io/dockerconfigjson
```