### PR TITLE
Allow arbitrary number of file uploads

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -861,12 +861,6 @@ func init() {
         "summary": "Uploads an Object.",
         "parameters": [
           {
-            "type": "file",
-            "name": "upfile",
-            "in": "formData",
-            "required": true
-          },
-          {
             "type": "string",
             "name": "bucket_name",
             "in": "path",
@@ -875,8 +869,7 @@ func init() {
           {
             "type": "string",
             "name": "prefix",
-            "in": "query",
-            "required": true
+            "in": "query"
           }
         ],
         "responses": {
@@ -6334,12 +6327,6 @@ func init() {
         "summary": "Uploads an Object.",
         "parameters": [
           {
-            "type": "file",
-            "name": "upfile",
-            "in": "formData",
-            "required": true
-          },
-          {
             "type": "string",
             "name": "bucket_name",
             "in": "path",
@@ -6348,8 +6335,7 @@ func init() {
           {
             "type": "string",
             "name": "prefix",
-            "in": "query",
-            "required": true
+            "in": "query"
           }
         ],
         "responses": {

--- a/restapi/operations/user_api/post_buckets_bucket_name_objects_upload_parameters.go
+++ b/restapi/operations/user_api/post_buckets_bucket_name_objects_upload_parameters.go
@@ -23,15 +23,12 @@ package user_api
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"io"
-	"mime/multipart"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/validate"
 )
 
 // NewPostBucketsBucketNameObjectsUploadParams creates a new PostBucketsBucketNameObjectsUploadParams object
@@ -56,15 +53,9 @@ type PostBucketsBucketNameObjectsUploadParams struct {
 	*/
 	BucketName string
 	/*
-	  Required: true
 	  In: query
 	*/
-	Prefix string
-	/*
-	  Required: true
-	  In: formData
-	*/
-	Upfile io.ReadCloser
+	Prefix *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +69,6 @@ func (o *PostBucketsBucketNameObjectsUploadParams) BindRequest(r *http.Request, 
 
 	qs := runtime.Values(r.URL.Query())
 
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		if err != http.ErrNotMultipart {
-			return errors.New(400, "%v", err)
-		} else if err := r.ParseForm(); err != nil {
-			return errors.New(400, "%v", err)
-		}
-	}
-
 	rBucketName, rhkBucketName, _ := route.Params.GetOK("bucket_name")
 	if err := o.bindBucketName(rBucketName, rhkBucketName, route.Formats); err != nil {
 		res = append(res, err)
@@ -94,16 +77,6 @@ func (o *PostBucketsBucketNameObjectsUploadParams) BindRequest(r *http.Request, 
 	qPrefix, qhkPrefix, _ := qs.GetOK("prefix")
 	if err := o.bindPrefix(qPrefix, qhkPrefix, route.Formats); err != nil {
 		res = append(res, err)
-	}
-
-	upfile, upfileHeader, err := r.FormFile("upfile")
-	if err != nil {
-		res = append(res, errors.New(400, "reading file %q failed: %v", "upfile", err))
-	} else if err := o.bindUpfile(upfile, upfileHeader); err != nil {
-		// Required: true
-		res = append(res, err)
-	} else {
-		o.Upfile = &runtime.File{Data: upfile, Header: upfileHeader}
 	}
 
 	if len(res) > 0 {
@@ -129,28 +102,18 @@ func (o *PostBucketsBucketNameObjectsUploadParams) bindBucketName(rawData []stri
 
 // bindPrefix binds and validates parameter Prefix from query.
 func (o *PostBucketsBucketNameObjectsUploadParams) bindPrefix(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	if !hasKey {
-		return errors.Required("prefix", "query", rawData)
-	}
 	var raw string
 	if len(rawData) > 0 {
 		raw = rawData[len(rawData)-1]
 	}
 
-	// Required: true
+	// Required: false
 	// AllowEmptyValue: false
-	if err := validate.RequiredString("prefix", "query", raw); err != nil {
-		return err
+	if raw == "" { // empty values pass all other validations
+		return nil
 	}
 
-	o.Prefix = raw
+	o.Prefix = &raw
 
-	return nil
-}
-
-// bindUpfile binds file parameter Upfile.
-//
-// The only supported validations on files are MinLength and MaxLength
-func (o *PostBucketsBucketNameObjectsUploadParams) bindUpfile(file multipart.File, header *multipart.FileHeader) error {
 	return nil
 }

--- a/restapi/operations/user_api/post_buckets_bucket_name_objects_upload_urlbuilder.go
+++ b/restapi/operations/user_api/post_buckets_bucket_name_objects_upload_urlbuilder.go
@@ -33,7 +33,7 @@ import (
 type PostBucketsBucketNameObjectsUploadURL struct {
 	BucketName string
 
-	Prefix string
+	Prefix *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -76,7 +76,10 @@ func (o *PostBucketsBucketNameObjectsUploadURL) Build() (*url.URL, error) {
 
 	qs := make(url.Values)
 
-	prefixQ := o.Prefix
+	var prefixQ string
+	if o.Prefix != nil {
+		prefixQ = *o.Prefix
+	}
 	if prefixQ != "" {
 		qs.Set("prefix", prefixQ)
 	}

--- a/swagger.yml
+++ b/swagger.yml
@@ -356,17 +356,12 @@ paths:
       consumes:
         - multipart/form-data
       parameters:
-        - in: formData
-          name: upfile
-          type: file
-          required: true
         - name: bucket_name
           in: path
           required: true
           type: string
         - name: prefix
           in: query
-          required: true
           type: string
       responses:
         200:


### PR DESCRIPTION
Now you can select multiple files on Console UI. 
Note: Folder upload is still not supported also a timeout may occur (with large files) which will be addressed in future prs.

Parameter definition for file upload on swagger.yaml was removed
since go-swagger doesn't support multiple upload of files. Implementation
was done instead on  user_objects.go file.

To test: Select multiple files on Console UI and upload should happen without any errors (on bucket, on subfolders, etc.)
