### PR TITLE
Changed field names & removed bottom texts

### DIFF
--- a/portal-ui/src/screens/LoginPage/LoginPage.tsx
+++ b/portal-ui/src/screens/LoginPage/LoginPage.tsx
@@ -281,7 +281,7 @@ const Login = ({ classes, userLoggedIn }: ILoginProps) => {
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     setAccessKey(e.target.value)
                   }
-                  label="Enter Access Key"
+                  label="Enter Username"
                   name="accessKey"
                   autoComplete="username"
                   disabled={loginSending}
@@ -295,7 +295,7 @@ const Login = ({ classes, userLoggedIn }: ILoginProps) => {
                     setSecretKey(e.target.value)
                   }
                   name="secretKey"
-                  label="Enter Secret Key"
+                  label="Enter Password"
                   type="password"
                   id="secretKey"
                   autoComplete="current-password"
@@ -316,12 +316,6 @@ const Login = ({ classes, userLoggedIn }: ILoginProps) => {
             </Grid>
             <Grid item xs={12} className={classes.linearPredef}>
               {loginSending && <LinearProgress />}
-            </Grid>
-            <Grid item xs={12} className={classes.disclaimer}>
-              <strong>Don't have an access key?</strong>
-              <br />
-              <br />
-              Contact your administrator to have one made
             </Grid>
           </form>
         </React.Fragment>
@@ -396,11 +390,6 @@ const Login = ({ classes, userLoggedIn }: ILoginProps) => {
             </Grid>
             <Grid item xs={12} className={classes.linearPredef}>
               {loginSending && <LinearProgress />}
-            </Grid>
-            <Grid item xs={12} className={classes.disclaimer}>
-              <strong>Don't have an access key?</strong>
-              <br />
-              Contact your administrator to have one made
             </Grid>
           </form>
         </React.Fragment>


### PR DESCRIPTION
fixes https://github.com/miniohq/engineering/issues/171

## What does this do?

Changes the username / password labels for login screen & removes bottom text of login screens

## How does it look?

<img width="1470" alt="Screen Shot 2021-06-16 at 12 02 09" src="https://user-images.githubusercontent.com/33497058/122262401-fd9ad400-ce9a-11eb-905b-0f1391760b0d.png">
<img width="1825" alt="Screen Shot 2021-06-16 at 12 00 47" src="https://user-images.githubusercontent.com/33497058/122262407-fecc0100-ce9a-11eb-8b78-3c556a33dfcd.png">
