### PR TITLE
Changed sizes for main container & table paper

### DIFF
--- a/portal-ui/src/screens/Console/Common/TableWrapper/TableWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/TableWrapper/TableWrapper.tsx
@@ -114,10 +114,10 @@ const styles = (theme: Theme) =>
       overflow: "auto",
       flexDirection: "column",
       padding: "19px 38px",
-      minHeight: "200px",
       boxShadow: "none",
       border: "#EAEDEE 1px solid",
       borderRadius: 3,
+      minHeight: "calc(100vh - 340px)",
     },
     allTableSettings: {
       "& .MuiTableCell-sizeSmall:last-child": {

--- a/portal-ui/src/screens/Console/Console.tsx
+++ b/portal-ui/src/screens/Console/Console.tsx
@@ -131,6 +131,8 @@ const styles = (theme: Theme) =>
     container: {
       paddingBottom: theme.spacing(4),
       margin: 0,
+      width: "100%",
+      maxWidth: "initial",
     },
     paper: {
       padding: theme.spacing(2),


### PR DESCRIPTION
fixes #373 

## What does this do?

Changed width size of main container to be full width. Also increased height of container to have minimum height.

## How does it look?

<img width="1577" alt="Screen Shot 2020-11-04 at 3 16 05 PM" src="https://user-images.githubusercontent.com/33497058/98169172-69eb3900-1eb1-11eb-9ea9-f241ebe3dad0.png">
<img width="1582" alt="Screen Shot 2020-11-04 at 3 15 49 PM" src="https://user-images.githubusercontent.com/33497058/98169185-6d7ec000-1eb1-11eb-86a4-05a6c57c057a.png">
<img width="1582" alt="Screen Shot 2020-11-04 at 3 15 42 PM" src="https://user-images.githubusercontent.com/33497058/98169186-6e175680-1eb1-11eb-8972-59f3b729955a.png">
