### PR TITLE
Add list objects UI and integrate with listing and delete api

### DIFF
--- a/pkg/acl/endpoints.go
+++ b/pkg/acl/endpoints.go
@@ -40,7 +40,7 @@ var (
 	heal              = "/heal"
 	remoteBuckets     = "/remote-buckets"
 	replication       = "/replication"
-	objectBrowser     = "/object-browser/:bucket?/*"
+	objectBrowser     = "/object-browser/:bucket?"
 	mainObjectBrowser = "/object-browser"
 )
 

--- a/portal-ui/src/screens/Console/Buckets/Buckets.tsx
+++ b/portal-ui/src/screens/Console/Buckets/Buckets.tsx
@@ -1,4 +1,4 @@
-// This file is part of MinIO Buckets Server
+// This file is part of MinIO Console Server
 // Copyright (c) 2020 MinIO, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,7 @@ import {
   createStyles,
   StyledProps,
   Theme,
-  withStyles
+  withStyles,
 } from "@material-ui/core/styles";
 
 import history from "../../../history";
@@ -28,7 +28,7 @@ import {
   RouteComponentProps,
   Router,
   Switch,
-  withRouter
+  withRouter,
 } from "react-router-dom";
 import { connect } from "react-redux";
 import { AppState } from "../../../store";
