### PR TITLE
Removed extra padding in logs container sections

### DIFF
--- a/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
+++ b/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
@@ -309,7 +309,7 @@ export const settingsCommon = {
 export const logsCommon = {
   logsSubContainer: {
     height: "calc(100vh - 230px)",
-    padding: "15px 33px",
+    padding: "15px 0",
   },
 };
 


### PR DESCRIPTION
## What does this do?

Fixes an issue with logs section were an extra margin is shown

## How does it look?

<img width="1943" alt="Screen Shot 2021-01-19 at 17 47 51" src="https://user-images.githubusercontent.com/33497058/105108215-63676900-5a7f-11eb-97e6-9307c8b4b7a8.png">
<img width="1940" alt="Screen Shot 2021-01-19 at 17 47 37" src="https://user-images.githubusercontent.com/33497058/105108218-65312c80-5a7f-11eb-81a7-f73f5c866d6c.png">
<img width="1943" alt="Screen Shot 2021-01-19 at 17 47 24" src="https://user-images.githubusercontent.com/33497058/105108219-65c9c300-5a7f-11eb-9454-bb48ff649d06.png">
<img width="1946" alt="Screen Shot 2021-01-19 at 17 47 13" src="https://user-images.githubusercontent.com/33497058/105108220-66625980-5a7f-11eb-803d-c72470b228eb.png">
