### PR TITLE
Replaced help icon in console

### DIFF
--- a/portal-ui/src/icons/HelpIcon.tsx
+++ b/portal-ui/src/icons/HelpIcon.tsx
@@ -1,0 +1,34 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React from "react";
+import { SvgIcon } from "@material-ui/core";
+const HelpIcon = (props: any) => {
+  return (
+    <SvgIcon {...props} viewBox={"0 0 12 12"}>
+      <path
+        d="M357.14,346a5,5,0,1,1-5,5,5,5,0,0,1,5-5m0-1a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
+        transform="translate(-351.14 -345.03)"
+      />
+      <path
+        d="M356.21,352.42v-1.86h.52c1.23,0,1.92-.45,1.92-1.29s-.68-1.18-1.89-1.18a8.07,8.07,0,0,0-.93.06l-.1-1.25a9.13,9.13,0,0,1,1.08-.08c2,0,3.19.94,3.19,2.4s-.93,2.24-2.64,2.46l-.05.74Zm1.56,1.8a1,1,0,1,1-1-1A1,1,0,0,1,357.77,354.22Z"
+        transform="translate(-351.14 -345.03)"
+      />
+    </SvgIcon>
+  );
+};
+
+export default HelpIcon;

--- a/portal-ui/src/screens/Console/Common/FormComponents/CSVMultiSelector/CSVMultiSelector.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/CSVMultiSelector/CSVMultiSelector.tsx
@@ -25,9 +25,9 @@ import get from "lodash/get";
 import debounce from "lodash/debounce";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
-import HelpIcon from "@material-ui/icons/Help";
 import { InputLabel, Tooltip } from "@material-ui/core";
 import { fieldBasic, tooltipHelper } from "../common/styleLibrary";
+import HelpIcon from "../../../../../icons/HelpIcon";
 import InputBoxWrapper from "../InputBoxWrapper/InputBoxWrapper";
 import AddIcon from "../../../../../icons/AddIcon";
 
