### PR TITLE
Fix escape characters in filename.

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -515,7 +515,7 @@ const ListObjects = ({
     const formData = new FormData();
 
     for (let file of files) {
-      const fileName = file.name;
+      const fileName = unescape(file.name);
       const blobFile = new Blob([file]);
       formData.append(fileName, blobFile);
     }


### PR DESCRIPTION
Automatically convert escape characters in filenames, so there is no problem with deleting such files.