### PR TITLE
Fix Group modal typos

### DIFF
--- a/portal-ui/src/screens/Console/Groups/UsersSelectors.tsx
+++ b/portal-ui/src/screens/Console/Groups/UsersSelectors.tsx
@@ -187,10 +187,10 @@ const UsersSelectors = ({
             <React.Fragment>
               <Grid item xs={12} className={classes.actionsTray}>
                 <span className={classes.actionsTitle}>
-                  {editMode ? "Edit" : "Assign"} Members
+                  {editMode ? "Edit Members" : "Assign Users"}
                 </span>
                 <TextField
-                  placeholder="Filter Groups"
+                  placeholder="Filter Users"
                   className={classes.filterField}
                   id="search-resource"
                   label=""


### PR DESCRIPTION
Changes Edit and Create Group to show the proper user messages.

<img width="774" alt="Screen Shot 2021-01-08 at 5 26 57 PM" src="https://user-images.githubusercontent.com/11819101/104074881-e282b480-51d6-11eb-9733-c03b620c1f97.png">
<img width="765" alt="Screen Shot 2021-01-08 at 5 26 51 PM" src="https://user-images.githubusercontent.com/11819101/104074886-e6163b80-51d6-11eb-870b-9491195e3d2a.png">