@@ -41,62 +41,62 @@ import ViewBucket from "./ViewBucket/ViewBucket";
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      display: "flex"
+      display: "flex",
     },
     toolbar: {
       background: theme.palette.background.default,
       color: "black",
-      paddingRight: 24 // keep right padding when drawer closed
+      paddingRight: 24, // keep right padding when drawer closed
     },
     toolbarIcon: {
       display: "flex",
       alignItems: "center",
       justifyContent: "flex-end",
       padding: "0 8px",
-      ...theme.mixins.toolbar
+      ...theme.mixins.toolbar,
     },
     appBar: {
       zIndex: theme.zIndex.drawer + 1,
       transition: theme.transitions.create(["width", "margin"], {
         easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.leavingScreen
-      })
+        duration: theme.transitions.duration.leavingScreen,
+      }),
     },
 
     menuButton: {
-      marginRight: 36
+      marginRight: 36,
     },
     menuButtonHidden: {
-      display: "none"
+      display: "none",
     },
     title: {
-      flexGrow: 1
+      flexGrow: 1,
     },
     appBarSpacer: {
-      height: "5px"
+      height: "5px",
     },
     content: {
       flexGrow: 1,
       height: "100vh",
-      overflow: "auto"
+      overflow: "auto",
     },
     container: {
       paddingTop: theme.spacing(4),
-      paddingBottom: theme.spacing(4)
+      paddingBottom: theme.spacing(4),
     },
     paper: {
       padding: theme.spacing(2),
       display: "flex",
       overflow: "auto",
-      flexDirection: "column"
+      flexDirection: "column",
     },
     fixedHeight: {
-      minHeight: 240
-    }
+      minHeight: 240,
+    },
   });
 
 const mapState = (state: AppState) => ({
-  open: state.system.sidebarOpen
+  open: state.system.sidebarOpen,
 });
 
 const connector = connect(mapState, { setMenuOpen });

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/DeleteObject.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/DeleteObject.tsx
@@ -1,0 +1,158 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
+import React from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  LinearProgress,
+} from "@material-ui/core";
+import api from "../../../../../../common/api";
+import { BucketObjectsList } from "../ListObjects/types";
+import Typography from "@material-ui/core/Typography";
+
+const styles = (theme: Theme) =>
+  createStyles({
+    errorBlock: {
+      color: "red",
+    },
+  });
+
+interface IDeleteObjectProps {
+  classes: any;
+  closeDeleteModalAndRefresh: (refresh: boolean) => void;
+  deleteOpen: boolean;
+  selectedObject: string;
+  selectedBucket: string;
+}
+
+interface IDeleteObjectState {
+  deleteLoading: boolean;
+  deleteError: string;
+}
+
+class DeleteObject extends React.Component<
+  IDeleteObjectProps,
+  IDeleteObjectState
+> {
+  state: IDeleteObjectState = {
+    deleteLoading: false,
+    deleteError: "",
+  };
+
+  removeRecord() {
+    const { deleteLoading } = this.state;
+    const { selectedObject, selectedBucket } = this.props;
+    if (deleteLoading) {
+      return;
+    }
+    var recursive = false;
+    if (selectedObject.endsWith("/")) {
+      recursive = true;
+    }
+    this.setState({ deleteLoading: true }, () => {
+      api
+        .invoke(
+          "DELETE",
+          `/api/v1/buckets/${selectedBucket}/objects?path=${selectedObject}&recursive=${recursive}`
+        )
+        .then((res: BucketObjectsList) => {
+          this.setState(
+            {
+              deleteLoading: false,
+              deleteError: "",
+            },
+            () => {
+              this.props.closeDeleteModalAndRefresh(true);
+            }
+          );
+        })
+        .catch((err) => {
+          this.setState({
+            deleteLoading: false,
+            deleteError: err,
+          });
+        });
+    });
+  }
+
+  render() {
+    const { classes, deleteOpen, selectedObject } = this.props;
+    const { deleteLoading, deleteError } = this.state;
+
+    return (
+      <Dialog
+        open={deleteOpen}
+        onClose={() => {
+          this.setState({ deleteError: "" }, () => {
+            this.props.closeDeleteModalAndRefresh(false);
+          });
+        }}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">Delete</DialogTitle>
+        <DialogContent>
+          {deleteLoading && <LinearProgress />}
+          <DialogContentText id="alert-dialog-description">
+            Are you sure you want to delete: <b>{selectedObject}</b>?{" "}
+            {deleteError !== "" && (
+              <React.Fragment>
+                <br />
+                <Typography
+                  component="p"
+                  variant="body1"
+                  className={classes.errorBlock}
+                >
+                  {deleteError}
+                </Typography>
+              </React.Fragment>
+            )}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              this.setState({ deleteError: "" }, () => {
+                this.props.closeDeleteModalAndRefresh(false);
+              });
+            }}
+            color="primary"
+            disabled={deleteLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              this.removeRecord();
+            }}
+            color="secondary"
+            autoFocus
+          >
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+}
+
+export default withStyles(styles)(DeleteObject);

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -1,0 +1,253 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
+import Grid from "@material-ui/core/Grid";
+import { Button } from "@material-ui/core";
+import Typography from "@material-ui/core/Typography";
+import TextField from "@material-ui/core/TextField";
+import InputAdornment from "@material-ui/core/InputAdornment";
+import SearchIcon from "@material-ui/icons/Search";
+import { BucketObject, BucketObjectsList } from "./types";
+import api from "../../../../../../common/api";
+import React, { useEffect, useState } from "react";
+import TableWrapper from "../../../../Common/TableWrapper/TableWrapper";
+import { MinTablePaginationActions } from "../../../../../../common/MinTablePaginationActions";
+import { CreateIcon } from "../../.././../../../icons";
+import { niceBytes } from "../../../../../../common/utils";
+import Moment from "react-moment";
+import DeleteObject from "./DeleteObject";
+
+const styles = (theme: Theme) =>
+  createStyles({
+    seeMore: {
+      marginTop: theme.spacing(3),
+    },
+    paper: {
+      display: "flex",
+      overflow: "auto",
+      flexDirection: "column",
+    },
+
+    addSideBar: {
+      width: "320px",
+      padding: "20px",
+    },
+    errorBlock: {
+      color: "red",
+    },
+    tableToolbar: {
+      paddingLeft: theme.spacing(2),
+      paddingRight: theme.spacing(0),
+    },
+    minTableHeader: {
+      color: "#393939",
+      "& tr": {
+        "& th": {
+          fontWeight: "bold",
+        },
+      },
+    },
+    actionsTray: {
+      textAlign: "right",
+      "& button": {
+        marginLeft: 10,
+      },
+    },
+    searchField: {
+      background: "#FFFFFF",
+      padding: 12,
+      borderRadius: 5,
+      boxShadow: "0px 3px 6px #00000012",
+    },
+  });
+
+interface IListObjectsProps {
+  classes: any;
+  match: any;
+}
+
+interface IListObjectsState {
+  records: BucketObject[];
+  totalRecords: number;
+  loading: boolean;
+  error: string;
+  deleteOpen: boolean;
+  deleteError: string;
+  selectedObject: string;
+  selectedBucket: string;
+  filterObjects: string;
+}
+
+class ListObjects extends React.Component<
+  IListObjectsProps,
+  IListObjectsState
+> {
+  state: IListObjectsState = {
+    records: [],
+    totalRecords: 0,
+    loading: false,
+    error: "",
+    deleteOpen: false,
+    deleteError: "",
+    selectedObject: "",
+    selectedBucket: "",
+    filterObjects: "",
+  };
+
+  fetchRecords = () => {
+    this.setState({ loading: true }, () => {
+      const { match } = this.props;
+      const bucketName = match.params["bucket"];
+      api
+        .invoke("GET", `/api/v1/buckets/${bucketName}/objects`)
+        .then((res: BucketObjectsList) => {
+          this.setState({
+            loading: false,
+            selectedBucket: bucketName,
+            records: res.objects || [],
+            totalRecords: !res.objects ? 0 : res.total,
+            error: "",
+          });
+          // TODO:
+          // if we get 0 results, and page > 0 , go down 1 page
+        })
+        .catch((err: any) => {
+          this.setState({ loading: false, error: err });
+        });
+    });
+  };
+
+  componentDidMount(): void {
+    this.fetchRecords();
+  }
+
+  closeDeleteModalAndRefresh(refresh: boolean) {
+    this.setState({ deleteOpen: false }, () => {
+      if (refresh) {
+        this.fetchRecords();
+      }
+    });
+  }
+
+  bucketFilter(): void {}
+
+  render() {
+    const { classes } = this.props;
+    const {
+      records,
+      loading,
+      selectedObject,
+      selectedBucket,
+      deleteOpen,
+      filterObjects,
+    } = this.state;
+    const displayParsedDate = (date: string) => {
+      return <Moment>{date}</Moment>;
+    };
+
+    const confirmDeleteObject = (object: string) => {
+      this.setState({ deleteOpen: true, selectedObject: object });
+    };
+
+    const tableActions = [
+      { type: "delete", onClick: confirmDeleteObject, sendOnlyId: true },
+    ];
+
+    const filteredRecords = records.filter((b: BucketObject) => {
+      if (filterObjects === "") {
+        return true;
+      } else {
+        if (b.name.indexOf(filterObjects) >= 0) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    });
+
+    return (
+      <React.Fragment>
+        {deleteOpen && (
+          <DeleteObject
+            deleteOpen={deleteOpen}
+            selectedBucket={selectedBucket}
+            selectedObject={selectedObject}
+            closeDeleteModalAndRefresh={(refresh: boolean) => {
+              this.closeDeleteModalAndRefresh(refresh);
+            }}
+          />
+        )}
+        <Grid container>
+          <Grid item xs={12}>
+            <Typography variant="h6">Objects</Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <br />
+          </Grid>
+          <Grid item xs={12} className={classes.actionsTray}>
+            <TextField
+              placeholder="Search Objects"
+              className={classes.searchField}
+              id="search-resource"
+              label=""
+              onChange={(val) => {
+                this.setState({
+                  filterObjects: val.target.value,
+                });
+              }}
+              InputProps={{
+                disableUnderline: true,
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon />
+                  </InputAdornment>
+                ),
+              }}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <br />
+          </Grid>
+          <Grid item xs={12}>
+            <TableWrapper
+              itemActions={tableActions}
+              columns={[
+                { label: "Name", elementKey: "name" },
+                {
+                  label: "Last Modified",
+                  elementKey: "last_modified",
+                  renderFunction: displayParsedDate,
+                },
+                {
+                  label: "Size",
+                  elementKey: "size",
+                  renderFunction: niceBytes,
+                },
+              ]}
+              isLoading={loading}
+              entityName="Objects"
+              idField="name"
+              records={filteredRecords}
+            />
+          </Grid>
+        </Grid>
+      </React.Fragment>
+    );
+  }
+}
+
+export default withStyles(styles)(ListObjects);

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/types.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/types.tsx
@@ -1,0 +1,27 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+export interface BucketObject {
+  name: string;
+  size: number;
+  last_modified: Date;
+  content_type: string;
+}
+
+export interface BucketObjectsList {
+  objects: BucketObject[];
+  total: number;
+}

