### PR TITLE
[WIP] Hash user passwords using argon2

### DIFF
--- a/restapi/user_account_test.go
+++ b/restapi/user_account_test.go
@@ -48,7 +48,7 @@ func Test_changePassword(t *testing.T) {
 				ctx:    context.Background(),
 				session: &models.Principal{
 					AccountAccessKey: "TESTTEST",
-					AccountSecretKey: "TESTTEST",
+					AccountSecretKey: "$argon2id$v=19$m=65536,t=1,p=4$EURl08Jh7TQCVP2SrvEJdQ$UPma6ZIozlvk+BG5Em1NDYV9GDu9Bsq3ocymUB1nRlg",
 				},
 				currentSecretKey: "TESTTEST",
 				newSecretKey:     "TESTTEST2",
@@ -66,7 +66,7 @@ func Test_changePassword(t *testing.T) {
 				ctx:    context.Background(),
 				session: &models.Principal{
 					AccountAccessKey: "TESTTEST",
-					AccountSecretKey: "TESTTEST",
+					AccountSecretKey: "$argon2id$v=19$m=65536,t=1,p=4$EURl08Jh7TQCVP2SrvEJdQ$UPma6ZIozlvk+BG5Em1NDYV9GDu9Bsq3ocymUB1nRlg",
 				},
 				currentSecretKey: "TESTTEST",
 				newSecretKey:     "TESTTEST2",
@@ -85,7 +85,7 @@ func Test_changePassword(t *testing.T) {
 				ctx:    context.Background(),
 				session: &models.Principal{
 					AccountAccessKey: "TESTTEST",
-					AccountSecretKey: "TESTTEST123",
+					AccountSecretKey: "$argon2id$v=19$m=65536,t=1,p=4$npAQ6LeqDsPMEQEIl7GnDA$cNasELqD07M78DWgmtVS2ilDu1GZioPkstpDdi0cFPA",
 				},
 				currentSecretKey: "TESTTEST",
 				newSecretKey:     "TESTTEST2",

--- a/restapi/user_login.go
+++ b/restapi/user_login.go
@@ -118,12 +118,17 @@ func getConsoleCredentials(ctx context.Context, accessKey, secretKey string) (*c
 	if err != nil {
 		return nil, err
 	}
+	// hashing password using argon2
+	hashedPassword, err := auth.NewPasswordHash(secretKey)
+	if err != nil {
+		return nil, err
+	}
 	// cCredentials will be sts credentials, account credentials will be need it in the scenario the user wish
 	// to change its password
 	cCredentials := &consoleCredentials{
 		consoleCredentials: creds,
 		accountAccessKey:   accessKey,
-		accountSecretKey:   secretKey,
+		accountSecretKey:   hashedPassword,
 	}
 	tokens, err := cCredentials.Get()
 	if err != nil {
@@ -162,11 +167,11 @@ func getLoginResponse(lr *models.LoginRequest) (*models.LoginResponse, *models.E
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	// prepare console credentials
-	consolCreds, err := getConsoleCredentials(ctx, *lr.AccessKey, *lr.SecretKey)
+	consoleCreds, err := getConsoleCredentials(ctx, *lr.AccessKey, *lr.SecretKey)
 	if err != nil {
 		return nil, prepareError(errInvalidCredentials, nil, err)
 	}
-	sessionID, err := login(consolCreds)
+	sessionID, err := login(consoleCreds)
 	if err != nil {
 		return nil, prepareError(errInvalidCredentials, nil, err)
 	}


### PR DESCRIPTION
Added support for hashing user secret key with argon2 and then store it inside the
encrypted session token, necessary for current password comparison (prevent account take over vulnerabilities) during the
change-password process