### PR TITLE
Default TLS redirect if Console runs with HTTPS

### DIFF
--- a/restapi/configure_console.go
+++ b/restapi/configure_console.go
@@ -189,7 +189,7 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 		AllowedHosts:                    getSecureAllowedHosts(),
 		AllowedHostsAreRegex:            getSecureAllowedHostsAreRegex(),
 		HostsProxyHeaders:               getSecureHostsProxyHeaders(),
-		SSLRedirect:                     GetTLSRedirect() == "on",
+		SSLRedirect:                     GetTLSRedirect() == "on" && len(GlobalPublicCerts) > 0,
 		SSLHost:                         getSecureTLSHost(),
 		STSSeconds:                      getSecureSTSSeconds(),
 		STSIncludeSubdomains:            getSecureSTSIncludeSubdomains(),


### PR DESCRIPTION
TLS redirect default behavior is `TRUE` only if Console is running with
HTTPS