### PR TITLE
Updated styles & behavior for settings page

### DIFF
--- a/portal-ui/src/icons/AddIcon.tsx
+++ b/portal-ui/src/icons/AddIcon.tsx
@@ -1,0 +1,34 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React from "react";
+import { SvgIcon } from "@material-ui/core";
+class AddIcon extends React.Component {
+  render() {
+    return (
+      <SvgIcon viewBox="0 0 12 12">
+        <path
+          fill="#081c42"
+          className="a"
+          d="M-13160.269,1885.114h-3.235v-4.381h-4.382V1877.5h4.382v-4.381h3.235v4.381h4.383v3.238h-4.383v4.38Z"
+          transform="translate(13167.886 -1873.114)"
+        />
+      </SvgIcon>
+    );
+  }
+}
+
+export default AddIcon;

--- a/portal-ui/src/icons/RemoveIcon.tsx
+++ b/portal-ui/src/icons/RemoveIcon.tsx
@@ -1,0 +1,33 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React from "react";
+import { SvgIcon } from "@material-ui/core";
+class RemoveIcon extends React.Component {
+  render() {
+    return (
+      <SvgIcon viewBox="0 0 11.656 3.101">
+        <path
+          fill="#081c42"
+          d="M-13157.172,1879.551h-11.656v-3.1h11.656v3.1Z"
+          transform="translate(13168.828 -1876.449)"
+        />
+      </SvgIcon>
+    );
+  }
+}
+
+export default RemoveIcon;

--- a/portal-ui/src/screens/Console/Common/FormComponents/CommentBoxWrapper/CommentBoxWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/CommentBoxWrapper/CommentBoxWrapper.tsx
@@ -68,11 +68,13 @@ const styles = (theme: Theme) =>
     },
     cssOutlinedInput: {
       borderColor: "#9C9C9C",
+      padding: 16,
     },
-    rootTest: {
+    rootContainer: {
       "& .MuiOutlinedInput-inputMultiline": {
         ...fieldBasic.inputLabel,
         fontSize: 13,
+        minHeight: 150,
       },
     },
   });
