### PR TITLE
ReadOnly filesystem error when loading certificates

### DIFF
--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -327,13 +327,18 @@ func GetAllCertificatesAndCAs() (*x509.CertPool, []*x509.Certificate, *xcerts.Ma
 	return GlobalRootCAs, globalPublicCerts, globalTLSCertsManager
 }
 
+// TLSCertsManager custom TLS Manager for SNI support
+type TLSCertsManager struct {
+	*xcerts.Manager
+}
+
 // AddCertificate check if Manager is initialized and then append a new certificate to it
-func AddCertificate(ctx context.Context, manager *xcerts.Manager, publicKey, privateKey string) (err error) {
+func (m *TLSCertsManager) AddCertificate(ctx context.Context, publicKey, privateKey string) (err error) {
 	// If Cert Manager is not nil add more certificates
-	if manager != nil {
-		return manager.AddCertificate(publicKey, privateKey)
+	if m.Manager != nil {
+		return m.Manager.AddCertificate(publicKey, privateKey)
 	}
 	// Initialize cert manager
-	manager, err = xcerts.NewManager(ctx, publicKey, privateKey, LoadX509KeyPair)
+	m.Manager, err = xcerts.NewManager(ctx, publicKey, privateKey, LoadX509KeyPair)
 	return err
 }

--- a/restapi/config.go
+++ b/restapi/config.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/minio/pkg/certs"
+	"github.com/minio/console/pkg/certs"
 	"github.com/minio/pkg/env"
 )
 
@@ -276,7 +276,7 @@ var (
 	// GlobalPublicCerts has certificates Console will use to serve clients
 	GlobalPublicCerts []*x509.Certificate
 	// GlobalTLSCertsManager custom TLS Manager for SNI support
-	GlobalTLSCertsManager *certs.Manager
+	GlobalTLSCertsManager *certs.TLSCertsManager
 )
 
 // getK8sSAToken assumes the plugin is running inside a k8s pod and extract the current service account from the


### PR DESCRIPTION
Read-only file-system, ie: when console is running as container in kubernetes, was
preventing console to run because of an error during creating
directories

```

E: 2021/06/07 18:31:27 server.go:64: Unable to load certs: unable to create certs CA directory at /tmp/certs/CAs: with mkdir /tmp/certs/CAs: read-only file system
I: 2021/06/07 18:31:27 server.go:60: Serving console at http://[::[]:9090
E: 2021/06/07 18:31:32 server.go:64: Refreshing subnet license failed: no license present
E: 2021/06/07 18:36:32 server.go:64: Refreshing subnet license failed: no license present
```

Note:

This PR fixes the scenario when you want to start console service with TLS via certificates in the `~/.console/certs` folder and also using the `--tls-certificate` and `--tls-key` flags

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>