### PR TITLE
Add loading circle on health info UI

### DIFF
--- a/portal-ui/src/utils/wsUtils.ts
+++ b/portal-ui/src/utils/wsUtils.ts
@@ -17,6 +17,7 @@
 // Close codes for websockets defined in RFC 6455
 export const WSCloseNormalClosure = 1000;
 export const WSCloseCloseGoingAway = 1001;
+export const WSCloseAbnormalClosure = 1006;
 export const WSClosePolicyViolation = 1008;
 export const WSCloseInternalServerErr = 1011;
 


### PR DESCRIPTION
fixes: https://github.com/minio/console/issues/558

Also hides the result of health info since it is only valuable when it is downloaded

<img width="889" alt="Screen Shot 2021-01-19 at 3 53 48 PM" src="https://user-images.githubusercontent.com/11819101/105097649-93f2d700-5a6e-11eb-92d0-bc76782c773c.png">
