### PR TITLE
Support Usage API talk to MinIO over TLS with Insecure

### DIFF
--- a/restapi/admin_tenants_test.go
+++ b/restapi/admin_tenants_test.go
@@ -91,6 +91,7 @@ func Test_TenantInfoTenantAdminClient(t *testing.T) {
 		tenantName  string
 		serviceName string
 		scheme      string
+		insecure    bool
 	}
 	tests := []struct {
 		name           string
@@ -236,7 +237,7 @@ func Test_TenantInfoTenantAdminClient(t *testing.T) {
 		k8sclientGetSecretMock = tt.mockGetSecret
 		k8sclientGetServiceMock = tt.mockGetService
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getTenantAdminClient(tt.args.ctx, tt.args.client, tt.args.namespace, tt.args.tenantName, tt.args.serviceName, tt.args.scheme)
+			got, err := getTenantAdminClient(tt.args.ctx, tt.args.client, tt.args.namespace, tt.args.tenantName, tt.args.serviceName, tt.args.scheme, tt.args.insecure)
 			if err != nil {
 				if tt.wantErr {
 					return

--- a/restapi/client-admin.go
+++ b/restapi/client-admin.go
@@ -19,6 +19,7 @@ package restapi
 import (
 	"context"
 	"io"
+	"log"
 	"path/filepath"
 	"runtime"
 
@@ -54,7 +55,8 @@ func NewAdminClientWithInsecure(url, accessKey, secretKey string, insecure bool)
 	if err != nil {
 		return nil, err.Trace(url)
 	}
-	s3Client.SetCustomTransport(STSClient.Transport)
+	stsClient := PrepareSTSClient(insecure)
+	s3Client.SetCustomTransport(stsClient.Transport)
 	return s3Client, nil
 }
 
@@ -266,7 +268,8 @@ func newAdminFromClaims(claims *models.Principal) (*madmin.AdminClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	adminClient.SetCustomTransport(STSClient.Transport)
+	stsClient := PrepareSTSClient(false)
+	adminClient.SetCustomTransport(stsClient.Transport)
 	return adminClient, nil
 }
 

--- a/restapi/client-admin.go
+++ b/restapi/client-admin.go
@@ -19,7 +19,6 @@ package restapi
 import (
 	"context"
 	"io"
-	"log"
 	"path/filepath"
 	"runtime"
 

--- a/restapi/client.go
+++ b/restapi/client.go
@@ -164,7 +164,6 @@ func (s consoleSTSAssumeRole) IsExpired() bool {
 
 // STSClient contains http.client configuration need it by STSAssumeRole
 var (
-	STSClient     = PrepareSTSClient()
 	MinioEndpoint = getMinIOServer()
 )
 
@@ -204,8 +203,9 @@ func newConsoleCredentials(accessKey, secretKey, location string) (*credentials.
 				Location:        location,
 				DurationSeconds: xjwt.GetConsoleSTSAndJWTDurationInSeconds(),
 			}
+			stsClient := PrepareSTSClient(false)
 			stsAssumeRole := &credentials.STSAssumeRole{
-				Client:      STSClient,
+				Client:      stsClient,
 				STSEndpoint: MinioEndpoint,
 				Options:     opts,
 			}
@@ -234,10 +234,11 @@ func getConsoleCredentialsFromSession(claims *models.Principal) *credentials.Cre
 // from the provided jwt
 func newMinioClient(claims *models.Principal) (*minio.Client, error) {
 	creds := getConsoleCredentialsFromSession(claims)
+	stsClient := PrepareSTSClient(false)
 	minioClient, err := minio.New(getMinIOEndpoint(), &minio.Options{
 		Creds:     creds,
 		Secure:    getMinIOEndpointIsSecure(),
-		Transport: STSClient.Transport,
+		Transport: stsClient.Transport,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Right now if MinIO is running  with TLS, and the certificate is not trusted by console, we fail usage requests. We need to leverage the support for insecure connections so we can read Health Checks and Usage information.