### PR TITLE
Use operator port variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/minio/mc v0.0.0-20200808005614-7e52c104bee1
 	github.com/minio/minio v0.0.0-20200808024306-2a9819aff876
 	github.com/minio/minio-go/v7 v7.0.5-0.20200807085956-d7db33ea7618
-	github.com/minio/operator v0.0.0-20200904194631-b8aa01dc5d70
+	github.com/minio/operator v0.0.0-20200921211523-69f9eef5b7b5
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/secure-io/sio-go v0.3.1
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -781,8 +781,8 @@ github.com/minio/minio-go/v7 v7.0.2/go.mod h1:dJ80Mv2HeGkYLH1sqS/ksz07ON6csH3S6J
 github.com/minio/minio-go/v7 v7.0.3/go.mod h1:TA0CQCjJZHM5SJj9IjqR0NmpmQJ6bCbXifAJ3mUU6Hw=
 github.com/minio/minio-go/v7 v7.0.5-0.20200807085956-d7db33ea7618 h1:8iTb0TFs6kDGAUnhI/s2QCZOYcSTtYmY9dF+Cbc0WJo=
 github.com/minio/minio-go/v7 v7.0.5-0.20200807085956-d7db33ea7618/go.mod h1:CSt2ETZNs+bIIhWTse0mcZKZWMGrFU7Er7RR0TmkDYk=
-github.com/minio/operator v0.0.0-20200904194631-b8aa01dc5d70 h1:FjyhnnrOHMzhJryqNoOISgp8p1dmmn1IMOlgBAaf8r4=
-github.com/minio/operator v0.0.0-20200904194631-b8aa01dc5d70/go.mod h1:NVl1+c7TYxJB22opK/m2L5SkTvlEYd1ZFPuL6SX5fCg=
+github.com/minio/operator v0.0.0-20200921211523-69f9eef5b7b5 h1:yQ7WHA2wbTTGHz0Z4xXSRxfUTm5fafM0ajvlZlQ2Zl4=
+github.com/minio/operator v0.0.0-20200921211523-69f9eef5b7b5/go.mod h1:6lavbNo2YuJWeQR5bZYsEWdbpRCO2KrTyfQ0PtC/AN4=
 github.com/minio/selfupdate v0.3.1 h1:BWEFSNnrZVMUWXbXIgLDNDjbejkmpAmZvy/nCz1HlEs=
 github.com/minio/selfupdate v0.3.1/go.mod h1:b8ThJzzH7u2MkF6PcIra7KaXO9Khf6alWPvMSyTDCFM=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=

--- a/restapi/admin_tenants.go
+++ b/restapi/admin_tenants.go
@@ -218,15 +218,19 @@ func deleteTenantAction(
 	return nil
 }
 
-func getTenantScheme(mi *operator.Tenant) string {
+// GetTenantServiceURL gets tenant's service url with the proper scheme and port
+func GetTenantServiceURL(mi *operator.Tenant) (svcURL string) {
 	scheme := "http"
+	port := operator.MinIOPortLoadBalancerSVC
 	if mi.AutoCert() || mi.ExternalCert() {
 		scheme = "https"
+		port = operator.MinIOTLSPortLoadBalancerSVC
 	}
-	return scheme
+	svc := fmt.Sprintf("%s.%s.svc.cluster.local", mi.MinIOCIServiceName(), mi.Namespace)
+	return fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(svc, strconv.Itoa(port)))
 }
 
