### PR TITLE
Fix bug when deleting objects with % in the name

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/DeleteObject.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/DeleteObject.tsx
@@ -27,7 +27,6 @@ import {
 } from "@material-ui/core";
 import { setErrorSnackMessage } from "../../../../../../actions";
 import api from "../../../../../../common/api";
-import * as url from "url";
 
 interface IDeleteObjectProps {
   closeDeleteModalAndRefresh: (refresh: boolean) => void;

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/DeleteObject.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/DeleteObject.tsx
@@ -27,6 +27,7 @@ import {
 } from "@material-ui/core";
 import { setErrorSnackMessage } from "../../../../../../actions";
 import api from "../../../../../../common/api";
+import * as url from "url";
 
 interface IDeleteObjectProps {
   closeDeleteModalAndRefresh: (refresh: boolean) => void;
@@ -53,7 +54,9 @@ const DeleteObject = ({
     if (selectedObject.endsWith("/")) {
       recursive = true;
     }
-    setDeleteLoading(true);
+    // Escape object name
+    selectedObject = encodeURIComponent(selectedObject);
+
     api
       .invoke(
         "DELETE",

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -468,7 +468,8 @@ const ListObjects = ({
     let files = e.target.files;
     let uploadUrl = `/api/v1/buckets/${bucketName}/objects/upload`;
     if (path !== "") {
-      uploadUrl = `${uploadUrl}?prefix=${path}`;
+      const encodedPath = encodeURIComponent(path);
+      uploadUrl = `${uploadUrl}?prefix=${encodedPath}`;
     }
     let xhr = new XMLHttpRequest();
     const areMultipleFiles = files.length > 1 ? true : false;

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ObjectDetails.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ObjectDetails.tsx
@@ -219,10 +219,11 @@ const ObjectDetails = ({
 
   useEffect(() => {
     if (loadObjectData) {
+      const encodedPath = encodeURIComponent(pathInBucket);
       api
         .invoke(
           "GET",
-          `/api/v1/buckets/${bucketName}/objects?prefix=${pathInBucket}&with_versions=true`
+          `/api/v1/buckets/${bucketName}/objects?prefix=${encodedPath}&with_versions=true`
         )
         .then((res: IFileInfo[]) => {
           const result = get(res, "objects", []);

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
@@ -25,9 +25,8 @@ export const download = (
 ) => {
   const anchor = document.createElement("a");
   document.body.appendChild(anchor);
-  const allPathData = objectPath.split("/");
-
-  let path = `/api/v1/buckets/${bucketName}/objects/download?prefix=${objectPath}`;
+  const encodedPath = encodeURIComponent(objectPath);
+  let path = `/api/v1/buckets/${bucketName}/objects/download?prefix=${encodedPath}`;
   if (!isNullOrUndefined(versionID) && versionID !== "null") {
     path = path.concat(`&version_id=${versionID}`);
   }


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/184


To test, upload a file called `02%20-%20FLY%20ME%20TO%20THE%20MOON%20.mp3` which now is supported from the Upload on the UI, then delete it.

Also support unicode now: `新文章.txt`

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>