### PR TITLE
Fixed default value for nulls in browse buckets

### DIFF
--- a/portal-ui/src/screens/Console/ObjectBrowser/BrowseBuckets.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/BrowseBuckets.tsx
@@ -131,10 +131,8 @@ const BrowseBuckets = ({
       api
         .invoke("GET", `/api/v1/buckets?offset=${offset}&limit=${rowsPerPage}`)
         .then((res: BucketList) => {
-          const buckets = get(res, "buckets", []);
-
           setLoading(false);
-          setRecords(buckets);
+          setRecords(res.buckets || []);
           setError("");
           // if we get 0 results, and page > 0 , go down 1 page
           if (


### PR DESCRIPTION
fixes #378 

## What does this do?

Fixes an issue with default null returned values from API

## How does it look?

<img width="1571" alt="Screen Shot 2020-11-06 at 6 33 43 PM" src="https://user-images.githubusercontent.com/33497058/98426482-a4de9f80-205e-11eb-97f1-44623e7714d8.png">