-func getTenantAdminClient(ctx context.Context, client K8sClientI, namespace, tenantName, serviceName, scheme string, insecure bool) (*madmin.AdminClient, error) {
+func getTenantAdminClient(ctx context.Context, client K8sClientI, namespace, tenantName, svcURL string, insecure bool) (*madmin.AdminClient, error) {
 	// get admin credentials from secret
 	creds, err := client.getSecret(ctx, namespace, fmt.Sprintf("%s-secret", tenantName), metav1.GetOptions{})
 	if err != nil {
@@ -242,7 +246,7 @@ func getTenantAdminClient(ctx context.Context, client K8sClientI, namespace, ten
 		log.Println("tenant's secret doesn't contain secretkey")
 		return nil, errorGeneric
 	}
-	mAdmin, pErr := NewAdminClientWithInsecure(scheme+"://"+net.JoinHostPort(serviceName, strconv.Itoa(operator.MinIOPort)), string(accessKey), string(secretkey), insecure)
+	mAdmin, pErr := NewAdminClientWithInsecure(svcURL, string(accessKey), string(secretkey), insecure)
 	if pErr != nil {
 		return nil, pErr.Cause
 	}
@@ -872,7 +876,7 @@ func updateTenantAction(ctx context.Context, operatorClient OperatorClientI, cli
 		prometheusPort:   fmt.Sprint(operator.MinIOPort),
 		prometheusScrape: "true",
 	}
-	if params.Body.EnablePrometheus && minInst.Spec.Metadata != nil && currentAnnotations != nil {
+	if params.Body.EnablePrometheus && currentAnnotations != nil {
 		// add prometheus annotations to the tenant
 		minInst.Annotations = addAnnotations(currentAnnotations, prometheusAnnotations)
 		// add prometheus annotations to the each zone
@@ -1019,17 +1023,15 @@ func getTenantUsageResponse(session *models.Principal, params admin_api.GetTenan
 		return nil, prepareError(err, errorUnableToGetTenantUsage)
 	}
 	minTenant.EnsureDefaults()
-	tenantScheme := getTenantScheme(minTenant)
 
-	svcName := fmt.Sprintf("%s.%s.svc.cluster.local", minTenant.MinIOCIServiceName(), minTenant.Namespace)
+	svcURL := GetTenantServiceURL(minTenant)
 
 	mAdmin, err := getTenantAdminClient(
 		ctx,
 		k8sClient,
 		params.Namespace,
 		params.Tenant,
-		svcName,
-		tenantScheme,
+		svcURL,
 		true)
 	if err != nil {
 		return nil, prepareError(err, errorUnableToGetTenantUsage)

--- a/restapi/admin_tenants_test.go
+++ b/restapi/admin_tenants_test.go
@@ -87,13 +87,12 @@ func Test_TenantInfoTenantAdminClient(t *testing.T) {
 	ctx := context.Background()
 	kClient := k8sClientMock{}
 	type args struct {
-		ctx         context.Context
-		client      K8sClientI
-		namespace   string
-		tenantName  string
-		serviceName string
-		scheme      string
-		insecure    bool
+		ctx        context.Context
+		client     K8sClientI
+		namespace  string
+		tenantName string
+		serviceURL string
+		insecure   bool
 	}
 	tests := []struct {
 		name           string
@@ -105,12 +104,11 @@ func Test_TenantInfoTenantAdminClient(t *testing.T) {
 		{
 			name: "Return Tenant Admin, no errors",
 			args: args{
-				ctx:         ctx,
-				client:      kClient,
-				namespace:   "default",
-				tenantName:  "tenant-1",
-				serviceName: "service-1",
-				scheme:      "http",
+				ctx:        ctx,
+				client:     kClient,
+				namespace:  "default",
+				tenantName: "tenant-1",
+				serviceURL: "http://service-1.default.svc.cluster.local:80",
 			},
 			mockGetSecret: func(ctx context.Context, namespace, secretName string, opts metav1.GetOptions) (*corev1.Secret, error) {
 				vals := make(map[string][]byte)
@@ -134,12 +132,11 @@ func Test_TenantInfoTenantAdminClient(t *testing.T) {
 		{
 			name: "Access key not stored on secrets",
 			args: args{
-				ctx:         ctx,
-				client:      kClient,
-				namespace:   "default",
-				tenantName:  "tenant-1",
-				serviceName: "service-1",
-				scheme:      "http",
+				ctx:        ctx,
+				client:     kClient,
+				namespace:  "default",
+				tenantName: "tenant-1",
+				serviceURL: "http://service-1.default.svc.cluster.local:80",
 			},
 			mockGetSecret: func(ctx context.Context, namespace, secretName string, opts metav1.GetOptions) (*corev1.Secret, error) {
 				vals := make(map[string][]byte)
@@ -162,12 +159,11 @@ func Test_TenantInfoTenantAdminClient(t *testing.T) {
 		{
 			name: "Secret key not stored on secrets",
 			args: args{
-				ctx:         ctx,
-				client:      kClient,
-				namespace:   "default",
-				tenantName:  "tenant-1",
-				serviceName: "service-1",
-				scheme:      "http",
+				ctx:        ctx,
+				client:     kClient,
+				namespace:  "default",
+				tenantName: "tenant-1",
+				serviceURL: "http://service-1.default.svc.cluster.local:80",
 			},
 			mockGetSecret: func(ctx context.Context, namespace, secretName string, opts metav1.GetOptions) (*corev1.Secret, error) {
 				vals := make(map[string][]byte)
@@ -190,12 +186,11 @@ func Test_TenantInfoTenantAdminClient(t *testing.T) {
 		{
 			name: "Handle error on getService",
 			args: args{
-				ctx:         ctx,
-				client:      kClient,
-				namespace:   "default",
-				tenantName:  "tenant-1",
-				serviceName: "service-1",
-				scheme:      "http",
+				ctx:        ctx,
+				client:     kClient,
+				namespace:  "default",
+				tenantName: "tenant-1",
+				serviceURL: "http://service-1.default.svc.cluster.local:80",
 			},
 			mockGetSecret: func(ctx context.Context, namespace, secretName string, opts metav1.GetOptions) (*corev1.Secret, error) {
 				vals := make(map[string][]byte)
@@ -214,12 +209,11 @@ func Test_TenantInfoTenantAdminClient(t *testing.T) {
 		{
 			name: "Handle error on getSecret",
 			args: args{
-				ctx:         ctx,
-				client:      kClient,
-				namespace:   "default",
-				tenantName:  "tenant-1",
-				serviceName: "service-1",
-				scheme:      "http",
+				ctx:        ctx,
+				client:     kClient,
+				namespace:  "default",
+				tenantName: "tenant-1",
+				serviceURL: "http://service-1.default.svc.cluster.local:80",
 			},
 			mockGetSecret: func(ctx context.Context, namespace, secretName string, opts metav1.GetOptions) (*corev1.Secret, error) {
 				return nil, errors.New("error")
@@ -239,7 +233,7 @@ func Test_TenantInfoTenantAdminClient(t *testing.T) {
 		k8sclientGetSecretMock = tt.mockGetSecret
 		k8sclientGetServiceMock = tt.mockGetService
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getTenantAdminClient(tt.args.ctx, tt.args.client, tt.args.namespace, tt.args.tenantName, tt.args.serviceName, tt.args.scheme, tt.args.insecure)
+			got, err := getTenantAdminClient(tt.args.ctx, tt.args.client, tt.args.namespace, tt.args.tenantName, tt.args.serviceURL, tt.args.insecure)
 			if err != nil {
 				if tt.wantErr {
 					return


### PR DESCRIPTION
Updates function getTenantSchemeNPort to return port depending on scheme.
Uses lates operator v3.0.21

-Tests updated