### PR TITLE
Create Tenant TLS refactor

### DIFF
--- a/restapi/consts.go
+++ b/restapi/consts.go
@@ -54,3 +54,9 @@ const (
 	prometheusPort   = "prometheus.io/port"
 	prometheusScrape = "prometheus.io/scrape"
 )
+
+// Image versions
+const (
+	KESImageVersion     = "minio/kes:v0.12.1"
+	ConsoleImageVersion = "minio/console:v0.4.6"
+)


### PR DESCRIPTION
- fixed small bug in which RequestAutoCert was not setting properly
- support AutoCert and external certificates on Tenant creation