### PR TITLE
fix: lazily interpret environment values

### DIFF
--- a/restapi/config.go
+++ b/restapi/config.go
@@ -51,19 +51,9 @@ var (
 	LicenseKey = ""
 )
 
-var (
-	logSearchAPI    string
-	logSearchURL    string
-	prometheusURL   string
-	prometheusJobID string
-	consoleImage    string
-)
+var consoleImage string
 
 func init() {
-	logSearchAPI = env.Get(LogSearchQueryAuthToken, "")
-	logSearchURL = env.Get(LogSearchURL, "http://localhost:8080")
-	prometheusURL = env.Get(PrometheusURL, "")
-	prometheusJobID = env.Get(PrometheusJobID, "minio-job")
 	consoleImage = env.Get(ConsoleOperatorConsoleImage, ConsoleImageDefaultVersion)
 }
 
@@ -97,10 +87,6 @@ func getMinIOEndpointIsSecure() bool {
 		}
 	}
 	return false
-}
-
-func getProductionMode() bool {
-	return strings.ToLower(env.Get(ConsoleProductionMode, "on")) == "on"
 }
 
 // GetHostname gets console hostname set on env variable,
@@ -244,19 +230,19 @@ func getSecureExpectCTHeader() string {
 }
 
 func getLogSearchAPIToken() string {
-	return logSearchAPI
+	return env.Get(LogSearchQueryAuthToken, "")
 }
 
 func getLogSearchURL() string {
-	return logSearchURL
+	return env.Get(LogSearchURL, "http://localhost:8080")
 }
 
 func getPrometheusURL() string {
-	return prometheusURL
+	return env.Get(PrometheusURL, "")
 }
 
 func getPrometheusJobID() string {
-	return prometheusJobID
+	return env.Get(PrometheusJobID, "minio-job")
 }
 
 // GetSubnetLicense returns the current subnet jwt license

--- a/restapi/configure_console.go
+++ b/restapi/configure_console.go
@@ -192,7 +192,7 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 		ReferrerPolicy:                  getSecureReferrerPolicy(),
 		FeaturePolicy:                   getSecureFeaturePolicy(),
 		ExpectCTHeader:                  getSecureExpectCTHeader(),
-		IsDevelopment:                   !getProductionMode(),
+		IsDevelopment:                   false,
 	}
 	secureMiddleware := secure.New(secureOptions)
 	return secureMiddleware.Handler(next)
@@ -268,10 +268,9 @@ func wrapHandlerSinglePageApplication(h http.Handler) http.HandlerFunc {
 	}
 }
 
-type logWriter struct{}
+type nullWriter struct{}
 
-func (lw logWriter) Write(b []byte) (int, error) {
-	LogError(string(bytes.TrimSuffix(b, []byte("\n"))))
+func (lw nullWriter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
@@ -280,6 +279,6 @@ func (lw logWriter) Write(b []byte) (int, error) {
 // This function can be called multiple times, depending on the number of serving schemes.
 // scheme value will be set accordingly: "http", "https" or "unix"
 func configureServer(s *http.Server, _, _ string) {
-	// Turn-off random logging by Go internall
-	s.ErrorLog = log.New(&logWriter{}, "", 0)
+	// Turn-off random logging by Go net/http
+	s.ErrorLog = log.New(&nullWriter{}, "", 0)
 }

--- a/restapi/user_log_search.go
+++ b/restapi/user_log_search.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 
 	"github.com/go-openapi/swag"
@@ -41,9 +40,6 @@ func registerLogSearchHandlers(api *operations.ConsoleAPI) {
 		}
 		return user_api.NewLogSearchOK().WithPayload(searchResp)
 	})
-}
-func init() {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
 
 // getLogSearchResponse performs a query to Log Search if Enabled


### PR DESCRIPTION
using `init()` to initialize environment values
can cause problems when console is imported
into dependent projects.