### PR TITLE
Add retention mode and legal hold mode on list objects  api

### DIFF
--- a/models/bucket_object.go
+++ b/models/bucket_object.go
@@ -35,14 +35,41 @@ type BucketObject struct {
 	// content type
 	ContentType string `json:"content_type,omitempty"`
 
+	// expiration
+	Expiration string `json:"expiration,omitempty"`
+
+	// expiration rule id
+	ExpirationRuleID string `json:"expiration_rule_id,omitempty"`
+
+	// is delete marker
+	IsDeleteMarker bool `json:"is_delete_marker,omitempty"`
+
+	// is latest
+	IsLatest bool `json:"is_latest,omitempty"`
+
 	// last modified
 	LastModified string `json:"last_modified,omitempty"`
+
+	// legal hold status
+	LegalHoldStatus string `json:"legal_hold_status,omitempty"`
 
 	// name
 	Name string `json:"name,omitempty"`
 
+	// retention mode
+	RetentionMode string `json:"retention_mode,omitempty"`
+
+	// retention until date
+	RetentionUntilDate string `json:"retention_until_date,omitempty"`
+
 	// size
 	Size int64 `json:"size,omitempty"`
+
+	// user tags
+	UserTags map[string]string `json:"user_tags,omitempty"`
+
+	// version id
+	VersionID string `json:"version_id,omitempty"`
 }
 
 // Validate validates this bucket object

--- a/restapi/client.go
+++ b/restapi/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/minio/minio-go/v7/pkg/replication"
 
@@ -54,6 +55,8 @@ type MinioClient interface {
 	getBucketNotification(ctx context.Context, bucketName string) (config notification.Configuration, err error)
 	getBucketPolicy(ctx context.Context, bucketName string) (string, error)
 	listObjects(ctx context.Context, bucket string, opts minio.ListObjectsOptions) <-chan minio.ObjectInfo
+	getObjectRetention(ctx context.Context, bucketName, objectName, versionID string) (mode *minio.RetentionMode, retainUntilDate *time.Time, err error)
+	getObjectLegalHold(ctx context.Context, bucketName, objectName string, opts minio.GetObjectLegalHoldOptions) (status *minio.LegalHoldStatus, err error)
 }
 
 // Interface implementation
@@ -114,6 +117,14 @@ func (c minioClient) getBucketReplication(ctx context.Context, bucketName string
 // implements minio.listObjects(ctx)
 func (c minioClient) listObjects(ctx context.Context, bucket string, opts minio.ListObjectsOptions) <-chan minio.ObjectInfo {
 	return c.client.ListObjects(ctx, bucket, opts)
+}
+
+func (c minioClient) getObjectRetention(ctx context.Context, bucketName, objectName, versionID string) (mode *minio.RetentionMode, retainUntilDate *time.Time, err error) {
+	return c.client.GetObjectRetention(ctx, bucketName, objectName, versionID)
+}
+
+func (c minioClient) getObjectLegalHold(ctx context.Context, bucketName, objectName string, opts minio.GetObjectLegalHoldOptions) (status *minio.LegalHoldStatus, err error) {
+	return c.client.GetObjectLegalHold(ctx, bucketName, objectName, opts)
 }
 
 // MCClient interface with all functions to be implemented

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -364,6 +364,11 @@ func init() {
             "type": "boolean",
             "name": "recursive",
             "in": "query"
+          },
+          {
+            "type": "boolean",
+            "name": "with_versions",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2570,15 +2575,45 @@ func init() {
         "content_type": {
           "type": "string"
         },
+        "expiration": {
+          "type": "string"
+        },
+        "expiration_rule_id": {
+          "type": "string"
+        },
+        "is_delete_marker": {
+          "type": "boolean"
+        },
+        "is_latest": {
+          "type": "boolean"
+        },
         "last_modified": {
+          "type": "string"
+        },
+        "legal_hold_status": {
           "type": "string"
         },
         "name": {
           "type": "string"
         },
+        "retention_mode": {
+          "type": "string"
+        },
+        "retention_until_date": {
+          "type": "string"
+        },
         "size": {
           "type": "integer",
           "format": "int64"
+        },
+        "user_tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "version_id": {
+          "type": "string"
         }
       }
     },
@@ -4739,6 +4774,11 @@ func init() {
           {
             "type": "boolean",
             "name": "recursive",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "name": "with_versions",
             "in": "query"
           }
         ],
@@ -7469,15 +7509,45 @@ func init() {
         "content_type": {
           "type": "string"
         },
+        "expiration": {
+          "type": "string"
+        },
+        "expiration_rule_id": {
+          "type": "string"
+        },
+        "is_delete_marker": {
+          "type": "boolean"
+        },
+        "is_latest": {
+          "type": "boolean"
+        },
         "last_modified": {
+          "type": "string"
+        },
+        "legal_hold_status": {
           "type": "string"
         },
         "name": {
           "type": "string"
         },
+        "retention_mode": {
+          "type": "string"
+        },
+        "retention_until_date": {
+          "type": "string"
+        },
         "size": {
           "type": "integer",
           "format": "int64"
+        },
+        "user_tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "version_id": {
+          "type": "string"
         }
       }
     },