@@ -142,7 +144,7 @@ const CommentBoxWrapper = ({
             InputProps={{
               classes: {
                 notchedOutline: classes.cssOutlinedInput,
-                root: classes.rootTest,
+                root: classes.rootContainer,
               },
             }}
             variant="outlined"

--- a/portal-ui/src/screens/Console/Common/FormComponents/InputBoxWrapper/InputBoxWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/InputBoxWrapper/InputBoxWrapper.tsx
@@ -16,6 +16,7 @@
 import React from "react";
 import {
   Grid,
+  IconButton,
   InputLabel,
   TextField,
   TextFieldProps,
@@ -49,6 +50,8 @@ interface InputBoxProps {
   placeholder?: string;
   min?: string;
   max?: string;
+  overlayIcon?: any;
+  overlayAction?: () => void;
 }
 
 const styles = (theme: Theme) =>
@@ -57,7 +60,10 @@ const styles = (theme: Theme) =>
     ...tooltipHelper,
     textBoxContainer: {
       flexGrow: 1,
+    },
+    textBoxWithIcon: {
       position: "relative",
+      paddingRight: 25,
     },
     errorState: {
       color: "#b53b4b",
@@ -65,6 +71,15 @@ const styles = (theme: Theme) =>
       position: "absolute",
       top: 7,
       right: 7,
+    },
+    overlayAction: {
+      position: "absolute",
+      right: 0,
+      top: 15,
+      "& svg": {
+        maxWidth: 15,
+        maxHeight: 15,
+      },
     },
   });
 
@@ -83,7 +98,7 @@ const inputStyles = makeStyles((theme: Theme) =>
       },
     },
     input: {
-      padding: "15px 5px 10px",
+      padding: "15px 30px 10px 5px",
       color: "#393939",
       fontSize: 13,
       fontWeight: 600,
@@ -127,6 +142,8 @@ const InputBoxWrapper = ({
   placeholder = "",
   min,
   max,
+  overlayIcon = null,
+  overlayAction,
   classes,
 }: InputBoxProps) => {
   let inputProps: any = { "data-index": index };
@@ -184,12 +201,28 @@ const InputBoxWrapper = ({
             error={error !== ""}
             helperText={error}
             placeholder={placeholder}
-            InputLabelProps={{
-              shrink: true,
-            }}
             className={classes.inputRebase}
           />
         </div>
+        {overlayIcon && (
+          <div className={classes.overlayAction}>
+            <IconButton
+              onClick={
+                overlayAction
+                  ? () => {
+                      overlayAction();
+                    }
+                  : () => null
+              }
+              size={"small"}
+              disableFocusRipple={false}
+              disableRipple={false}
+              disableTouchRipple={false}
+            >
+              {overlayIcon}
+            </IconButton>
+          </div>
+        )}
       </Grid>
     </React.Fragment>
   );

--- a/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
+++ b/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
@@ -35,6 +35,7 @@ export const fieldBasic = {
   },
   fieldContainer: {
     marginBottom: 20,
+    position: "relative" as const,
   },
   tooltipContainer: {
     marginLeft: 5,

--- a/portal-ui/src/screens/Console/Configurations/ConfTargetGeneric.tsx
+++ b/portal-ui/src/screens/Console/Configurations/ConfTargetGeneric.tsx
@@ -123,6 +123,8 @@ const ConfTargetGeneric = ({
               setValueElement(field.name, value, item)
             }
             tooltip={field.tooltip}
+            commonPlaceholder={field.placeholder}
+            withBorder={!!field.withBorder}
           />
         );
       case "comment":

--- a/portal-ui/src/screens/Console/Configurations/types.ts
+++ b/portal-ui/src/screens/Console/Configurations/types.ts
@@ -40,6 +40,7 @@ export interface KVField {
   options?: SelectorTypes[];
   multiline?: boolean;
   placeholder?: string;
+  withBorder?: boolean;
 }
 
 export interface IConfigurationElement {

--- a/portal-ui/src/screens/Console/Configurations/utils.ts
+++ b/portal-ui/src/screens/Console/Configurations/utils.ts
@@ -27,33 +27,34 @@ export const notifyWebhooks = "notify_webhooks";
 export const notifyNsq = "notify_nsq";
 
 export const configurationElements: IConfigurationElement[] = [
-  { configuration_id: "region", configuration_label: "Region Configuration" },
-  { configuration_id: "cache", configuration_label: "Cache Configuration" },
+  {
+    configuration_id: "region",
+    configuration_label: "Edit Region Configuration",
+  },
+  {
+    configuration_id: "cache",
+    configuration_label: "Edit Cache Configuration",
+  },
   {
     configuration_id: "compression",
-    configuration_label: "Compression Configuration",
+    configuration_label: "Edit Compression Configuration",
   },
-  { configuration_id: "etcd", configuration_label: "Etcd Configuration" },
+  { configuration_id: "etcd", configuration_label: "Edit Etcd Configuration" },
   {
     configuration_id: "identity_openid",
-    configuration_label: "Identity Openid Configuration",
+    configuration_label: "Edit Identity Openid Configuration",
   },
   {
     configuration_id: "identity_ldap",
-    configuration_label: "Identity LDAP Configuration",
+    configuration_label: "Edit Identity LDAP Configuration",
   },
-  {
-    configuration_id: "kms_vault",
-    configuration_label: "KMS Vault Configuration",
-  },
-  { configuration_id: "kms_kes", configuration_label: "KMS KES Configuration" },
   {
     configuration_id: "logger_webhook",
-    configuration_label: "Logger Webhook Configuration",
+    configuration_label: "Edit Logger Webhook Configuration",
   },
   {
     configuration_id: "audit_webhook",
-    configuration_label: "Audit Webhook Configuration",
+    configuration_label: "Edit Audit Webhook Configuration",
   },
 ];
 
@@ -62,17 +63,18 @@ export const fieldsConfigurations: any = {
     {
       name: "name",
       required: true,
-      label: "name",
+      label: "Server Location",
       tooltip: 'Name of the location of the server e.g. "us-west-rack2"',
       type: "string",
+      placeholder: "e.g. us-west-rack-2",
     },
     {
       name: "comment",
       required: false,
-      label: "comment",
+      label: "Comment",
       tooltip: "You can add a comment to this setting",
       type: "comment",
-      multiline: true,
+      placeholder: "Enter Comment",
     },
   ],
   cache: [
@@ -83,6 +85,7 @@ export const fieldsConfigurations: any = {
       tooltip:
         'Mountpoints e.g. "/optane1" or "/optane2", you can write one per field',
       type: "csv",
+      placeholder: "Enter Mount Point",
     },
     {
       name: "expiry",
@@ -90,6 +93,7 @@ export const fieldsConfigurations: any = {
       label: "Expiry",
       tooltip: 'Cache expiry duration in days e.g. "90"',
       type: "number",
+      placeholder: "Enter Number of Days",
     },
     {
       name: "quota",
@@ -97,6 +101,7 @@ export const fieldsConfigurations: any = {
       label: "Quota",
       tooltip: 'Limit cache drive usage in percentage e.g. "90"',
       type: "number",
+      placeholder: "Enter in %",
     },
     {
       name: "exclude",
@@ -105,6 +110,7 @@ export const fieldsConfigurations: any = {
       tooltip:
         'Wildcard exclusion patterns e.g. "bucket/*.tmp" or "*.exe", you can write one per field',
       type: "csv",
+      placeholder: "Enter Wildcard Exclusion Patterns",
     },
     {
       name: "after",
@@ -112,6 +118,7 @@ export const fieldsConfigurations: any = {
       label: "After",
       tooltip: "Minimum number of access before caching an object",
       type: "number",
+      placeholder: "Enter Number of Attempts",
     },
     {
       name: "watermark_low",
@@ -119,6 +126,7 @@ export const fieldsConfigurations: any = {
       label: "Watermark Low",
       tooltip: "Watermark Low",
       type: "number",
+      placeholder: "Enter Watermark Low",
     },
     {
       name: "watermark_high",
@@ -126,6 +134,7 @@ export const fieldsConfigurations: any = {
       label: "Watermark High",
       tooltip: "Watermark High",
       type: "number",
+      placeholder: "Enter Watermark High",
     },
     {
       name: "comment",
@@ -134,6 +143,7 @@ export const fieldsConfigurations: any = {
       tooltip: "You can add a comment to this setting",
       type: "comment",
       multiline: true,
+      placeholder: "Enter Comment",
     },
   ],
   compression: [
@@ -144,6 +154,8 @@ export const fieldsConfigurations: any = {
       tooltip:
         'Extensions to compress e.g. ".txt",".log" or ".csv", you can write one per field',
       type: "csv",
+      placeholder: "Enter an Extension",
+      withBorder: true,
     },
     {
       name: "mime_types",
@@ -152,6 +164,8 @@ export const fieldsConfigurations: any = {
       tooltip:
         'Mime types e.g. "text/*","application/json" or "application/xml", you can write one per field',
       type: "csv",
+      placeholder: "Enter a Mime Type",
+      withBorder: true,
     },
   ],
   etcd: [
@@ -162,6 +176,7 @@ export const fieldsConfigurations: any = {
       tooltip:
         'List of etcd endpoints e.g. "http://localhost:2379", you can write one per field',
       type: "csv",
+      placeholder: "Enter Endpoint",
     },
     {
       name: "path_prefix",
@@ -169,6 +184,7 @@ export const fieldsConfigurations: any = {
       label: "Path Prefix",
       tooltip: 'namespace prefix to isolate tenants e.g. "customer1/"',
       type: "string",
+      placeholder: "Enter Path Prefix",
     },
     {
       name: "coredns_path",
@@ -176,6 +192,7 @@ export const fieldsConfigurations: any = {
       label: "Coredns Path",
       tooltip: 'Shared bucket DNS records, default is "/skydns"',
       type: "string",
+      placeholder: "Enter Coredns Path",
     },
     {
       name: "client_cert",
@@ -183,6 +200,7 @@ export const fieldsConfigurations: any = {
       label: "Client Cert",
       tooltip: "Client cert for mTLS authentication",
       type: "string",
+      placeholder: "Enter Client Cert",
     },
     {
       name: "client_cert_key",
@@ -190,6 +208,7 @@ export const fieldsConfigurations: any = {
       label: "Client Cert Key",
       tooltip: "Client cert key for mTLS authentication",
       type: "string",
+      placeholder: "Enter Client Cert Key",
     },
     {
       name: "comment",
@@ -198,6 +217,7 @@ export const fieldsConfigurations: any = {
       tooltip: "You can add a comment to this setting",
       type: "comment",
       multiline: true,
+      placeholder: "Enter Comment",
     },
   ],
   identity_openid: [
@@ -207,12 +227,14 @@ export const fieldsConfigurations: any = {
       label: "Config URL",
       tooltip: "Config URL for Client ID configuration",
       type: "string",
+      placeholder: "Enter Config URL",
     },
     {
       name: "client_id",
       required: false,
       label: "Client ID",
       type: "string",
+      placeholder: "Enter Client ID",
     },
     {
       name: "claim_name",
@@ -220,6 +242,7 @@ export const fieldsConfigurations: any = {
       label: "Claim Name",
       tooltip: "Claim Name",
       type: "string",
+      placeholder: "Enter Claim Name",
     },
     {
       name: "claim_prefix",
@@ -227,15 +250,17 @@ export const fieldsConfigurations: any = {
       label: "Claim Prefix",
       tooltip: "Claim Prefix",
       type: "string",
+      placeholder: "Enter Claim Prefix",
     },
   ],
   identity_ldap: [
     {
       name: "server_addr",
       required: true,
-      label: "Server ADDR",
+      label: "Server Addr",
       tooltip: 'AD/LDAP server address e.g. "myldapserver.com:636"',
       type: "string",
+      placeholder: "Enter Server Address",
     },
     {
       name: "username_format",
@@ -244,6 +269,7 @@ export const fieldsConfigurations: any = {
       tooltip:
         'List of username bind DNs e.g. "uid=%s","cn=accounts","dc=myldapserver" or "dc=com", you can write one per field',
       type: "csv",
+      placeholder: "Enter Username Format",
     },
     {
       name: "username_search_filter",
@@ -252,6 +278,7 @@ export const fieldsConfigurations: any = {
       tooltip:
         'User search filter, for example "(cn=%s)" or "(sAMAccountName=%s)" or "(uid=%s)"',
       type: "string",
+      placeholder: "Enter Username Search Filter",
     },
     {
       name: "group_search_filter",
@@ -260,6 +287,7 @@ export const fieldsConfigurations: any = {
       tooltip:
         'Search filter for groups e.g. "(&(objectclass=groupOfNames)(memberUid=%s))"',
       type: "string",
+      placeholder: "Enter Group Search Filter",
     },
     {
       name: "username_search_base_dn",
@@ -267,6 +295,7 @@ export const fieldsConfigurations: any = {
       label: "Username Search Base DN",
       tooltip: "List of username search DNs, you can write one per field",
       type: "csv",
+      placeholder: "Enter Username Search Base DN",
     },
     {
       name: "group_name_attribute",
@@ -274,6 +303,7 @@ export const fieldsConfigurations: any = {
       label: "Group Name Attribute",
       tooltip: 'Search attribute for group name e.g. "cn"',
       type: "string",
+      placeholder: "Enter Group Name Attribute",
     },
     {
       name: "sts_expiry",
@@ -282,6 +312,7 @@ export const fieldsConfigurations: any = {
       tooltip:
         'temporary credentials validity duration in s,m,h,d. Default is "1h"',
       type: "string",
+      placeholder: "Enter STS Expiry",
     },
     {
       name: "tls_skip_verify",
@@ -305,23 +336,23 @@ export const fieldsConfigurations: any = {
       label: "Comment",
       tooltip: "Optionally add a comment to this setting",
       type: "comment",
-      multiline: true,
+      placeholder: "Enter Comment",
     },
   ],
-  kms_vault: [],
-  kms_kes: [],
   logger_webhook: [
     {
       name: "endpoint",
       required: true,
       label: "Endpoint",
       type: "string",
+      placeholder: "Enter Endpoint",
     },
     {
       name: "auth_token",
       required: true,
       label: "Auth Token",
       type: "string",
+      placeholder: "Enter Auth Token",
     },
   ],
   audit_webhook: [
@@ -330,12 +361,14 @@ export const fieldsConfigurations: any = {
       required: true,
       label: "Endpoint",
       type: "string",
+      placeholder: "Enter Endpoint",
     },
     {
       name: "auth_token",
       required: true,
       label: "Auth Token",
       type: "string",
+      placeholder: "Enter Auth Token",
     },
   ],
 };

--- a/portal-ui/src/screens/Console/Users/AddUser.tsx
+++ b/portal-ui/src/screens/Console/Users/AddUser.tsx
@@ -210,7 +210,6 @@ class AddUserContent extends React.Component<
 
     const sendEnabled =
       accessKey.trim() !== "" &&
-      selectedGroups.length > 0 &&
       ((secretKey.trim() !== "" && selectedUser === null) ||
         selectedUser !== null);
     return (


### PR DESCRIPTION
## What does this do?

Updated styles & behavior for settings page, also implemented a couple of performance improvements on some fields

## How does it look?

<img width="868" alt="Screen Shot 2020-10-20 at 2 34 33 PM" src="https://user-images.githubusercontent.com/33497058/96635420-708a8580-12e1-11eb-900f-6cf015ce09f7.png">
<img width="826" alt="Screen Shot 2020-10-20 at 2 34 28 PM" src="https://user-images.githubusercontent.com/33497058/96635429-72544900-12e1-11eb-8b10-d03c33dc9581.png">
<img width="865" alt="Screen Shot 2020-10-20 at 2 34 23 PM" src="https://user-images.githubusercontent.com/33497058/96635432-72ecdf80-12e1-11eb-92af-8c864d0f8172.png">
<img width="1062" alt="Screen Shot 2020-10-20 at 2 34 17 PM" src="https://user-images.githubusercontent.com/33497058/96635433-741e0c80-12e1-11eb-8681-a3c1b7d67e04.png">
<img width="923" alt="Screen Shot 2020-10-20 at 2 34 10 PM" src="https://user-images.githubusercontent.com/33497058/96635435-741e0c80-12e1-11eb-99f4-518fd724ed68.png">
<img width="885" alt="Screen Shot 2020-10-20 at 2 34 03 PM" src="https://user-images.githubusercontent.com/33497058/96635436-74b6a300-12e1-11eb-9e61-ceb0f565d1a5.png">
<img width="874" alt="Screen Shot 2020-10-20 at 2 33 56 PM" src="https://user-images.githubusercontent.com/33497058/96635438-74b6a300-12e1-11eb-8b73-2bd8d61e6a82.png">
<img width="905" alt="Screen Shot 2020-10-20 at 2 33 49 PM" src="https://user-images.githubusercontent.com/33497058/96635439-754f3980-12e1-11eb-9a0a-67823da46a6a.png">
<img width="883" alt="Screen Shot 2020-10-20 at 2 33 39 PM" src="https://user-images.githubusercontent.com/33497058/96635444-75e7d000-12e1-11eb-9bbc-d820336677ab.png">
<img width="937" alt="Screen Shot 2020-10-20 at 2 33 34 PM" src="https://user-images.githubusercontent.com/33497058/96635446-75e7d000-12e1-11eb-8e45-a0bd6cc4dae4.png">

