### PR TITLE
Remove minio root credentials from CreateTenant response

### DIFF
--- a/models/create_tenant_response.go
+++ b/models/create_tenant_response.go
@@ -33,14 +33,8 @@ import (
 // swagger:model createTenantResponse
 type CreateTenantResponse struct {
 
-	// access key
-	AccessKey string `json:"access_key,omitempty"`
-
 	// console
 	Console *CreateTenantResponseConsole `json:"console,omitempty"`
-
-	// secret key
-	SecretKey string `json:"secret_key,omitempty"`
 }
 
 // Validate validates this create tenant response

--- a/portal-ui/src/screens/Console/Common/CredentialsPrompt/CredentialsPrompt.tsx
+++ b/portal-ui/src/screens/Console/Common/CredentialsPrompt/CredentialsPrompt.tsx
@@ -82,14 +82,6 @@ const CredentialsPrompt = ({
         <Grid container>
           <Grid item xs={12} className={classes.formScrollable}>
             A new {entity} has been created with the following details:
-            <ul>
-              <li>
-                <b>Access Key:</b> {newServiceAccount.accessKey}
-              </li>
-              <li>
-                <b>Secret Key:</b> {newServiceAccount.secretKey}
-              </li>
-            </ul>
             {consoleCreds && (
               <React.Fragment>
                 <Grid item xs={12}>
@@ -131,8 +123,6 @@ const CredentialsPrompt = ({
                 download(
                   "credentials.json",
                   JSON.stringify({
-                    access_key: newServiceAccount.accessKey,
-                    secret_key: newServiceAccount.secretKey,
                     ...consoleExtras,
                   })
                 );

--- a/portal-ui/src/screens/Console/Common/CredentialsPrompt/types.ts
+++ b/portal-ui/src/screens/Console/Common/CredentialsPrompt/types.ts
@@ -15,8 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 export interface NewServiceAccount {
-  accessKey: string;
-  secretKey: string;
   console?: ConsoleSA;
 }
 

--- a/portal-ui/src/screens/Console/Tenants/ListTenants/AddTenant.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/AddTenant.tsx
@@ -913,8 +913,6 @@ const AddTenant = ({
         .invoke("POST", `/api/v1/tenants`, dataSend)
         .then((res) => {
           const newSrvAcc: NewServiceAccount = {
-            accessKey: res.access_key,
-            secretKey: res.secret_key,
             console: {
               accessKey: res.console.access_key,
               secretKey: res.console.secret_key,

--- a/restapi/admin_tenants.go
+++ b/restapi/admin_tenants.go
@@ -778,10 +778,7 @@ func getTenantCreatedResponse(session *models.Principal, params admin_api.Create
 			return nil, prepareError(err)
 		}
 	}
-	response = &models.CreateTenantResponse{
-		AccessKey: accessKey,
-		SecretKey: secretKey,
-	}
+	response = &models.CreateTenantResponse{}
 	// Attach Console Credentials
 	if enableConsole {
 		response.Console = &models.CreateTenantResponseConsole{

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -3279,9 +3279,6 @@ func init() {
     "createTenantResponse": {
       "type": "object",
       "properties": {
-        "access_key": {
-          "type": "string"
-        },
         "console": {
           "type": "object",
           "properties": {
@@ -3292,9 +3289,6 @@ func init() {
               "type": "string"
             }
           }
-        },
-        "secret_key": {
-          "type": "string"
         }
       }
     },
@@ -8668,9 +8662,6 @@ func init() {
     "createTenantResponse": {
       "type": "object",
       "properties": {
-        "access_key": {
-          "type": "string"
-        },
         "console": {
           "type": "object",
           "properties": {
@@ -8681,9 +8672,6 @@ func init() {
               "type": "string"
             }
           }
-        },
-        "secret_key": {
-          "type": "string"
         }
       }
     },

--- a/swagger.yml
+++ b/swagger.yml
@@ -2967,10 +2967,6 @@ definitions:
   createTenantResponse:
     type: object
     properties:
-      access_key:
-        type: string
-      secret_key:
-        type: string
       console:
         type: object
         properties:


### PR DESCRIPTION
Fixes https://github.com/minio/console/issues/393
Test Creating a tenant on operator-ui.
It should only show the console creds and also if you click download it should include only console credentials.