### PR TITLE
Added sync icon to get information button

### DIFF
--- a/portal-ui/src/icons/SyncIcon.tsx
+++ b/portal-ui/src/icons/SyncIcon.tsx
@@ -1,0 +1,29 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React from "react";
+import { SvgIcon } from "@material-ui/core";
+const SyncIcon = () => {
+  return (
+    <SvgIcon>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"></path>
+      </svg>
+    </SvgIcon>
+  );
+};
+
+export default SyncIcon;

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/ListBuckets.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/ListBuckets.tsx
@@ -289,7 +289,7 @@ const ListBuckets = ({
                 startIcon={<CreateIcon />}
                 onClick={() => {
                   addBucketOpen(true);
-                }}
+                }} 
               >
                 Create Bucket
               </Button>

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/PrDashboard.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/PrDashboard.tsx
@@ -48,6 +48,7 @@ import PieChartWidget from "./Widgets/PieChartWidget";
 import SingleRepWidget from "./Widgets/SingleRepWidget";
 import DateTimePickerWrapper from "../../Common/FormComponents/DateTimePickerWrapper/DateTimePickerWrapper";
 import api from "../../../../common/api";
+import SyncIcon from "../../../../icons/SyncIcon";
 
 interface IPrDashboard {
   classes: any;
@@ -56,12 +57,22 @@ interface IPrDashboard {
 
 const styles = (theme: Theme) =>
   createStyles({
+    ...actionsTray,
+    ...containerForHeader(theme.spacing(4)),
     widgetsContainer: {
       height: "calc(100vh - 250px)",
       paddingBottom: 235,
     },
-    ...actionsTray,
-    ...containerForHeader(theme.spacing(4)),
+    syncButton: {
+      "&.MuiButton-root .MuiButton-iconSizeMedium > *:first-child": {
+        fontSize: 18,
+
+      }
+    },
+    actionsTray: {
+      ...actionsTray.actionsTray,
+      padding: "0 10px"
+    },
   });
 
 const PrDashboard = ({ classes, displayErrorMessage }: IPrDashboard) => {
@@ -222,8 +233,10 @@ const PrDashboard = ({ classes, displayErrorMessage }: IPrDashboard) => {
           variant="contained"
           color="primary"
           onClick={triggerLoad}
+          startIcon={<SyncIcon />}
+          className={classes.syncButton}
         >
-          Get Information
+          Sync
         </Button>
       </Grid>
       <Grid item xs={12} className={classes.widgetsContainer}>


### PR DESCRIPTION
fixes https://github.com/miniohq/engineering/issues/132

## What does this do?

Replaced Get Information button by a Sync one with an icon. action will remain the same

## How does it look?

<img width="1177" alt="Screen Shot 2021-05-13 at 21 12 56" src="https://user-images.githubusercontent.com/33497058/118210710-763bea00-b430-11eb-8676-10a8aedb5b7b.png">

