### PR TITLE
Added support for custom structure in bar charts

### DIFF
--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/BarChartWidget.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/BarChartWidget.tsx
@@ -1,5 +1,5 @@
 // This file is part of MinIO Console Server
-// Copyright (c) 2020 MinIO, Inc.
+// Copyright (c) 2021 MinIO, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -43,18 +43,16 @@ const styles = (theme: Theme) =>
 
 const CustomizedAxisTick = ({ x, y, payload }: any) => {
   return (
-    <g transform={`translate(${x},${y})`}>
-      <Text
-        width={50}
-        fontSize={"63%"}
-        textAnchor="end"
-        verticalAnchor="middle"
-        angle={0}
-        fill="#333"
-      >
-        {payload.value}
-      </Text>
-    </g>
+    <text
+      width={50}
+      fontSize={"63%"}
+      textAnchor="end"
+      fill="#333"
+      transform={`translate(${x},${y})`}
+      dy={3}
+    >
+      {payload.value}
+    </text>
   );
 };
 

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/types.ts
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/types.ts
@@ -1,5 +1,5 @@
 // This file is part of MinIO Console Server
-// Copyright (c) 2020 MinIO, Inc.
+// Copyright (c) 2021 MinIO, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -42,4 +42,9 @@ export interface ISinglePieConfiguration {
 
 export interface IDataSRep {
   value: number;
+}
+
+export interface IBarChartRelation {
+  originTag: string;
+  displayTag: string;
 }

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/types.ts
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/types.ts
@@ -1,5 +1,5 @@
 // This file is part of MinIO Console Server
-// Copyright (c) 2020 MinIO, Inc.
+// Copyright (c) 2021 MinIO, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -16,6 +16,7 @@
 
 import {
   IBarChartConfiguration,
+  IBarChartRelation,
   IDataSRep,
   ILinearGraphConfiguration,
   IPieChartConfiguration,
@@ -46,4 +47,5 @@ export interface IDashboardPanel {
   disableYAxis?: boolean;
   xAxisFormatter?: (item: string) => string;
   yAxisFormatter?: (item: string) => string;
+  customStructure?: IBarChartRelation[];
 }


### PR DESCRIPTION
## What does this do?
Added support for custom structure in bar charts so we can customize bar order & label

## How it looks?

<img width="908" alt="Screen Shot 2021-01-18 at 21 49 47" src="https://user-images.githubusercontent.com/33497058/104986132-082e6b80-59d8-11eb-824a-974d06e60fb2.png">