@@ -165,7 +165,9 @@ const CSVMultiSelector = ({
           {tooltip !== "" && (
             <div className={classes.tooltipContainer}>
               <Tooltip title={tooltip} placement="top-start">
-                <HelpIcon className={classes.tooltip} />
+                <div>
+                  <HelpIcon className={classes.tooltip} />
+                </div>
               </Tooltip>
             </div>
           )}

--- a/portal-ui/src/screens/Console/Common/FormComponents/CheckboxWrapper/CheckboxWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/CheckboxWrapper/CheckboxWrapper.tsx
@@ -21,7 +21,7 @@ import {
   fieldBasic,
   tooltipHelper,
 } from "../common/styleLibrary";
-import HelpIcon from "@material-ui/icons/Help";
+import HelpIcon from "../../../../../icons/HelpIcon";
 
 interface CheckBoxProps {
   label: string;
@@ -86,7 +86,9 @@ const CheckboxWrapper = ({
             {tooltip !== "" && (
               <div className={classes.tooltipContainer}>
                 <Tooltip title={tooltip} placement="top-start">
-                  <HelpIcon className={classes.tooltip} />
+                  <div>
+                    <HelpIcon className={classes.tooltip} />
+                  </div>
                 </Tooltip>
               </div>
             )}

--- a/portal-ui/src/screens/Console/Common/FormComponents/CodeMirrorWrapper/CodeMirrorWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/CodeMirrorWrapper/CodeMirrorWrapper.tsx
@@ -15,11 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import HelpIcon from "@material-ui/icons/Help";
 import Grid from "@material-ui/core/Grid";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import { InputLabel, Tooltip } from "@material-ui/core";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
+import HelpIcon from "../../../../../icons/HelpIcon";
 import { fieldBasic } from "../common/styleLibrary";
 import "./ConsoleCodeMirror.css";
 
@@ -56,7 +56,9 @@ const CodeMirrorWrapper = ({
         {tooltip !== "" && (
           <div className={classes.tooltipContainer}>
             <Tooltip title={tooltip} placement="top-start">
-              <HelpIcon className={classes.tooltip} />
+              <div>
+                <HelpIcon className={classes.tooltip} />
+              </div>
             </Tooltip>
           </div>
         )}

--- a/portal-ui/src/screens/Console/Common/FormComponents/CommentBoxWrapper/CommentBoxWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/CommentBoxWrapper/CommentBoxWrapper.tsx
@@ -17,7 +17,7 @@ import React from "react";
 import { Grid, InputLabel, TextField, Tooltip } from "@material-ui/core";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import { fieldBasic, tooltipHelper } from "../common/styleLibrary";
-import HelpIcon from "@material-ui/icons/Help";
+import HelpIcon from "../../../../../icons/HelpIcon";
 
 interface CommentBoxProps {
   label: string;
@@ -101,7 +101,9 @@ const CommentBoxWrapper = ({
             {tooltip !== "" && (
               <div className={classes.tooltipContainer}>
                 <Tooltip title={tooltip} placement="top-start">
-                  <HelpIcon className={classes.tooltip} />
+                  <div>
+                    <HelpIcon className={classes.tooltip} />
+                  </div>
                 </Tooltip>
               </div>
             )}

--- a/portal-ui/src/screens/Console/Common/FormComponents/DateSelector/DateSelector.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/DateSelector/DateSelector.tsx
@@ -25,12 +25,12 @@ import Grid from "@material-ui/core/Grid";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import InputLabel from "@material-ui/core/InputLabel";
 import Tooltip from "@material-ui/core/Tooltip";
-import HelpIcon from "@material-ui/icons/Help";
 import FormControl from "@material-ui/core/FormControl";
 import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
 import InputBase from "@material-ui/core/InputBase";
 import { fieldBasic, tooltipHelper } from "../common/styleLibrary";
+import HelpIcon from "../../../../../icons/HelpIcon";
 import FormSwitchWrapper from "../FormSwitchWrapper/FormSwitchWrapper";
 import { days, months, validDate, years } from "./utils";
 
@@ -178,7 +178,9 @@ const DateSelector = forwardRef(
               {tooltip !== "" && (
                 <div className={classes.tooltipContainer}>
                   <Tooltip title={tooltip} placement="top-start">
-                    <HelpIcon className={classes.tooltip} />
+                    <div>
+                      <HelpIcon className={classes.tooltip} />
+                    </div>
                   </Tooltip>
                 </div>
               )}

--- a/portal-ui/src/screens/Console/Common/FormComponents/FileSelector/FileSelector.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/FileSelector/FileSelector.tsx
@@ -20,10 +20,10 @@ import { Grid, InputLabel, Tooltip } from "@material-ui/core";
 import IconButton from "@material-ui/core/IconButton";
 import AttachFileIcon from "@material-ui/icons/AttachFile";
 import CancelIcon from "@material-ui/icons/Cancel";
-import HelpIcon from "@material-ui/icons/Help";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import { fieldBasic, tooltipHelper } from "../common/styleLibrary";
 import { fileProcess } from "./utils";
+import HelpIcon from "../../../../../icons/HelpIcon";
 import ErrorBlock from "../../../../shared/ErrorBlock";
 
 interface InputBoxProps {
@@ -123,7 +123,9 @@ const FileSelector = ({
             {tooltip !== "" && (
               <div className={classes.tooltipContainer}>
                 <Tooltip title={tooltip} placement="top-start">
-                  <HelpIcon className={classes.tooltip} />
+                  <div>
+                    <HelpIcon className={classes.tooltip} />
+                  </div>
                 </Tooltip>
               </div>
             )}

--- a/portal-ui/src/screens/Console/Common/FormComponents/FormSwitchWrapper/FormSwitchWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/FormSwitchWrapper/FormSwitchWrapper.tsx
@@ -19,7 +19,7 @@ import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import { InputLabel, Switch, Tooltip } from "@material-ui/core";
 import Grid from "@material-ui/core/Grid";
 import { actionsTray, fieldBasic } from "../common/styleLibrary";
-import HelpIcon from "@material-ui/icons/Help";
+import HelpIcon from "../../../../../icons/HelpIcon";
 
 interface IFormSwitch {
   label?: string;
@@ -218,7 +218,9 @@ const FormSwitchWrapper = ({
             {tooltip !== "" && (
               <div className={classes.tooltipContainer}>
                 <Tooltip title={tooltip} placement="top-start">
-                  <HelpIcon className={classes.tooltip} />
+                  <div>
+                    <HelpIcon className={classes.tooltip} />
+                  </div>
                 </Tooltip>
               </div>
             )}

--- a/portal-ui/src/screens/Console/Common/FormComponents/InputBoxWrapper/InputBoxWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/InputBoxWrapper/InputBoxWrapper.tsx
@@ -30,7 +30,7 @@ import {
   withStyles,
 } from "@material-ui/core/styles";
 import { fieldBasic, tooltipHelper } from "../common/styleLibrary";
-import HelpIcon from "@material-ui/icons/Help";
+import HelpIcon from "../../../../../icons/HelpIcon";
 
 interface InputBoxProps {
   label: string;
@@ -173,7 +173,9 @@ const InputBoxWrapper = ({
             {tooltip !== "" && (
               <div className={classes.tooltipContainer}>
                 <Tooltip title={tooltip} placement="top-start">
-                  <HelpIcon className={classes.tooltip} />
+                  <div>
+                    <HelpIcon className={classes.tooltip} />
+                  </div>
                 </Tooltip>
               </div>
             )}

--- a/portal-ui/src/screens/Console/Common/FormComponents/RadioGroupSelector/RadioGroupSelector.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/RadioGroupSelector/RadioGroupSelector.tsx
@@ -27,7 +27,7 @@ import {
   makeStyles,
 } from "@material-ui/core/styles";
 import { fieldBasic, radioIcons, tooltipHelper } from "../common/styleLibrary";
-import HelpIcon from "@material-ui/icons/Help";
+import HelpIcon from "../../../../../icons/HelpIcon";
 
 export interface SelectorTypes {
   label: string;
@@ -127,7 +127,9 @@ export const RadioGroupSelector = ({
           {tooltip !== "" && (
             <div className={classes.tooltipContainer}>
               <Tooltip title={tooltip} placement="top-start">
-                <HelpIcon className={classes.tooltip} />
+                <div>
+                  <HelpIcon className={classes.tooltip} />
+                </div>
               </Tooltip>
             </div>
           )}

--- a/portal-ui/src/screens/Console/Common/FormComponents/SelectWrapper/SelectWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/SelectWrapper/SelectWrapper.tsx
@@ -25,7 +25,7 @@ import {
 } from "@material-ui/core";
 import { createStyles, Theme, withStyles } from "@material-ui/core/styles";
 import { fieldBasic, tooltipHelper } from "../common/styleLibrary";
-import HelpIcon from "@material-ui/icons/Help";
+import HelpIcon from "../../../../../icons/HelpIcon";
 
 interface selectorTypes {
   label: string;
@@ -99,7 +99,9 @@ const SelectWrapper = ({
             {tooltip !== "" && (
               <div className={classes.tooltipContainer}>
                 <Tooltip title={tooltip} placement="top-start">
-                  <HelpIcon className={classes.tooltip} />
+                  <div>
+                    <HelpIcon className={classes.tooltip} />
+                  </div>
                 </Tooltip>
               </div>
             )}

--- a/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
+++ b/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
@@ -82,7 +82,7 @@ export const modalBasic = {
 
 export const tooltipHelper = {
   tooltip: {
-    fontSize: 18,
+    fontSize: 16,
   },
 };
 

--- a/portal-ui/src/screens/Console/Tenants/ListTenants/AddTenant.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/AddTenant.tsx
@@ -19,7 +19,7 @@ import debounce from "lodash/debounce";
 import get from "lodash/get";
 import Grid from "@material-ui/core/Grid";
 import InputBoxWrapper from "../../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
-import { Button, LinearProgress, Paper, Typography } from "@material-ui/core";
+import { Button, LinearProgress, Typography } from "@material-ui/core";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
@@ -296,10 +296,6 @@ const AddTenant = ({ classes }: IAddTenantProps) => {
   const [vaultCertVal, setVaultCertVal] = useState<string>("");
   const [vaultCAVal, setVaultCAVal] = useState<string>("");
   const [gemaltoCAVal, setGemaltoCAVal] = useState<string>("");
-
-  // Flow
-
-  const showCredentialsAndRedirect = () => {};
 
   // CA Certificates functions
   const addCaCertificate = () => {

--- a/portal-ui/src/screens/Console/Tenants/ListTenants/PoolsMultiSelector.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/PoolsMultiSelector.tsx
@@ -19,13 +19,13 @@ import Grid from "@material-ui/core/Grid";
 import get from "lodash/get";
 import { InputLabel, Tooltip } from "@material-ui/core";
 import IconButton from "@material-ui/core/IconButton";
-import HelpIcon from "@material-ui/icons/Help";
 import InputBoxWrapper from "../../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
 import {
   fieldBasic,
   tooltipHelper,
 } from "../../Common/FormComponents/common/styleLibrary";
 import DeleteIcon from "../../../../icons/DeleteIcon";
+import HelpIcon from "../../../../icons/HelpIcon";
 import { IPool } from "./types";
 
 interface IPoolsMultiSelector {
@@ -219,7 +219,9 @@ const PoolsMultiSelector = ({
           {tooltip !== "" && (
             <div className={classes.tooltipContainer}>
               <Tooltip title={tooltip} placement="top-start">
-                <HelpIcon className={classes.tooltip} />
+                <div>
+                  <HelpIcon className={classes.tooltip} />
+                </div>
               </Tooltip>
             </div>
           )}


### PR DESCRIPTION
fixes #597 

## What does this do?

Replaced help icon with icon from console

## How does it look?

<img width="725" alt="Screen Shot 2021-02-12 at 17 24 18" src="https://user-images.githubusercontent.com/33497058/107833419-d1d6d880-6d58-11eb-95b4-7d87d509ab95.png">
