### PR TITLE
Fixed max size for widgets

### DIFF
--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/PrDashboard.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/PrDashboard.tsx
@@ -229,15 +229,20 @@ const PrDashboard = ({ classes, displayErrorMessage }: IPrDashboard) => {
       <Grid item xs={12} className={classes.widgetsContainer}>
         <AutoSizer style={autoSizerStyleProp}>
           {({ width, height }: any) => {
-            const hpanel = height < minHeight ? minHeight : height;
+            let hpanel = height < minHeight ? minHeight : height;
+            if (hpanel > 380) {
+              hpanel = 480;
+            }
+            const totalWidth = width > 1920 ? 1920 : width;
             return (
               <ReactGridLayout
-                width={width}
+                width={totalWidth}
                 cols={colsInGrid}
                 containerPadding={[xSpacing, ySpacing]}
                 onLayoutChange={saveDashboardDistribution}
                 layout={dashboardDistr}
                 rowHeight={hpanel / 6}
+                style={{ margin: "0 auto", width: totalWidth }}
               >
                 {panels(width)}
               </ReactGridLayout>


### PR DESCRIPTION
fixes #587 

## What does this do?
Fixed max-widget sizes for prometheus dashboard on high-res screens

## How does it look?

<img width="2554" alt="Screen Shot 2021-03-03 at 13 30 07" src="https://user-images.githubusercontent.com/33497058/109862087-a2174400-7c25-11eb-92df-d4083a5635c6.png">
<img width="3360" alt="Screen Shot 2021-03-03 at 13 29 11" src="https://user-images.githubusercontent.com/33497058/109862096-a4799e00-7c25-11eb-84f4-7996a01e855e.png">