### PR TITLE
Changed default TLS redirect to off when no configuration is provided

### DIFF
--- a/restapi/config.go
+++ b/restapi/config.go
@@ -43,7 +43,7 @@ var (
 	TLSPort = "9443"
 
 	// TLSRedirect console tls redirect rule
-	TLSRedirect = "on"
+	TLSRedirect = "off"
 
 	// SessionDuration cookie validity duration
 	SessionDuration = 45 * time.Minute


### PR DESCRIPTION
## What does this do?

Fixes an infinite reload issue when no TLS configuration is set 

**NOTE:** You may need to clear your cache in order to test this PR