--- a/portal-ui/src/screens/Console/Buckets/ViewBucket/AddReplicationModal.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ViewBucket/AddReplicationModal.tsx
@@ -1,3 +1,19 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import React, { useState, useEffect } from "react";
 import get from "lodash/get";
 import ModalWrapper from "../../Common/ModalWrapper/ModalWrapper";

--- a/portal-ui/src/screens/Console/Console.tsx
+++ b/portal-ui/src/screens/Console/Console.tsx
@@ -69,6 +69,7 @@ import TenantDetails from "./Tenants/TenantDetails/TenantDetails";
 import { clearSession } from "../../common/utils";
 import RemoteBuckets from "./RemoteBuckets/RemoteBuckets";
 import ObjectBrowser from "./ObjectBrowser/ObjectBrowser";
+import ListObjects from "./Buckets/ListBuckets/Objects/ListObjects/ListObjects";
 
 function Copyright() {
   return (
@@ -255,11 +256,11 @@ const Console = ({
     },
     {
       component: ObjectBrowser,
-      path: "/object-browser/:bucket?/*",
+      path: "/object-browser",
     },
     {
-      component: ObjectBrowser,
-      path: "/object-browser",
+      component: ListObjects,
+      path: "/object-browser/:bucket?",
     },
     {
       component: Watch,

--- a/portal-ui/src/screens/Console/ObjectBrowser/BrowseBuckets.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/BrowseBuckets.tsx
@@ -30,6 +30,7 @@ import { MinTablePaginationActions } from "../../../common/MinTablePaginationAct
 import { Bucket, BucketList } from "../Buckets/types";
 import TableWrapper from "../Common/TableWrapper/TableWrapper";
 import api from "../../../common/api";
+import history from "../../../history";
 
 const styles = (theme: Theme) =>
   createStyles({

--- a/portal-ui/src/screens/Console/Trace/Trace.tsx
+++ b/portal-ui/src/screens/Console/Trace/Trace.tsx
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import React, { useEffect } from "react";
 import { IMessageEvent, w3cwebsocket as W3CWebSocket } from "websocket";
 import { AppState } from "../../../store";

--- a/restapi/user_objects.go
+++ b/restapi/user_objects.go
@@ -161,6 +161,7 @@ func deleteMultipleObjects(ctx context.Context, client MCClient, recursive bool)
 	contentCh := make(chan *mc.ClientContent, 1)
 
 	errorCh := client.remove(ctx, isIncomplete, isRemoveBucket, isBypass, contentCh)
+OUTER_LOOP:
 	for content := range client.list(ctx, listOpts) {
 		if content.Err != nil {
 			switch content.Err.ToGoError().(type) {
@@ -184,8 +185,7 @@ func deleteMultipleObjects(ctx context.Context, client MCClient, recursive bool)
 					// Ignore Permission error.
 					continue
 				}
-				close(contentCh)
-				return pErr.Cause
+				break OUTER_LOOP
 			}
 		}
 	}


### PR DESCRIPTION
fixes https://github.com/minio/console/issues/290
Integrates apis for objects.
When you click on a bucket it will redirect to the objects of that bucket, right know it only does a single redirect.
Also if the item is a folder or a single object, it should be deleted with no issues. (the api calls either recursive or not)
<img width="1570" alt="Screen Shot 2020-10-01 at 5 17 00 PM" src="https://user-images.githubusercontent.com/11819101/94875573-ff566180-0409-11eb-9d47-207f145d9733.png">
<img width="859" alt="Screen Shot 2020-10-01 at 5 17 06 PM" src="https://user-images.githubusercontent.com/11819101/94875576-01202500-040a-11eb-8b92-f43b9276c0a1.png">
