### PR TITLE
Add disabled functionality and fix styling for RadioGroupSelector

### DIFF
--- a/portal-ui/src/screens/Console/Common/FormComponents/RadioGroupSelector/RadioGroupSelector.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/RadioGroupSelector/RadioGroupSelector.tsx
@@ -41,6 +41,7 @@ interface RadioGroupProps {
   id: string;
   name: string;
   tooltip?: string;
+  disableOptions?: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   classes: any;
   displayInColumn?: boolean;
@@ -60,6 +61,11 @@ const styles = (theme: Theme) =>
       marginTop: 11,
     },
     optionLabel: {
+      "&.Mui-disabled": {
+        "& .MuiFormControlLabel-label": {
+          color: "#9c9c9c",
+        },
+      },
       "&:last-child": {
         marginRight: 0,
       },
@@ -109,6 +115,7 @@ export const RadioGroupSelector = ({
   name,
   onChange,
   tooltip = "",
+  disableOptions = false,
   classes,
   displayInColumn = false,
 }: RadioGroupProps) => {
@@ -139,9 +146,10 @@ export const RadioGroupSelector = ({
               return (
                 <FormControlLabel
                   key={`rd-${name}-${selectorOption.value}`}
-                  value={selectorOption.value}
+                  value={disableOptions ? "disabled" : selectorOption.value}
                   control={<RadioButton />}
                   label={selectorOption.label}
+                  disabled={disableOptions}
                   className={clsx(classes.optionLabel, {
                     [classes.checkedOption]:
                       selectorOption.value === currentSelection,

--- a/portal-ui/src/screens/Console/Common/FormComponents/RadioGroupSelector/RadioGroupSelector.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/RadioGroupSelector/RadioGroupSelector.tsx
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import React from "react";
+import clsx from "clsx";
 import Grid from "@material-ui/core/Grid";
 import RadioGroup from "@material-ui/core/RadioGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
@@ -58,8 +59,18 @@ const styles = (theme: Theme) =>
       paddingBottom: 10,
       marginTop: 11,
     },
+    optionLabel: {
+      "&:last-child": {
+        marginRight: 0,
+      },
+      "& .MuiFormControlLabel-label": {
+        fontSize: 12,
+        color: "#000",
+      },
+    },
     checkedOption: {
       "& .MuiFormControlLabel-label": {
+        fontSize: 12,
         color: "#000",
         fontWeight: 700,
       },
@@ -131,11 +142,10 @@ export const RadioGroupSelector = ({
                   value={selectorOption.value}
                   control={<RadioButton />}
                   label={selectorOption.label}
-                  className={
-                    selectorOption.value === currentSelection
-                      ? classes.checkedOption
-                      : ""
-                  }
+                  className={clsx(classes.optionLabel, {
+                    [classes.checkedOption]:
+                      selectorOption.value === currentSelection,
+                  })}
                 />
               );
             })}

--- a/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
+++ b/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
@@ -104,6 +104,9 @@ const radioBasic = {
   width: 12,
   height: 12,
   borderRadius: "100%",
+  'input:disabled ~ &': {
+    border: "1px solid #9C9C9C",
+  },
 };
 
 export const radioIcons = {


### PR DESCRIPTION
This commit includes the following changes:
- Adjust RadioGroupSelector label styling based on mockups
- Add disabled support for Radio Group Selector options

<img width="669" alt="Screen Shot 2020-11-10 at 1 45 43 PM" src="https://user-images.githubusercontent.com/27314853/98752358-e29d3a00-2376-11eb-82aa-d5f0c75f6abf.png">

<img width="670" alt="Screen Shot 2020-11-10 at 5 00 39 PM" src="https://user-images.githubusercontent.com/27314853/98752366-e630c100-2376-11eb-8ee6-461a9ceed669.png">
