### PR TITLE
Add labels and annotations on Tenant Creation request api

### DIFF
--- a/models/create_tenant_request.go
+++ b/models/create_tenant_request.go
@@ -72,6 +72,9 @@ type CreateTenantRequest struct {
 	// image registry
 	ImageRegistry *ImageRegistry `json:"image_registry,omitempty"`
 
+	// labels
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// mounth path
 	MounthPath string `json:"mounth_path,omitempty"`
 

--- a/models/zone.go
+++ b/models/zone.go
@@ -207,6 +207,9 @@ func (m *Zone) UnmarshalBinary(b []byte) error {
 // swagger:model ZoneVolumeConfiguration
 type ZoneVolumeConfiguration struct {
 
+	// annotations
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// labels
 	Labels map[string]string `json:"labels,omitempty"`
 

--- a/restapi/admin_tenants_test.go
+++ b/restapi/admin_tenants_test.go
@@ -331,6 +331,11 @@ func Test_TenantInfo(t *testing.T) {
 						Name:              "tenant1",
 						Namespace:         "minio-ns",
 						DeletionTimestamp: &testTimeStamp,
+						Annotations: map[string]string{
+							prometheusPath:   "some/path",
+							prometheusPort:   "other/path",
+							prometheusScrape: "other/path",
+						},
 					},
 					Spec: operator.TenantSpec{
 						Zones: []operator.Zone{
@@ -351,13 +356,6 @@ func Test_TenantInfo(t *testing.T) {
 							},
 						},
 						Image: "minio/minio:RELEASE.2020-06-14T18-32-17Z",
-						Metadata: &metav1.ObjectMeta{
-							Annotations: map[string]string{
-								prometheusPath:   "some/path",
-								prometheusPort:   "other/path",
-								prometheusScrape: "other/path",
-							},
-						},
 					},
 					Status: operator.TenantStatus{
 						CurrentState: "ready",
@@ -396,16 +394,14 @@ func Test_TenantInfo(t *testing.T) {
 						CreationTimestamp: testTimeStamp,
 						Name:              "tenant1",
 						Namespace:         "minio-ns",
+						Annotations: map[string]string{
+							prometheusPath:   "some/path",
+							prometheusScrape: "other/path",
+						},
 					},
 					Spec: operator.TenantSpec{
 						Zones: []operator.Zone{},
 						Image: "minio/minio:RELEASE.2020-06-14T18-32-17Z",
-						Metadata: &metav1.ObjectMeta{
-							Annotations: map[string]string{
-								prometheusPath:   "some/path",
-								prometheusScrape: "other/path",
-							},
-						},
 					},
 					Status: operator.TenantStatus{
 						CurrentState: "ready",
@@ -430,16 +426,14 @@ func Test_TenantInfo(t *testing.T) {
 						CreationTimestamp: testTimeStamp,
 						Name:              "tenant1",
 						Namespace:         "minio-ns",
+						Annotations: map[string]string{
+							prometheusPath:   "some/path",
+							prometheusScrape: "other/path",
+						},
 					},
 					Spec: operator.TenantSpec{
 						Zones: []operator.Zone{},
 						Image: "minio/minio:RELEASE.2020-06-14T18-32-17Z",
-						Metadata: &metav1.ObjectMeta{
-							Annotations: map[string]string{
-								prometheusPath:   "some/path",
-								prometheusScrape: "other/path",
-							},
-						},
 						Console: &operator.ConsoleConfiguration{
 							Image: "minio/console:master",
 						},

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2226,6 +2226,12 @@ func init() {
         "image_registry": {
           "$ref": "#/definitions/imageRegistry"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "mounth_path": {
           "type": "string"
         },
@@ -3438,6 +3444,12 @@ func init() {
             "size"
           ],
           "properties": {
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
             "labels": {
               "type": "object",
               "additionalProperties": {
@@ -6089,6 +6101,12 @@ func init() {
         "size"
       ],
       "properties": {
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {
@@ -6381,6 +6399,12 @@ func init() {
         },
         "image_registry": {
           "$ref": "#/definitions/imageRegistry"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "mounth_path": {
           "type": "string"
@@ -7528,6 +7552,12 @@ func init() {
             "size"
           ],
           "properties": {
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
             "labels": {
               "type": "object",
               "additionalProperties": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -1148,7 +1148,7 @@ paths:
             $ref: "#/definitions/error"
       tags:
         - AdminAPI
-    put: 
+    put:
       summary: Tenant Update Zones
       operationId: TenantUpdateZones
       parameters:
@@ -1282,7 +1282,7 @@ paths:
             $ref: "#/definitions/error"
       tags:
         - AdminAPI
-  
+
   /cluster/max-allocatable-memory:
     get:
       summary: Get maximum allocatable memory for given number of nodes
@@ -1908,7 +1908,7 @@ definitions:
         type: string
       enable_prometheus:
         type: boolean
-  
+
   imageRegistry:
     type: object
     required:
@@ -1922,7 +1922,7 @@ definitions:
         type: string
       password:
         type: string
-        
+
   createTenantRequest:
     type: object
     required:
@@ -1963,6 +1963,10 @@ definitions:
       erasureCodingParity:
         type: integer
       annotations:
+        type: object
+        additionalProperties:
+          type: string
+      labels:
         type: object
         additionalProperties:
           type: string
@@ -2213,6 +2217,10 @@ definitions:
             type: object
             additionalProperties:
               type: string
+          annotations:
+            type: object
+            additionalProperties:
+              type: string
       resources:
         $ref: "#/definitions/zoneResources"
       node_selector:
@@ -2263,14 +2271,14 @@ definitions:
           type: string
       type: object
     type: array
-  
+
   zoneTolerationSeconds:
     description: TolerationSeconds represents the period of
-            time the toleration (which must be of effect NoExecute,
-            otherwise this field is ignored) tolerates the taint.
-            By default, it is not set, which means tolerate the taint
-            forever (do not evict). Zero and negative values will
-            be treated as 0 (evict immediately) by the system.
+      time the toleration (which must be of effect NoExecute,
+      otherwise this field is ignored) tolerates the taint.
+      By default, it is not set, which means tolerate the taint
+      forever (do not evict). Zero and negative values will
+      be treated as 0 (evict immediately) by the system.
     type: object
     required:
       - seconds
@@ -2646,13 +2654,13 @@ definitions:
       used:
         type: integer
         format: int64
-  
+
   deleteTenantRequest:
     type: object
     properties:
       delete_pvcs:
         type: boolean
-  
+
   zoneUpdateRequest:
     type: object
     required:
@@ -2662,7 +2670,7 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/zone"
-  
+
   maxAllocatableMemResponse:
     type: object
     properties:


### PR DESCRIPTION
### What does it do?
This allows to set the Labels on the Tenant Metadata when the tenant is being created.