--- a/restapi/operations/user_api/list_objects_parameters.go
+++ b/restapi/operations/user_api/list_objects_parameters.go
@@ -61,6 +61,10 @@ type ListObjectsParams struct {
 	  In: query
 	*/
 	Recursive *bool
+	/*
+	  In: query
+	*/
+	WithVersions *bool
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -86,6 +90,11 @@ func (o *ListObjectsParams) BindRequest(r *http.Request, route *middleware.Match
 
 	qRecursive, qhkRecursive, _ := qs.GetOK("recursive")
 	if err := o.bindRecursive(qRecursive, qhkRecursive, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qWithVersions, qhkWithVersions, _ := qs.GetOK("with_versions")
+	if err := o.bindWithVersions(qWithVersions, qhkWithVersions, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -146,6 +155,28 @@ func (o *ListObjectsParams) bindRecursive(rawData []string, hasKey bool, formats
 		return errors.InvalidType("recursive", "query", "bool", raw)
 	}
 	o.Recursive = &value
+
+	return nil
+}
+
+// bindWithVersions binds and validates parameter WithVersions from query.
+func (o *ListObjectsParams) bindWithVersions(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("with_versions", "query", "bool", raw)
+	}
+	o.WithVersions = &value
 
 	return nil
 }

--- a/restapi/operations/user_api/list_objects_urlbuilder.go
+++ b/restapi/operations/user_api/list_objects_urlbuilder.go
@@ -35,8 +35,9 @@ import (
 type ListObjectsURL struct {
 	BucketName string
 
-	Prefix    *string
-	Recursive *bool
+	Prefix       *string
+	Recursive    *bool
+	WithVersions *bool
 
 	_basePath string
 	// avoid unkeyed usage
@@ -93,6 +94,14 @@ func (o *ListObjectsURL) Build() (*url.URL, error) {
 	}
 	if recursiveQ != "" {
 		qs.Set("recursive", recursiveQ)
+	}
+
+	var withVersionsQ string
+	if o.WithVersions != nil {
+		withVersionsQ = swag.FormatBool(*o.WithVersions)
+	}
+	if withVersionsQ != "" {
+		qs.Set("with_versions", withVersionsQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/swagger.yml
+++ b/swagger.yml
@@ -240,6 +240,10 @@ paths:
           in: query
           required: false
           type: boolean
+        - name: with_versions
+          in: query
+          required: false
+          type: boolean
       responses:
         200:
           description: A successful response.
@@ -1660,6 +1664,26 @@ definitions:
       content_type:
         type: string
       last_modified:
+        type: string
+      is_latest:
+        type: boolean
+      is_delete_marker:
+        type: boolean
+      version_id:
+        type: string
+      user_tags:
+        type: object
+        additionalProperties:
+          type: string
+      expiration:
+        type: string
+      expiration_rule_id:
+        type: string
+      legal_hold_status:
+        type: string
+      retention_mode:
+        type: string
+      retention_until_date:
         type: string
 
   makeBucketRequest:


### PR DESCRIPTION
Fixes https://github.com/minio/console/issues/300
Adds extra fields for list objects api with retention mode, legalhold and isDeleteMarker
For objects with versions needs a version flag on the api:
GET `/api/v1/buckets/bucket2/objects?prefix=photo_2020-06-16_13-15-05.jpg&with_versions=true`:

```
{
    "objects": [
        {
            "is_latest": true,
            "last_modified": "2020-10-02 22:51:15.316 +0000 UTC",
            "legal_hold_status": "ON",
            "name": "photo_2020-06-16_13-15-05.jpg",
            "size": 103614,
            "version_id": "314ab4ab-913f-4b32-a706-3b76d7203699"
        },
        {
            "is_delete_marker": true,
            "last_modified": "2020-10-02 22:49:55.826 +0000 UTC",
            "name": "photo_2020-06-16_13-15-05.jpg",
            "version_id": "0156a9ac-8129-44c4-870d-c742b3b7b981"
        },
        {
            "last_modified": "2020-10-02 20:35:46.239 +0000 UTC",
            "name": "photo_2020-06-16_13-15-05.jpg",
            "retention_mode": "GOVERNANCE",
            "retention_until_date": "2020-10-07 22:46:41 +0000 UTC",
            "size": 103614,
            "version_id": "e088545a-d27f-4939-9165-568a0df2eba7"
        },
        {
            "is_delete_marker": true,
            "last_modified": "2020-10-02 20:35:18.911 +0000 UTC",
            "name": "photo_2020-06-16_13-15-05.jpg",
            "version_id": "73ba7b01-d36f-4fa6-997f-0cdfe60fadc8"
        }
    ],
    "total": 4
}
```

- [X] Tests added