### PR TITLE
Remove the last k8s import on restapi

### DIFF
--- a/operatorapi/error.go
+++ b/operatorapi/error.go
@@ -40,8 +40,8 @@ var (
 	errAccessDenied                       = errors.New("access denied")
 )
 
-// PrepareError receives an error object and parse it against k8sErrors, returns the right error code paired with a generic error message
-func PrepareError(err ...error) *models.Error {
+// prepareError receives an error object and parse it against k8sErrors, returns the right error code paired with a generic error message
+func prepareError(err ...error) *models.Error {
 	errorCode := int32(500)
 	errorMessage := errorGeneric.Error()
 	if len(err) > 0 {

--- a/operatorapi/operator_direct_csi.go
+++ b/operatorapi/operator_direct_csi.go
@@ -22,8 +22,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/minio/console/restapi"
-
 	"github.com/minio/console/operatorapi/operations/operator_api"
 
 	"github.com/minio/console/cluster"
@@ -153,12 +151,12 @@ func getDirectCSIDrivesListResponse(session *models.Principal) (*models.GetDirec
 	ctx := context.Background()
 	client, err := cluster.DirectCSIClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	drives, err := getDirectCSIDriveList(ctx, client.DirectV1beta1())
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return drives, nil
 }
@@ -207,12 +205,12 @@ func getDirectCSIVolumesListResponse(session *models.Principal) (*models.GetDire
 	ctx := context.Background()
 	client, err := cluster.DirectCSIClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	volumes, err := getDirectCSIVolumesList(ctx, client.DirectV1beta1())
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return volumes, nil
 }
@@ -308,12 +306,12 @@ func formatVolumesResponse(session *models.Principal, params operator_api.Direct
 	ctx := context.Background()
 	client, err := cluster.DirectCSIClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	formatResult, errFormat := formatDrives(ctx, client.DirectV1beta1(), params.Body.Drives, *params.Body.Force)
 	if errFormat != nil {
-		return nil, restapi.PrepareError(errFormat)
+		return nil, prepareError(errFormat)
 	}
 	return formatResult, nil
 }

--- a/operatorapi/operator_login.go
+++ b/operatorapi/operator_login.go
@@ -163,11 +163,11 @@ func getLoginResponse(lr *models.LoginRequest) (*models.LoginResponse, *models.E
 	// prepare console credentials
 	consolCreds, err := getConsoleCredentials(ctx, *lr.AccessKey, *lr.SecretKey)
 	if err != nil {
-		return nil, PrepareError(errInvalidCredentials, nil, err)
+		return nil, prepareError(errInvalidCredentials, nil, err)
 	}
 	sessionID, err := login(consolCreds)
 	if err != nil {
-		return nil, PrepareError(errInvalidCredentials, nil, err)
+		return nil, prepareError(errInvalidCredentials, nil, err)
 	}
 	// serialize output
 	loginResponse := &models.LoginResponse{
@@ -188,7 +188,7 @@ func getLoginDetailsResponse() (*models.LoginDetails, *models.Error) {
 		// initialize new oauth2 client
 		oauth2Client, err := oauth2.NewOauth2ProviderClient(ctx, nil, restapi.GetConsoleSTSClient())
 		if err != nil {
-			return nil, PrepareError(err)
+			return nil, prepareError(err)
 		}
 		// Validate user against IDP
 		identityProvider := &auth.IdentityProvider{Client: oauth2Client}
@@ -208,12 +208,12 @@ func getLoginOauth2AuthResponse() (*models.LoginResponse, *models.Error) {
 
 	creds, err := restapi.NewConsoleCredentials("", getK8sSAToken(), "")
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	credentials := restapi.ConsoleCredentials{ConsoleCredentials: creds, Actions: []string{}}
 	token, err := login(credentials)
 	if err != nil {
-		return nil, PrepareError(errInvalidCredentials, nil, err)
+		return nil, prepareError(errInvalidCredentials, nil, err)
 	}
 	// serialize output
 	loginResponse := &models.LoginResponse{
@@ -226,12 +226,12 @@ func getLoginOauth2AuthResponse() (*models.LoginResponse, *models.Error) {
 func getLoginOperatorResponse(lmr *models.LoginOperatorRequest) (*models.LoginResponse, *models.Error) {
 	creds, err := restapi.NewConsoleCredentials("", *lmr.Jwt, "")
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	consoleCreds := restapi.ConsoleCredentials{ConsoleCredentials: creds, Actions: []string{}}
 	token, err := login(consoleCreds)
 	if err != nil {
-		return nil, PrepareError(errInvalidCredentials, nil, err)
+		return nil, prepareError(errInvalidCredentials, nil, err)
 	}
 	// serialize output
 	loginResponse := &models.LoginResponse{

--- a/operatorapi/operator_namespaces.go
+++ b/operatorapi/operator_namespaces.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 
 	"github.com/minio/console/operatorapi/operations/operator_api"
-	"github.com/minio/console/restapi"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/minio/console/cluster"
@@ -50,7 +49,7 @@ func getNamespaceCreatedResponse(session *models.Principal, params operator_api.
 	clientset, err := cluster.K8sClient(session.STSSessionToken)
 
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 
 	namespace := *params.Body.Name
@@ -58,7 +57,7 @@ func getNamespaceCreatedResponse(session *models.Principal, params operator_api.
 	errCreation := getNamespaceCreated(ctx, clientset.CoreV1(), namespace)
 
 	if errCreation != nil {
-		return restapi.PrepareError(errCreation)
+		return prepareError(errCreation)
 	}
 
 	return nil

--- a/operatorapi/operator_nodes.go
+++ b/operatorapi/operator_nodes.go
@@ -23,7 +23,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/set"
 
 	"github.com/minio/console/operatorapi/operations/operator_api"
-	"github.com/minio/console/restapi"
 
 	"github.com/minio/console/cluster"
 
@@ -136,12 +135,12 @@ func min(x, y int64) int64 {
 func getMaxAllocatableMemoryResponse(ctx context.Context, session *models.Principal, numNodes int32) (*models.MaxAllocatableMemResponse, *models.Error) {
 	client, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	clusterResources, err := getMaxAllocatableMemory(ctx, client.CoreV1(), numNodes)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return clusterResources, nil
 }
@@ -176,12 +175,12 @@ func getNodeLabels(ctx context.Context, clientset v1.CoreV1Interface) (*models.N
 func getNodeLabelsResponse(ctx context.Context, session *models.Principal) (*models.NodeLabels, *models.Error) {
 	client, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	clusterResources, err := getNodeLabels(ctx, client.CoreV1())
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return clusterResources, nil
 }

--- a/operatorapi/operator_parity.go
+++ b/operatorapi/operator_parity.go
@@ -56,7 +56,7 @@ func getParityResponse(params operator_api.GetParityParams) (models.ParityRespon
 	parityValues, err := GetParityInfo(nodes, disksPerNode)
 	if err != nil {
 		restapi.LogError("error getting parity info: %v", err)
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	return parityValues, nil

--- a/operatorapi/operator_session.go
+++ b/operatorapi/operator_session.go
@@ -39,7 +39,7 @@ func registerSessionHandlers(api *operations.OperatorAPI) {
 func getSessionResponse(session *models.Principal) (*models.SessionResponse, *models.Error) {
 	// serialize output
 	if session == nil {
-		return nil, PrepareError(errorGenericInvalidSession)
+		return nil, prepareError(errorGenericInvalidSession)
 	}
 	sessionResp := &models.SessionResponse{
 		Pages:    acl.GetAuthorizedEndpoints(session.Actions),

--- a/operatorapi/operator_tenants.go
+++ b/operatorapi/operator_tenants.go
@@ -248,12 +248,12 @@ func registerTenantHandlers(api *operations.OperatorAPI) {
 func getDeleteTenantResponse(session *models.Principal, params operator_api.DeleteTenantParams) *models.Error {
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	// get Kubernetes Client
 	clientset, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	opClient := &operatorClient{
 		client: opClientClientSet,
@@ -263,7 +263,7 @@ func getDeleteTenantResponse(session *models.Principal, params operator_api.Dele
 		deleteTenantPVCs = params.Body.DeletePvcs
 	}
 	if err = deleteTenantAction(context.Background(), opClient, clientset.CoreV1(), params.Namespace, params.Tenant, deleteTenantPVCs); err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -307,14 +307,14 @@ func getDeletePodResponse(session *models.Principal, params operator_api.DeleteP
 	// get Kubernetes Client
 	clientset, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	listOpts := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("v1.min.io/tenant=%s", params.Tenant),
 		FieldSelector: fmt.Sprintf("metadata.name=%s%s", params.Tenant, params.PodName[len(params.Tenant):]),
 	}
 	if err = clientset.CoreV1().Pods(params.Namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, listOpts); err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -437,7 +437,7 @@ func getTenantDetailsResponse(session *models.Principal, params operator_api.Ten
 	defer cancel()
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	opClient := &operatorClient{
@@ -446,7 +446,7 @@ func getTenantDetailsResponse(session *models.Principal, params operator_api.Ten
 
 	minTenant, err := getTenant(ctx, opClient, params.Namespace, params.Tenant)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	info := getTenantInfo(minTenant)
@@ -462,7 +462,7 @@ func getTenantDetailsResponse(session *models.Principal, params operator_api.Ten
 	// get Kubernetes Client
 	clientSet, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	k8sClient := k8sClient{
@@ -659,14 +659,14 @@ func getTenantSecurityResponse(session *models.Principal, params operator_api.Te
 	//defer cancel()
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	opClient := &operatorClient{
 		client: opClientClientSet,
 	}
 	minTenant, err := getTenant(ctx, opClient, params.Namespace, params.Tenant)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// get Kubernetes Client
 	clientSet, err := cluster.K8sClient(session.STSSessionToken)
@@ -674,11 +674,11 @@ func getTenantSecurityResponse(session *models.Principal, params operator_api.Te
 		client: clientSet,
 	}
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	info, err := getTenantSecurity(ctx, &k8sClient, minTenant)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return info, nil
 }
@@ -689,12 +689,12 @@ func getUpdateTenantSecurityResponse(session *models.Principal, params operator_
 	defer cancel()
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	// get Kubernetes Client
 	clientSet, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	k8sClient := k8sClient{
 		client: clientSet,
@@ -703,7 +703,7 @@ func getUpdateTenantSecurityResponse(session *models.Principal, params operator_
 		client: opClientClientSet,
 	}
 	if err := updateTenantSecurity(ctx, opClient, &k8sClient, params.Namespace, params); err != nil {
-		return restapi.PrepareError(err, errors.New("unable to update tenant"))
+		return prepareError(err, errors.New("unable to update tenant"))
 	}
 	return nil
 }
@@ -917,14 +917,14 @@ func getListAllTenantsResponse(session *models.Principal, params operator_api.Li
 	ctx := context.Background()
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	opClient := &operatorClient{
 		client: opClientClientSet,
 	}
 	listT, err := listTenants(ctx, opClient, "", params.Limit)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return listT, nil
 }
@@ -934,14 +934,14 @@ func getListTenantsResponse(session *models.Principal, params operator_api.ListT
 	ctx := context.Background()
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	opClient := &operatorClient{
 		client: opClientClientSet,
 	}
 	listT, err := listTenants(ctx, opClient, params.Namespace, params.Limit)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return listT, nil
 }
@@ -965,7 +965,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 		client: clientSet,
 	}
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	ns := *tenantReq.Namespace
@@ -1004,7 +1004,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 	}
 	_, err = clientSet.CoreV1().Secrets(ns).Create(ctx, &instanceSecret, metav1.CreateOptions{})
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// delete secrets created if an error occurred during tenant creation,
@@ -1025,7 +1025,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 	// Check the Erasure Coding Parity for validity and pass it to Tenant
 	if tenantReq.ErasureCodingParity > 0 {
 		if tenantReq.ErasureCodingParity < 2 || tenantReq.ErasureCodingParity > 8 {
-			return nil, restapi.PrepareError(errorInvalidErasureCodingValue)
+			return nil, prepareError(errorInvalidErasureCodingValue)
 		}
 		environmentVariables = append(environmentVariables, corev1.EnvVar{
 			Name:  "MINIO_STORAGE_CLASS_STANDARD",
@@ -1121,7 +1121,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 			}
 			_, err := clientSet.CoreV1().Secrets(ns).Create(ctx, &userSecret, metav1.CreateOptions{})
 			if err != nil {
-				return nil, restapi.PrepareError(err)
+				return nil, prepareError(err)
 			}
 		}
 		// attach the users to the tenant
@@ -1147,7 +1147,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 		externalCertSecretName := fmt.Sprintf("%s-instance-external-certificates", secretName)
 		externalCertSecret, err := createOrReplaceExternalCertSecrets(ctx, &k8sClient, ns, tenantReq.TLS.Minio, externalCertSecretName, tenantName)
 		if err != nil {
-			return nil, restapi.PrepareError(err)
+			return nil, prepareError(err)
 		}
 		minInst.Spec.ExternalCertSecret = externalCertSecret
 	}
@@ -1159,7 +1159,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 			certificates := []*models.KeyPairConfiguration{tenantReq.Encryption.Client}
 			certificateSecrets, err := createOrReplaceExternalCertSecrets(ctx, &k8sClient, ns, certificates, tenantExternalClientCertSecretName, tenantName)
 			if err != nil {
-				return nil, restapi.PrepareError(restapi.ErrorGeneric)
+				return nil, prepareError(restapi.ErrorGeneric)
 			}
 			if len(certificateSecrets) > 0 {
 				minInst.Spec.ExternalClientCertSecret = certificateSecrets[0]
@@ -1169,7 +1169,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 		// KES configuration for Tenant instance
 		minInst.Spec.KES, err = getKESConfiguration(ctx, &k8sClient, ns, tenantReq.Encryption, secretName, tenantName)
 		if err != nil {
-			return nil, restapi.PrepareError(restapi.ErrorGeneric)
+			return nil, prepareError(restapi.ErrorGeneric)
 		}
 		// Set Labels, Annotations and Node Selector for KES
 		minInst.Spec.KES.Labels = tenantReq.Encryption.Labels
@@ -1182,7 +1182,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 		for i, caCertificate := range tenantReq.TLS.CaCertificates {
 			certificateContent, err := base64.StdEncoding.DecodeString(caCertificate)
 			if err != nil {
-				return nil, restapi.PrepareError(restapi.ErrorGeneric, nil, err)
+				return nil, prepareError(restapi.ErrorGeneric, nil, err)
 			}
 			caCertificates = append(caCertificates, tenantSecret{
 				Name: fmt.Sprintf("ca-certificate-%d", i),
@@ -1194,7 +1194,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 		if len(caCertificates) > 0 {
 			certificateSecrets, err := createOrReplaceSecrets(ctx, &k8sClient, ns, caCertificates, tenantName)
 			if err != nil {
-				return nil, restapi.PrepareError(restapi.ErrorGeneric, nil, err)
+				return nil, prepareError(restapi.ErrorGeneric, nil, err)
 			}
 			minInst.Spec.ExternalCaCertSecret = certificateSecrets
 		}
@@ -1251,7 +1251,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 			certificates := []*models.KeyPairConfiguration{tenantReq.TLS.Console}
 			externalCertSecret, err := createOrReplaceExternalCertSecrets(ctx, &k8sClient, ns, certificates, externalCertSecretName, tenantName)
 			if err != nil {
-				return nil, restapi.PrepareError(restapi.ErrorGeneric)
+				return nil, prepareError(restapi.ErrorGeneric)
 			}
 			if len(externalCertSecret) > 0 {
 				minInst.Spec.Console.ExternalCertSecret = externalCertSecret[0]
@@ -1283,7 +1283,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 
 		_, err = clientSet.CoreV1().Secrets(ns).Create(ctx, &instanceSecret, metav1.CreateOptions{})
 		if err != nil {
-			return nil, restapi.PrepareError(restapi.ErrorGeneric)
+			return nil, prepareError(restapi.ErrorGeneric)
 		}
 
 		// Set Labels, Annotations and Node Selector for Console
@@ -1299,7 +1299,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 			for i, caCertificate := range tenantReq.TLS.ConsoleCaCertificates {
 				certificateContent, err := base64.StdEncoding.DecodeString(caCertificate)
 				if err != nil {
-					return nil, restapi.PrepareError(restapi.ErrorGeneric, nil, err)
+					return nil, prepareError(restapi.ErrorGeneric, nil, err)
 				}
 				caCertificates = append(caCertificates, tenantSecret{
 					Name: fmt.Sprintf("console-ca-certificate-%d", i),
@@ -1311,7 +1311,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 			if len(caCertificates) > 0 {
 				certificateSecrets, err := createOrReplaceSecrets(ctx, &k8sClient, ns, caCertificates, tenantName)
 				if err != nil {
-					return nil, restapi.PrepareError(restapi.ErrorGeneric, nil, err)
+					return nil, prepareError(restapi.ErrorGeneric, nil, err)
 				}
 				minInst.Spec.Console.ExternalCaCertSecret = certificateSecrets
 			}
@@ -1330,7 +1330,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 		pool, err := parseTenantPoolRequest(pool)
 		if err != nil {
 			restapi.LogError("parseTenantPoolRequest failed: %v", err)
-			return nil, restapi.PrepareError(err)
+			return nil, prepareError(err)
 		}
 		minInst.Spec.Pools = append(minInst.Spec.Pools, *pool)
 	}
@@ -1346,7 +1346,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 	if tenantReq.ImagePullSecret != "" {
 		imagePullSecret = tenantReq.ImagePullSecret
 	} else if imagePullSecret, err = setImageRegistry(ctx, tenantReq.ImageRegistry, clientSet.CoreV1(), ns, tenantName); err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// pass the image pull secret to the Tenant
 	if imagePullSecret != "" {
@@ -1465,20 +1465,20 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 
 	opClient, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	_, err = opClient.MinioV2().Tenants(ns).Create(context.Background(), &minInst, metav1.CreateOptions{})
 	if err != nil {
 		restapi.LogError("Creating new tenant failed with: %v", err)
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// Integrations
 	if os.Getenv("GKE_INTEGRATION") != "" {
 		err := gkeIntegration(clientSet, tenantName, ns, session.STSSessionToken)
 		if err != nil {
-			return nil, restapi.PrepareError(err)
+			return nil, prepareError(err)
 		}
 	}
 	response = &models.CreateTenantResponse{}
@@ -1660,12 +1660,12 @@ func getUpdateTenantResponse(session *models.Principal, params operator_api.Upda
 	ctx := context.Background()
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	// get Kubernetes Client
 	clientSet, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	opClient := &operatorClient{
 		client: opClientClientSet,
@@ -1676,7 +1676,7 @@ func getUpdateTenantResponse(session *models.Principal, params operator_api.Upda
 		},
 	}
 	if err := updateTenantAction(ctx, opClient, clientSet.CoreV1(), httpC, params.Namespace, params); err != nil {
-		return restapi.PrepareError(err, errors.New("unable to update tenant"))
+		return prepareError(err, errors.New("unable to update tenant"))
 	}
 	return nil
 }
@@ -1710,13 +1710,13 @@ func getTenantAddPoolResponse(session *models.Principal, params operator_api.Ten
 	ctx := context.Background()
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	opClient := &operatorClient{
 		client: opClientClientSet,
 	}
 	if err := addTenantPool(ctx, opClient, params); err != nil {
-		return restapi.PrepareError(err, errors.New("unable to add pool"))
+		return prepareError(err, errors.New("unable to add pool"))
 	}
 	return nil
 }
@@ -1729,11 +1729,11 @@ func getTenantUsageResponse(session *models.Principal, params operator_api.GetTe
 
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err, errorUnableToGetTenantUsage)
+		return nil, prepareError(err, errorUnableToGetTenantUsage)
 	}
 	clientSet, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err, errorUnableToGetTenantUsage)
+		return nil, prepareError(err, errorUnableToGetTenantUsage)
 	}
 
 	opClient := &operatorClient{
@@ -1745,7 +1745,7 @@ func getTenantUsageResponse(session *models.Principal, params operator_api.GetTe
 
 	minTenant, err := getTenant(ctx, opClient, params.Namespace, params.Tenant)
 	if err != nil {
-		return nil, restapi.PrepareError(err, errorUnableToGetTenantUsage)
+		return nil, prepareError(err, errorUnableToGetTenantUsage)
 	}
 	minTenant.EnsureDefaults()
 
@@ -1758,7 +1758,7 @@ func getTenantUsageResponse(session *models.Principal, params operator_api.GetTe
 		svcURL,
 	)
 	if err != nil {
-		return nil, restapi.PrepareError(err, errorUnableToGetTenantUsage)
+		return nil, prepareError(err, errorUnableToGetTenantUsage)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -1766,7 +1766,7 @@ func getTenantUsageResponse(session *models.Principal, params operator_api.GetTe
 	// serialize output
 	adminInfo, err := restapi.GetAdminInfo(ctx, adminClient)
 	if err != nil {
-		return nil, restapi.PrepareError(err, errorUnableToGetTenantUsage)
+		return nil, prepareError(err, errorUnableToGetTenantUsage)
 	}
 	info := &models.TenantUsage{Used: adminInfo.Usage, DiskUsed: adminInfo.DisksUsage}
 	return info, nil
@@ -1776,14 +1776,14 @@ func getTenantPodsResponse(session *models.Principal, params operator_api.GetTen
 	ctx := context.Background()
 	clientset, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	listOpts := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", miniov2.TenantLabel, params.Tenant),
 	}
 	pods, err := clientset.CoreV1().Pods(params.Namespace).List(ctx, listOpts)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	retval := []*models.TenantPod{}
 	for _, pod := range pods.Items {
@@ -1806,13 +1806,13 @@ func getPodLogsResponse(session *models.Principal, params operator_api.GetPodLog
 	ctx := context.Background()
 	clientset, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return "", restapi.PrepareError(err)
+		return "", prepareError(err)
 	}
 	listOpts := &corev1.PodLogOptions{}
 	logs := clientset.CoreV1().Pods(params.Namespace).GetLogs(params.PodName, listOpts)
 	buff, err := logs.DoRaw(ctx)
 	if err != nil {
-		return "", restapi.PrepareError(err)
+		return "", prepareError(err)
 	}
 	return string(buff), nil
 }
@@ -1821,15 +1821,15 @@ func getPodEventsResponse(session *models.Principal, params operator_api.GetPodE
 	ctx := context.Background()
 	clientset, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	pod, err := clientset.CoreV1().Pods(params.Namespace).Get(ctx, params.PodName, metav1.GetOptions{})
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	events, err := clientset.CoreV1().Events(params.Namespace).List(ctx, metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.uid=%s", pod.UID)})
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	retval := models.EventListWrapper{}
 	for i := 0; i < len(events.Items); i++ {
@@ -2264,7 +2264,7 @@ func getTenantUpdatePoolResponse(session *models.Principal, params operator_api.
 	ctx := context.Background()
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	opClient := &operatorClient{
@@ -2274,7 +2274,7 @@ func getTenantUpdatePoolResponse(session *models.Principal, params operator_api.
 	t, err := updateTenantPools(ctx, opClient, params.Namespace, params.Tenant, params.Body.Pools)
 	if err != nil {
 		restapi.LogError("error updating Tenant's pools: %v", err)
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// parse it to models.Tenant
@@ -2329,12 +2329,12 @@ func getTenantYAML(session *models.Principal, params operator_api.GetTenantYAMLP
 
 	opClient, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	tenant, err := opClient.MinioV2().Tenants(params.Namespace).Get(params.HTTPRequest.Context(), params.Tenant, metav1.GetOptions{})
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// remove managed fields
 	tenant.ManagedFields = []metav1.ManagedFieldsEntry{}
@@ -2352,7 +2352,7 @@ func getTenantYAML(session *models.Principal, params operator_api.GetTenantYAMLP
 
 	err = serializer.Encode(tenant, buf)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	yb := buf.String()
@@ -2378,12 +2378,12 @@ func getUpdateTenantYAML(session *models.Principal, params operator_api.PutTenan
 	// get Kubernetes Client
 	opClient, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 
 	tenant, err := opClient.MinioV2().Tenants(params.Namespace).Get(params.HTTPRequest.Context(), params.Tenant, metav1.GetOptions{})
 	if err != nil {
-		return restapi.PrepareError(err)
+		return prepareError(err)
 	}
 	upTenant := tenant.DeepCopy()
 	// only update safe fields: spec, metadata.finalizers, metadata.labels and metadata.annotations

--- a/operatorapi/operator_tenants_helper.go
+++ b/operatorapi/operator_tenants_helper.go
@@ -25,8 +25,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/minio/console/restapi"
-
 	"github.com/minio/console/operatorapi/operations/operator_api"
 
 	"errors"
@@ -90,20 +88,20 @@ func getTenantUpdateCertificatesResponse(session *models.Principal, params opera
 	// get Kubernetes Client
 	clientSet, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err, errorUnableToUpdateTenantCertificates)
+		return prepareError(err, errorUnableToUpdateTenantCertificates)
 	}
 	k8sClient := k8sClient{
 		client: clientSet,
 	}
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err, errorUnableToUpdateTenantCertificates)
+		return prepareError(err, errorUnableToUpdateTenantCertificates)
 	}
 	opClient := operatorClient{
 		client: opClientClientSet,
 	}
 	if err := tenantUpdateCertificates(ctx, &opClient, &k8sClient, params.Namespace, params); err != nil {
-		return restapi.PrepareError(err, errorUnableToUpdateTenantCertificates)
+		return prepareError(err, errorUnableToUpdateTenantCertificates)
 	}
 	return nil
 }
@@ -168,20 +166,20 @@ func getTenantUpdateEncryptionResponse(session *models.Principal, params operato
 	// get Kubernetes Client
 	clientSet, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err, errorUpdatingEncryptionConfig)
+		return prepareError(err, errorUpdatingEncryptionConfig)
 	}
 	k8sClient := k8sClient{
 		client: clientSet,
 	}
 	opClientClientSet, err := cluster.OperatorClient(session.STSSessionToken)
 	if err != nil {
-		return restapi.PrepareError(err, errorUpdatingEncryptionConfig)
+		return prepareError(err, errorUpdatingEncryptionConfig)
 	}
 	opClient := operatorClient{
 		client: opClientClientSet,
 	}
 	if err := tenantUpdateEncryption(ctx, &opClient, &k8sClient, params.Namespace, params); err != nil {
-		return restapi.PrepareError(err, errorUpdatingEncryptionConfig)
+		return prepareError(err, errorUpdatingEncryptionConfig)
 	}
 	return nil
 }

--- a/operatorapi/operator_volumes.go
+++ b/operatorapi/operator_volumes.go
@@ -26,7 +26,6 @@ import (
 	"github.com/minio/console/models"
 	"github.com/minio/console/operatorapi/operations"
 	"github.com/minio/console/operatorapi/operations/operator_api"
-	"github.com/minio/console/restapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,7 +46,7 @@ func getPVCsResponse(session *models.Principal) (*models.ListPVCsResponse, *mode
 	clientset, err := cluster.K8sClient(session.STSSessionToken)
 
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// Filter Tenant PVCs. They keep their v1 tenant annotation
@@ -59,7 +58,7 @@ func getPVCsResponse(session *models.Principal) (*models.ListPVCsResponse, *mode
 	listAllPvcs, err2 := clientset.CoreV1().PersistentVolumeClaims("").List(ctx, listOpts)
 
 	if err2 != nil {
-		return nil, restapi.PrepareError(err2)
+		return nil, prepareError(err2)
 	}
 
 	var ListPVCs []*models.PvcsListResponse

--- a/operatorapi/resource_quota.go
+++ b/operatorapi/resource_quota.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/minio/console/restapi"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/minio/console/cluster"
@@ -99,14 +97,14 @@ func getResourceQuotaResponse(session *models.Principal, params operator_api.Get
 	ctx := context.Background()
 	client, err := cluster.K8sClient(session.STSSessionToken)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	k8sClient := &k8sClient{
 		client: client,
 	}
 	resourceQuota, err := getResourceQuota(ctx, k8sClient, params.Namespace, params.ResourceQuotaName)
 	if err != nil {
-		return nil, restapi.PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return resourceQuota, nil
 }

--- a/restapi/admin_arns.go
+++ b/restapi/admin_arns.go
@@ -54,7 +54,7 @@ func getArns(ctx context.Context, client MinioAdmin) (*models.ArnsResponse, erro
 func getArnsResponse(session *models.Principal) (*models.ArnsResponse, *models.Error) {
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -65,7 +65,7 @@ func getArnsResponse(session *models.Principal) (*models.ArnsResponse, *models.E
 	// serialize output
 	arnsList, err := getArns(ctx, adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return arnsList, nil
 }

--- a/restapi/admin_config.go
+++ b/restapi/admin_config.go
@@ -79,7 +79,7 @@ func listConfig(client MinioAdmin) ([]*models.ConfigDescription, error) {
 func getListConfigResponse(session *models.Principal) (*models.ListConfigResponse, *models.Error) {
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
@@ -87,7 +87,7 @@ func getListConfigResponse(session *models.Principal) (*models.ListConfigRespons
 
 	configDescs, err := listConfig(adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	listGroupsResponse := &models.ListConfigResponse{
 		Configurations: configDescs,
@@ -127,7 +127,7 @@ func getConfigResponse(session *models.Principal, params admin_api.ConfigInfoPar
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
@@ -135,7 +135,7 @@ func getConfigResponse(session *models.Principal, params admin_api.ConfigInfoPar
 
 	configkv, err := getConfig(ctx, adminClient, params.Name)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	configurationObj := &models.Configuration{
 		Name:      params.Name,
@@ -179,7 +179,7 @@ func buildConfig(configName *string, kvs []*models.ConfigurationKV) *string {
 func setConfigResponse(session *models.Principal, name string, configRequest *models.SetConfigRequest) (*models.SetConfigResponse, *models.Error) {
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
@@ -190,7 +190,7 @@ func setConfigResponse(session *models.Principal, name string, configRequest *mo
 
 	needsRestart, err := setConfigWithARNAccountID(ctx, adminClient, &configName, configRequest.KeyValues, configRequest.ArnResourceID)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return &models.SetConfigResponse{Restart: needsRestart}, nil
 }

--- a/restapi/admin_groups.go
+++ b/restapi/admin_groups.go
@@ -75,7 +75,7 @@ func getListGroupsResponse(session *models.Principal) (*models.ListGroupsRespons
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
@@ -83,7 +83,7 @@ func getListGroupsResponse(session *models.Principal) (*models.ListGroupsRespons
 
 	groups, err := adminClient.listGroups(ctx)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// serialize output
@@ -109,7 +109,7 @@ func getGroupInfoResponse(session *models.Principal, params admin_api.GroupInfoP
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
@@ -117,7 +117,7 @@ func getGroupInfoResponse(session *models.Principal, params admin_api.GroupInfoP
 
 	groupDesc, err := groupInfo(ctx, adminClient, params.Name)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	groupResponse := &models.Group{
@@ -148,19 +148,19 @@ func getAddGroupResponse(session *models.Principal, params *models.AddGroupReque
 	ctx := context.Background()
 	// AddGroup request needed to proceed
 	if params == nil {
-		return PrepareError(errGroupBodyNotInRequest)
+		return prepareError(errGroupBodyNotInRequest)
 	}
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 
 	if err := addGroup(ctx, adminClient, *params.Group, params.Members); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -184,18 +184,18 @@ func getRemoveGroupResponse(session *models.Principal, params admin_api.RemoveGr
 	ctx := context.Background()
 
 	if params.Name == "" {
-		return PrepareError(errGroupNameNotInRequest)
+		return prepareError(errGroupNameNotInRequest)
 	}
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// createad a MinIO Admin Client interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 
 	if err := removeGroup(ctx, adminClient, params.Name); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -257,10 +257,10 @@ func setGroupStatus(ctx context.Context, client MinioAdmin, group, status string
 func getUpdateGroupResponse(session *models.Principal, params admin_api.UpdateGroupParams) (*models.Group, *models.Error) {
 	ctx := context.Background()
 	if params.Name == "" {
-		return nil, PrepareError(errGroupNameNotInRequest)
+		return nil, prepareError(errGroupNameNotInRequest)
 	}
 	if params.Body == nil {
-		return nil, PrepareError(errGroupBodyNotInRequest)
+		return nil, prepareError(errGroupBodyNotInRequest)
 
 	}
 	expectedGroupUpdate := params.Body
@@ -268,7 +268,7 @@ func getUpdateGroupResponse(session *models.Principal, params admin_api.UpdateGr
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
@@ -276,7 +276,7 @@ func getUpdateGroupResponse(session *models.Principal, params admin_api.UpdateGr
 
 	groupUpdated, err := groupUpdate(ctx, adminClient, groupName, expectedGroupUpdate)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	groupResponse := &models.Group{
 		Name:    groupUpdated.Name,

--- a/restapi/admin_info.go
+++ b/restapi/admin_info.go
@@ -792,7 +792,7 @@ func getAdminInfoResponse(session *models.Principal) (*models.AdminInfoResponse,
 	prometheusURL := getPrometheusURL()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	sessionResp, err2 := getUsageWidgetsForDeployment(prometheusURL, mAdmin)
@@ -814,7 +814,7 @@ func getUsageWidgetsForDeployment(prometheusURL string, mAdmin *madmin.AdminClie
 		// serialize output
 		usage, err := GetAdminInfo(ctx, adminClient)
 		if err != nil {
-			return nil, PrepareError(err)
+			return nil, prepareError(err)
 		}
 		sessionResp := &models.AdminInfoResponse{
 			Buckets: usage.Buckets,

--- a/restapi/admin_notification_endpoints.go
+++ b/restapi/admin_notification_endpoints.go
@@ -79,7 +79,7 @@ func getNotificationEndpoints(ctx context.Context, client MinioAdmin) (*models.N
 func getNotificationEndpointsResponse(session *models.Principal) (*models.NotifEndpointResponse, *models.Error) {
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -90,7 +90,7 @@ func getNotificationEndpointsResponse(session *models.Principal) (*models.NotifE
 	// serialize output
 	notfEndpointResp, err := getNotificationEndpoints(ctx, adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return notfEndpointResp, nil
 }
@@ -150,7 +150,7 @@ func addNotificationEndpoint(ctx context.Context, client MinioAdmin, params *adm
 func getAddNotificationEndpointResponse(session *models.Principal, params *admin_api.AddNotificationEndpointParams) (*models.SetNotificationEndpointResponse, *models.Error) {
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -161,7 +161,7 @@ func getAddNotificationEndpointResponse(session *models.Principal, params *admin
 	// serialize output
 	notfEndpointResp, err := addNotificationEndpoint(ctx, adminClient, params)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return notfEndpointResp, nil
 }

--- a/restapi/admin_policies.go
+++ b/restapi/admin_policies.go
@@ -102,7 +102,7 @@ func getListPoliciesWithBucketResponse(session *models.Principal, bucket string)
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
@@ -110,7 +110,7 @@ func getListPoliciesWithBucketResponse(session *models.Principal, bucket string)
 
 	policies, err := listPoliciesWithBucket(ctx, bucket, adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// serialize output
 	listPoliciesResponse := &models.ListPoliciesResponse{
@@ -180,7 +180,7 @@ func getListPoliciesResponse(session *models.Principal) (*models.ListPoliciesRes
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
@@ -188,7 +188,7 @@ func getListPoliciesResponse(session *models.Principal) (*models.ListPoliciesRes
 
 	policies, err := listPolicies(ctx, adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// serialize output
 	listPoliciesResponse := &models.ListPoliciesResponse{
@@ -203,7 +203,7 @@ func getListUsersForPolicyResponse(session *models.Principal, policy string) ([]
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -211,7 +211,7 @@ func getListUsersForPolicyResponse(session *models.Principal, policy string) ([]
 
 	users, err := listUsers(ctx, adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	var filteredUsers []string
@@ -231,7 +231,7 @@ func getListGroupsForPolicyResponse(session *models.Principal, policy string) ([
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -239,7 +239,7 @@ func getListGroupsForPolicyResponse(session *models.Principal, policy string) ([
 
 	groups, err := adminClient.listGroups(ctx)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	var filteredGroups []string
@@ -269,18 +269,18 @@ func removePolicy(ctx context.Context, client MinioAdmin, name string) error {
 func getRemovePolicyResponse(session *models.Principal, params admin_api.RemovePolicyParams) *models.Error {
 	ctx := context.Background()
 	if params.Name == "" {
-		return PrepareError(errPolicyNameNotInRequest)
+		return prepareError(errPolicyNameNotInRequest)
 	}
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 
 	if err := removePolicy(ctx, adminClient, params.Name); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -308,19 +308,19 @@ func addPolicy(ctx context.Context, client MinioAdmin, name, policy string) (*mo
 func getAddPolicyResponse(session *models.Principal, params *models.AddPolicyRequest) (*models.Policy, *models.Error) {
 	ctx := context.Background()
 	if params == nil {
-		return nil, PrepareError(errPolicyBodyNotInRequest)
+		return nil, prepareError(errPolicyBodyNotInRequest)
 	}
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 	policy, err := addPolicy(ctx, adminClient, *params.Name, *params.Policy)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return policy, nil
 }
@@ -346,14 +346,14 @@ func getPolicyInfoResponse(session *models.Principal, params admin_api.PolicyInf
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 	policy, err := policyInfo(ctx, adminClient, params.Name)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return policy, nil
 }
@@ -371,18 +371,18 @@ func setPolicy(ctx context.Context, client MinioAdmin, name, entityName string, 
 func getSetPolicyResponse(session *models.Principal, name string, params *models.SetPolicyRequest) *models.Error {
 	ctx := context.Background()
 	if name == "" {
-		return PrepareError(errPolicyNameNotInRequest)
+		return prepareError(errPolicyNameNotInRequest)
 	}
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 
 	if err := setPolicy(ctx, adminClient, name, *params.EntityName, *params.EntityType); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -391,14 +391,14 @@ func getSetPolicyMultipleResponse(session *models.Principal, name string, params
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 
 	if err := setPolicyMultipleEntities(ctx, adminClient, name, params.Users, params.Groups); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }

--- a/restapi/admin_profiling.go
+++ b/restapi/admin_profiling.go
@@ -86,18 +86,18 @@ func startProfiling(ctx context.Context, client MinioAdmin, profilerType models.
 func getProfilingStartResponse(session *models.Principal, params *models.ProfilingStartRequest) (*models.StartProfilingList, *models.Error) {
 	ctx := context.Background()
 	if params == nil {
-		return nil, PrepareError(errPolicyBodyNotInRequest)
+		return nil, prepareError(errPolicyBodyNotInRequest)
 	}
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 	profilingItems, err := startProfiling(ctx, adminClient, *params.Type)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	profilingList := &models.StartProfilingList{
 		StartResults: profilingItems,
@@ -121,14 +121,14 @@ func getProfilingStopResponse(session *models.Principal) (io.ReadCloser, *models
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 	profilingData, err := stopProfiling(ctx, adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return profilingData, nil
 }

--- a/restapi/admin_remote_buckets.go
+++ b/restapi/admin_remote_buckets.go
@@ -410,14 +410,14 @@ func setMultiBucketReplicationResponse(session *models.Principal, params user_ap
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
 		LogError("error creating Madmin Client:", err)
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	adminClient := AdminClient{Client: mAdmin}
 
 	mClient, err := newMinioClient(session)
 	if err != nil {
 		LogError("error creating MinIO Client:", err)
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -427,7 +427,7 @@ func setMultiBucketReplicationResponse(session *models.Principal, params user_ap
 
 	if replicationResults == nil {
 		err = errors.New("error setting buckets replication")
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	resParsed := []*models.MultiBucketResponseItem{}
@@ -454,14 +454,14 @@ func listExternalBucketsResponse(params user_api.ListExternalBucketsParams) (*mo
 	defer cancel()
 	remoteAdmin, err := newAdminFromCreds(*params.Body.AccessKey, *params.Body.SecretKey, *params.Body.TargetURL, *params.Body.UseTLS)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	remoteClient := AdminClient{Client: remoteAdmin}
 	buckets, err := getAccountInfo(ctx, remoteClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// serialize output
@@ -514,7 +514,7 @@ func deleteReplicationRuleResponse(session *models.Principal, params user_api.De
 	err := deleteReplicationRule(ctx, session, params.BucketName, params.RuleID)
 
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }

--- a/restapi/admin_service.go
+++ b/restapi/admin_service.go
@@ -63,14 +63,14 @@ func getRestartServiceResponse(session *models.Principal) *models.Error {
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a MinIO Admin Client interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 
 	if err := serviceRestart(ctx, adminClient); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }

--- a/restapi/admin_subscription.go
+++ b/restapi/admin_subscription.go
@@ -72,7 +72,7 @@ func getSubscriptionInfoResponse() (*models.License, *models.Error) {
 	// validate license key and obtain license info
 	licenseInfo, _, err := subscriptionValidate(client, licenseKey, "", "")
 	if err != nil {
-		return nil, PrepareError(errLicenseNotFound, nil, err)
+		return nil, prepareError(errLicenseNotFound, nil, err)
 	}
 	return licenseInfo, nil
 }

--- a/restapi/admin_tiers.go
+++ b/restapi/admin_tiers.go
@@ -133,7 +133,7 @@ func getTiers(ctx context.Context, client MinioAdmin) (*models.TierListResponse,
 func getTiersResponse(session *models.Principal) (*models.TierListResponse, *models.Error) {
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -144,7 +144,7 @@ func getTiersResponse(session *models.Principal) (*models.TierListResponse, *mod
 	// serialize output
 	tiersResp, err := getTiers(ctx, adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return tiersResp, nil
 }
@@ -223,7 +223,7 @@ func addTier(ctx context.Context, client MinioAdmin, params *admin_api.AddTierPa
 func getAddTierResponse(session *models.Principal, params *admin_api.AddTierParams) *models.Error {
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -234,7 +234,7 @@ func getAddTierResponse(session *models.Principal, params *admin_api.AddTierPara
 	// serialize output
 	errTier := addTier(ctx, adminClient, params)
 	if errTier != nil {
-		return PrepareError(errTier)
+		return prepareError(errTier)
 	}
 	return nil
 }
@@ -306,7 +306,7 @@ func getTier(ctx context.Context, client MinioAdmin, params *admin_api.GetTierPa
 func getGetTierResponse(session *models.Principal, params *admin_api.GetTierParams) (*models.Tier, *models.Error) {
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -317,7 +317,7 @@ func getGetTierResponse(session *models.Principal, params *admin_api.GetTierPara
 	// serialize output
 	addTierResp, err := getTier(ctx, adminClient, params)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return addTierResp, nil
 }
@@ -342,7 +342,7 @@ func editTierCredentials(ctx context.Context, client MinioAdmin, params *admin_a
 func getEditTierCredentialsResponse(session *models.Principal, params *admin_api.EditTierCredentialsParams) *models.Error {
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -353,7 +353,7 @@ func getEditTierCredentialsResponse(session *models.Principal, params *admin_api
 	// serialize output
 	err = editTierCredentials(ctx, adminClient, params)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }

--- a/restapi/admin_users.go
+++ b/restapi/admin_users.go
@@ -145,7 +145,7 @@ func getListUsersResponse(session *models.Principal) (*models.ListUsersResponse,
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -153,7 +153,7 @@ func getListUsersResponse(session *models.Principal) (*models.ListUsersResponse,
 
 	users, err := listUsers(ctx, adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// serialize output
 	listUsersResponse := &models.ListUsersResponse{
@@ -191,7 +191,7 @@ func getUserAddResponse(session *models.Principal, params admin_api.AddUserParam
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -199,7 +199,7 @@ func getUserAddResponse(session *models.Principal, params admin_api.AddUserParam
 
 	user, err := addUser(ctx, adminClient, params.Body.AccessKey, params.Body.SecretKey, params.Body.Groups)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return user, nil
 }
@@ -214,11 +214,11 @@ func getRemoveUserResponse(session *models.Principal, params admin_api.RemoveUse
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 
 	if session.AccountAccessKey == params.Name {
-		return PrepareError(errAvoidSelfAccountDelete)
+		return prepareError(errAvoidSelfAccountDelete)
 	}
 
 	// create a minioClient interface implementation
@@ -226,7 +226,7 @@ func getRemoveUserResponse(session *models.Principal, params admin_api.RemoveUse
 	adminClient := AdminClient{Client: mAdmin}
 
 	if err := removeUser(ctx, adminClient, params.Name); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 
 	return nil
@@ -247,7 +247,7 @@ func getUserInfoResponse(session *models.Principal, params admin_api.GetUserInfo
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// create a minioClient interface implementation
@@ -256,7 +256,7 @@ func getUserInfoResponse(session *models.Principal, params admin_api.GetUserInfo
 
 	user, err := getUserInfo(ctx, adminClient, params.Name)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	userInformation := &models.User{
@@ -362,7 +362,7 @@ func getUpdateUserGroupsResponse(session *models.Principal, params admin_api.Upd
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// create a minioClient interface implementation
@@ -372,7 +372,7 @@ func getUpdateUserGroupsResponse(session *models.Principal, params admin_api.Upd
 	user, err := updateUserGroups(ctx, adminClient, params.Name, params.Body.Groups)
 
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	return user, nil
@@ -398,7 +398,7 @@ func getUpdateUserResponse(session *models.Principal, params admin_api.UpdateUse
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// create a minioClient interface implementation
@@ -410,13 +410,13 @@ func getUpdateUserResponse(session *models.Principal, params admin_api.UpdateUse
 	groups := params.Body.Groups
 
 	if err := setUserStatus(ctx, adminClient, name, status); err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	userElem, errUG := updateUserGroups(ctx, adminClient, name, groups)
 
 	if errUG != nil {
-		return nil, PrepareError(errUG)
+		return nil, prepareError(errUG)
 	}
 	return userElem, nil
 }
@@ -469,7 +469,7 @@ func getAddUsersListToGroupsResponse(session *models.Principal, params admin_api
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 
 	// create a minioClient interface implementation
@@ -480,7 +480,7 @@ func getAddUsersListToGroupsResponse(session *models.Principal, params admin_api
 	groupsList := params.Body.Groups
 
 	if err := addUsersListToGroups(ctx, adminClient, usersList, groupsList); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 
 	return nil
@@ -490,7 +490,7 @@ func getListUsersWithAccessToBucketResponse(session *models.Principal, bucket st
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -519,7 +519,7 @@ func policyAllowsAndMatchesBucket(policy *iampolicy.Policy, bucket string) int {
 func listUsersWithAccessToBucket(ctx context.Context, adminClient MinioAdmin, bucket string) ([]string, *models.Error) {
 	users, err := adminClient.listUsers(ctx)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	var retval []string
 	akHasAccess := make(map[string]struct{})
@@ -597,7 +597,7 @@ func getChangeUserPasswordResponse(session *models.Principal, params admin_api.C
 	ctx := context.Background()
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -609,7 +609,7 @@ func getChangeUserPasswordResponse(session *models.Principal, params admin_api.C
 
 	// changes password of user to newSecretKey
 	if err := changeUserPassword(ctx, adminClient, user, newSecretKey); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }

--- a/restapi/error.go
+++ b/restapi/error.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/minio/console/models"
 	"github.com/minio/madmin-go"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
@@ -38,26 +37,14 @@ var (
 	errAccessDenied                 = errors.New("access denied")
 )
 
-// PrepareError receives an error object and parse it against k8sErrors, returns the right error code paired with a generic error message
-func PrepareError(err ...error) *models.Error {
+// prepareError receives an error object and parse it against k8sErrors, returns the right error code paired with a generic error message
+func prepareError(err ...error) *models.Error {
 	errorCode := int32(500)
 	errorMessage := ErrorGeneric.Error()
 	if len(err) > 0 {
 		frame := getFrame(2)
 		fileParts := strings.Split(frame.File, "/")
 		LogError("original error -> (%s:%d: %v)", fileParts[len(fileParts)-1], frame.Line, err[0])
-		if k8sErrors.IsUnauthorized(err[0]) {
-			errorCode = 401
-			errorMessage = errorGenericUnauthorized.Error()
-		}
-		if k8sErrors.IsForbidden(err[0]) {
-			errorCode = 403
-			errorMessage = errorGenericForbidden.Error()
-		}
-		if k8sErrors.IsNotFound(err[0]) {
-			errorCode = 404
-			errorMessage = ErrorGenericNotFound.Error()
-		}
 		if err[0] == ErrorGenericNotFound {
 			errorCode = 404
 			errorMessage = ErrorGenericNotFound.Error()

--- a/restapi/error.go
+++ b/restapi/error.go
@@ -15,8 +15,6 @@ var (
 	ErrorGeneric               = errors.New("an error occurred, please try again")
 	errInvalidCredentials      = errors.New("invalid Login")
 	errorGenericInvalidSession = errors.New("invalid session")
-	errorGenericUnauthorized   = errors.New("unauthorized")
-	errorGenericForbidden      = errors.New("forbidden")
 	// ErrorGenericNotFound Generic error for not found
 	ErrorGenericNotFound = errors.New("not found")
 	// Explicit error messages

--- a/restapi/user_account.go
+++ b/restapi/user_account.go
@@ -73,7 +73,7 @@ func getChangePasswordResponse(session *models.Principal, params user_api.Accoun
 		STSSecretAccessKey: *params.Body.CurrentSecretKey,
 	})
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// parentAccountClient will contain access and secret key credentials for the user
 	userClient := AdminClient{Client: parentAccountClient}
@@ -82,18 +82,18 @@ func getChangePasswordResponse(session *models.Principal, params user_api.Accoun
 
 	// currentSecretKey will compare currentSecretKey against the stored secret key inside the encrypted session
 	if err := changePassword(ctx, userClient, session, newSecretKey); err != nil {
-		return nil, PrepareError(errChangePassword, nil, err)
+		return nil, prepareError(errChangePassword, nil, err)
 	}
 	// user credentials are updated at this point, we need to generate a new admin client and authenticate using
 	// the new credentials
 	credentials, err := getConsoleCredentials(ctx, accessKey, newSecretKey)
 	if err != nil {
-		return nil, PrepareError(errInvalidCredentials, nil, err)
+		return nil, prepareError(errInvalidCredentials, nil, err)
 	}
 	// authenticate user and generate new session token
 	sessionID, err := login(credentials)
 	if err != nil {
-		return nil, PrepareError(errInvalidCredentials, nil, err)
+		return nil, prepareError(errInvalidCredentials, nil, err)
 	}
 	// serialize output
 	loginResponse := &models.LoginResponse{
@@ -108,7 +108,7 @@ func getUserHasPermissionsResponse(session *models.Principal, params user_api.Ha
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -116,7 +116,7 @@ func getUserHasPermissionsResponse(session *models.Principal, params user_api.Ha
 
 	userPolicy, err := getAccountPolicy(ctx, adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	var perms []*models.PermissionAction

--- a/restapi/user_bucket_quota.go
+++ b/restapi/user_bucket_quota.go
@@ -54,7 +54,7 @@ func registerBucketQuotaHandlers(api *operations.ConsoleAPI) {
 func setBucketQuotaResponse(session *models.Principal, params user_api.SetBucketQuotaParams) *models.Error {
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -102,7 +102,7 @@ func getBucketQuotaResponse(session *models.Principal, params user_api.GetBucket
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// create a minioClient interface implementation

--- a/restapi/user_buckets.go
+++ b/restapi/user_buckets.go
@@ -182,7 +182,7 @@ func doSetVersioning(client MCClient, state VersionState) error {
 func setBucketVersioningResponse(session *models.Principal, bucketName string, params *user_api.SetBucketVersioningParams) *models.Error {
 	s3Client, err := newS3BucketClient(session, bucketName, "")
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a mc S3Client interface implementation
 	// defining the client to be used
@@ -195,7 +195,7 @@ func setBucketVersioningResponse(session *models.Principal, bucketName string, p
 	}
 
 	if err := doSetVersioning(amcClient, versioningState); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -324,14 +324,14 @@ func getListBucketsResponse(session *models.Principal) (*models.ListBucketsRespo
 
 	mAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	adminClient := AdminClient{Client: mAdmin}
 	buckets, err := getAccountInfo(ctx, adminClient)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// serialize output
@@ -354,11 +354,11 @@ func getMakeBucketResponse(session *models.Principal, br *models.MakeBucketReque
 	defer cancel()
 	// bucket request needed to proceed
 	if br == nil {
-		return PrepareError(errBucketBodyNotInRequest)
+		return prepareError(errBucketBodyNotInRequest)
 	}
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -370,7 +370,7 @@ func getMakeBucketResponse(session *models.Principal, br *models.MakeBucketReque
 	}
 
 	if err := makeBucket(ctx, minioClient, *br.Name, br.Locking); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 
 	// make sure to delete bucket if an error occurs after bucket was created
@@ -387,14 +387,14 @@ func getMakeBucketResponse(session *models.Principal, br *models.MakeBucketReque
 	if br.Versioning || br.Retention != nil {
 		s3Client, err := newS3BucketClient(session, *br.Name, "")
 		if err != nil {
-			return PrepareError(err)
+			return prepareError(err)
 		}
 		// create a mc S3Client interface implementation
 		// defining the client to be used
 		amcClient := mcClient{client: s3Client}
 
 		if err = doSetVersioning(amcClient, VersionEnable); err != nil {
-			return PrepareError(err)
+			return prepareError(err)
 		}
 	}
 
@@ -402,7 +402,7 @@ func getMakeBucketResponse(session *models.Principal, br *models.MakeBucketReque
 	if br.Quota != nil && br.Quota.Enabled != nil && *br.Quota.Enabled {
 		mAdmin, err := NewMinioAdminClient(session)
 		if err != nil {
-			return PrepareError(err)
+			return prepareError(err)
 		}
 		// create a minioClient interface implementation
 		// defining the client to be used
@@ -417,7 +417,7 @@ func getMakeBucketResponse(session *models.Principal, br *models.MakeBucketReque
 	if br.Retention != nil {
 		err = setBucketRetentionConfig(ctx, minioClient, *br.Name, *br.Retention.Mode, *br.Retention.Unit, br.Retention.Validity)
 		if err != nil {
-			return PrepareError(err)
+			return prepareError(err)
 		}
 	}
 	return nil
@@ -459,7 +459,7 @@ func getBucketSetPolicyResponse(session *models.Principal, bucketName string, re
 
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -467,12 +467,12 @@ func getBucketSetPolicyResponse(session *models.Principal, bucketName string, re
 
 	// set bucket access policy
 	if err := setBucketAccessPolicy(ctx, minioClient, bucketName, *req.Access); err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// get updated bucket details and return it
 	bucket, err := getBucketInfo(minioClient, bucketName)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return bucket, nil
 }
@@ -485,19 +485,19 @@ func removeBucket(client MinioClient, bucketName string) error {
 // getDeleteBucketResponse performs removeBucket() to delete a bucket
 func getDeleteBucketResponse(session *models.Principal, params user_api.DeleteBucketParams) *models.Error {
 	if params.Name == "" {
-		return PrepareError(errBucketNameNotInRequest)
+		return prepareError(errBucketNameNotInRequest)
 	}
 	bucketName := params.Name
 
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	if err := removeBucket(minioClient, bucketName); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -535,7 +535,7 @@ func getBucketInfo(client MinioClient, bucketName string) (*models.Bucket, error
 func getBucketInfoResponse(session *models.Principal, params user_api.BucketInfoParams) (*models.Bucket, *models.Error) {
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -543,7 +543,7 @@ func getBucketInfoResponse(session *models.Principal, params user_api.BucketInfo
 
 	bucket, err := getBucketInfo(minioClient, params.Name)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return bucket, nil
 
@@ -593,13 +593,13 @@ func enableBucketEncryptionResponse(session *models.Principal, params user_api.E
 	defer cancel()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	if err := enableBucketEncryption(ctx, minioClient, params.BucketName, *params.Body.EncType, params.Body.KmsKeyID); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -615,13 +615,13 @@ func disableBucketEncryptionResponse(session *models.Principal, params user_api.
 	defer cancel()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	if err := disableBucketEncryption(ctx, minioClient, params.BucketName); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -642,14 +642,14 @@ func getBucketEncryptionInfoResponse(session *models.Principal, params user_api.
 	defer cancel()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	bucketInfo, err := getBucketEncryptionInfo(ctx, minioClient, params.BucketName)
 	if err != nil {
-		return nil, PrepareError(errSSENotConfigured, err)
+		return nil, prepareError(errSSENotConfigured, err)
 	}
 	return bucketInfo, nil
 }
@@ -689,14 +689,14 @@ func getSetBucketRetentionConfigResponse(session *models.Principal, params user_
 	defer cancel()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	err = setBucketRetentionConfig(ctx, minioClient, params.BucketName, *params.Body.Mode, *params.Body.Unit, params.Body.Validity)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -743,7 +743,7 @@ func getBucketRetentionConfigResponse(session *models.Principal, bucketName stri
 	defer cancel()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -751,7 +751,7 @@ func getBucketRetentionConfigResponse(session *models.Principal, bucketName stri
 
 	config, err := getBucketRetentionConfig(ctx, minioClient, bucketName)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return config, nil
 }
@@ -800,7 +800,7 @@ func getBucketRewindResponse(session *models.Principal, params user_api.GetBucke
 	s3Client, err := newS3BucketClient(session, params.BucketName, prefix)
 	if err != nil {
 		LogError("error creating S3Client: %v", err)
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	// create a mc S3Client interface implementation
@@ -810,7 +810,7 @@ func getBucketRewindResponse(session *models.Principal, params user_api.GetBucke
 	parsedDate, errDate := time.Parse(time.RFC3339, params.Date)
 
 	if errDate != nil {
-		return nil, PrepareError(errDate)
+		return nil, prepareError(errDate)
 	}
 
 	var rewindItems []*models.RewindItem

--- a/restapi/user_buckets_events.go
+++ b/restapi/user_buckets_events.go
@@ -127,7 +127,7 @@ func listBucketEvents(client MinioClient, bucketName string) ([]*models.Notifica
 func getListBucketEventsResponse(session *models.Principal, params user_api.ListBucketEventsParams) (*models.ListBucketEventsResponse, *models.Error) {
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -135,7 +135,7 @@ func getListBucketEventsResponse(session *models.Principal, params user_api.List
 
 	bucketEvents, err := listBucketEvents(minioClient, params.BucketName)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// serialize output
 	listBucketsResponse := &models.ListBucketEventsResponse{
@@ -179,14 +179,14 @@ func getCreateBucketEventsResponse(session *models.Principal, bucketName string,
 	ctx := context.Background()
 	s3Client, err := newS3BucketClient(session, bucketName, "")
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a mc S3Client interface implementation
 	// defining the client to be used
 	mcClient := mcClient{client: s3Client}
 	err = createBucketEvent(ctx, mcClient, *eventReq.Configuration.Arn, eventReq.Configuration.Events, eventReq.Configuration.Prefix, eventReq.Configuration.Suffix, eventReq.IgnoreExisting)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -214,14 +214,14 @@ func getDeleteBucketEventsResponse(session *models.Principal, bucketName string,
 	ctx := context.Background()
 	s3Client, err := newS3BucketClient(session, bucketName, "")
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a mc S3Client interface implementation
 	// defining the client to be used
 	mcClient := mcClient{client: s3Client}
 	err = deleteBucketEventNotification(ctx, mcClient, arn, events, prefix, suffix)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }

--- a/restapi/user_buckets_lifecycle.go
+++ b/restapi/user_buckets_lifecycle.go
@@ -98,7 +98,7 @@ func getBucketLifecycleResponse(session *models.Principal, params user_api.GetBu
 	ctx := context.Background()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -106,7 +106,7 @@ func getBucketLifecycleResponse(session *models.Principal, params user_api.GetBu
 
 	bucketEvents, err := getBucketLifecycle(ctx, minioClient, params.BucketName)
 	if err != nil {
-		return nil, PrepareError(errBucketLifeCycleNotConfigured, err)
+		return nil, prepareError(errBucketLifeCycleNotConfigured, err)
 	}
 	return bucketEvents, nil
 }
@@ -233,7 +233,7 @@ func getAddBucketLifecycleResponse(session *models.Principal, params user_api.Ad
 	ctx := context.Background()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -241,7 +241,7 @@ func getAddBucketLifecycleResponse(session *models.Principal, params user_api.Ad
 
 	err = addBucketLifecycle(ctx, minioClient, params)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 
 	return nil

--- a/restapi/user_log_search.go
+++ b/restapi/user_log_search.go
@@ -66,13 +66,13 @@ func getLogSearchResponse(params user_api.LogSearchParams) (*models.LogSearchRes
 func logSearch(endpoint string) (*models.LogSearchResponse, *models.Error) {
 	resp, err := http.Get(endpoint)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	if resp.StatusCode != 200 {
@@ -84,7 +84,7 @@ func logSearch(endpoint string) (*models.LogSearchResponse, *models.Error) {
 
 	var results []logsearchServer.ReqInfoRow
 	if err = json.Unmarshal(body, &results); err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	response := models.LogSearchResponse{

--- a/restapi/user_login.go
+++ b/restapi/user_login.go
@@ -163,11 +163,11 @@ func getLoginResponse(lr *models.LoginRequest) (*models.LoginResponse, *models.E
 	// prepare console credentials
 	consolCreds, err := getConsoleCredentials(ctx, *lr.AccessKey, *lr.SecretKey)
 	if err != nil {
-		return nil, PrepareError(errInvalidCredentials, nil, err)
+		return nil, prepareError(errInvalidCredentials, nil, err)
 	}
 	sessionID, err := login(consolCreds)
 	if err != nil {
-		return nil, PrepareError(errInvalidCredentials, nil, err)
+		return nil, prepareError(errInvalidCredentials, nil, err)
 	}
 	// serialize output
 	loginResponse := &models.LoginResponse{
@@ -188,7 +188,7 @@ func getLoginDetailsResponse() (*models.LoginDetails, *models.Error) {
 		// initialize new oauth2 client
 		oauth2Client, err := oauth2.NewOauth2ProviderClient(ctx, nil, GetConsoleSTSClient())
 		if err != nil {
-			return nil, PrepareError(err)
+			return nil, prepareError(err)
 		}
 		// Validate user against IDP
 		identityProvider := &auth.IdentityProvider{Client: oauth2Client}
@@ -221,18 +221,18 @@ func getLoginOauth2AuthResponse(lr *models.LoginOauth2AuthRequest) (*models.Logi
 		// initialize new oauth2 client
 		oauth2Client, err := oauth2.NewOauth2ProviderClient(ctx, nil, GetConsoleSTSClient())
 		if err != nil {
-			return nil, PrepareError(err)
+			return nil, prepareError(err)
 		}
 		// initialize new identity provider
 		identityProvider := auth.IdentityProvider{Client: oauth2Client}
 		// Validate user against IDP
 		userCredentials, err := verifyUserAgainstIDP(ctx, identityProvider, *lr.Code, *lr.State)
 		if err != nil {
-			return nil, PrepareError(errInvalidCredentials, nil, err)
+			return nil, prepareError(errInvalidCredentials, nil, err)
 		}
 		creds, err := userCredentials.Get()
 		if err != nil {
-			return nil, PrepareError(errInvalidCredentials, nil, err)
+			return nil, prepareError(errInvalidCredentials, nil, err)
 		}
 		// initialize admin client
 		mAdminClient, err := NewMinioAdminClient(&models.Principal{
@@ -241,14 +241,14 @@ func getLoginOauth2AuthResponse(lr *models.LoginOauth2AuthRequest) (*models.Logi
 			STSSessionToken:    creds.SessionToken,
 		})
 		if err != nil {
-			return nil, PrepareError(errInvalidCredentials, nil, err)
+			return nil, prepareError(errInvalidCredentials, nil, err)
 		}
 		userAdminClient := AdminClient{Client: mAdminClient}
 		// Obtain the current policy assigned to this user
 		// necessary for generating the list of allowed endpoints
 		policy, err := getAccountPolicy(ctx, userAdminClient)
 		if err != nil {
-			return nil, PrepareError(ErrorGeneric, nil, err)
+			return nil, prepareError(ErrorGeneric, nil, err)
 		}
 		// by default every user starts with an empty array of available actions
 		// therefore we would have access only to pages that doesn't require any privilege
@@ -265,7 +265,7 @@ func getLoginOauth2AuthResponse(lr *models.LoginOauth2AuthRequest) (*models.Logi
 			Actions:            actions,
 		})
 		if err != nil {
-			return nil, PrepareError(errInvalidCredentials, nil, err)
+			return nil, prepareError(errInvalidCredentials, nil, err)
 		}
 		// serialize output
 		loginResponse := &models.LoginResponse{
@@ -273,19 +273,19 @@ func getLoginOauth2AuthResponse(lr *models.LoginOauth2AuthRequest) (*models.Logi
 		}
 		return loginResponse, nil
 	}
-	return nil, PrepareError(ErrorGeneric)
+	return nil, prepareError(ErrorGeneric)
 }
 
 // getLoginOperatorResponse validate the provided service account token against k8s api
 func getLoginOperatorResponse(lmr *models.LoginOperatorRequest) (*models.LoginResponse, *models.Error) {
 	creds, err := NewConsoleCredentials("", *lmr.Jwt, "")
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	consoleCreds := ConsoleCredentials{ConsoleCredentials: creds, Actions: []string{}}
 	token, err := login(consoleCreds)
 	if err != nil {
-		return nil, PrepareError(errInvalidCredentials, nil, err)
+		return nil, prepareError(errInvalidCredentials, nil, err)
 	}
 	// serialize output
 	loginResponse := &models.LoginResponse{

--- a/restapi/user_objects.go
+++ b/restapi/user_objects.go
@@ -149,11 +149,11 @@ func getListObjectsResponse(session *models.Principal, params user_api.ListObjec
 	}
 	// bucket request needed to proceed
 	if params.BucketName == "" {
-		return nil, PrepareError(errBucketNameNotInRequest)
+		return nil, prepareError(errBucketNameNotInRequest)
 	}
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
@@ -161,7 +161,7 @@ func getListObjectsResponse(session *models.Principal, params user_api.ListObjec
 
 	objs, err := listBucketObjects(params.HTTPRequest.Context(), minioClient, params.BucketName, prefix, recursive, withVersions)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 
 	resp := &models.ListObjectsResponse{
@@ -232,14 +232,14 @@ func getDownloadObjectResponse(session *models.Principal, params user_api.Downlo
 	ctx := context.Background()
 	s3Client, err := newS3BucketClient(session, params.BucketName, params.Prefix)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a mc S3Client interface implementation
 	// defining the client to be used
 	mcClient := mcClient{client: s3Client}
 	object, err := downloadObject(ctx, mcClient, params.VersionID)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return object, nil
 }
@@ -263,7 +263,7 @@ func getDeleteObjectResponse(session *models.Principal, params user_api.DeleteOb
 	ctx := context.Background()
 	s3Client, err := newS3BucketClient(session, params.BucketName, params.Path)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a mc S3Client interface implementation
 	// defining the client to be used
@@ -278,7 +278,7 @@ func getDeleteObjectResponse(session *models.Principal, params user_api.DeleteOb
 	}
 	err = deleteObjects(ctx, mcClient, params.BucketName, params.Path, version, rec)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -386,13 +386,13 @@ func getUploadObjectResponse(session *models.Principal, params user_api.PostBuck
 	ctx := context.Background()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	if err := uploadFiles(ctx, minioClient, params); err != nil {
-		PrepareError(err, ErrorGeneric)
+		prepareError(err, ErrorGeneric)
 	}
 	return nil
 }
@@ -481,7 +481,7 @@ func getShareObjectResponse(session *models.Principal, params user_api.ShareObje
 	ctx := context.Background()
 	s3Client, err := newS3BucketClient(session, params.BucketName, params.Prefix)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a mc S3Client interface implementation
 	// defining the client to be used
@@ -492,7 +492,7 @@ func getShareObjectResponse(session *models.Principal, params user_api.ShareObje
 	}
 	url, err := getShareObjectURL(ctx, mcClient, params.VersionID, expireDuration)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return url, nil
 }
@@ -519,14 +519,14 @@ func getSetObjectLegalHoldResponse(session *models.Principal, params user_api.Pu
 	defer cancel()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	err = setObjectLegalHold(ctx, minioClient, params.BucketName, params.Prefix, params.VersionID, *params.Body.Status)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -546,14 +546,14 @@ func getSetObjectRetentionResponse(session *models.Principal, params user_api.Pu
 	defer cancel()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	err = setObjectRetention(ctx, minioClient, params.BucketName, params.VersionID, params.Prefix, params.Body)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -590,14 +590,14 @@ func deleteObjectRetentionResponse(session *models.Principal, params user_api.De
 	defer cancel()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	err = deleteObjectRetention(ctx, minioClient, params.BucketName, params.Prefix, params.VersionID)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }
@@ -616,14 +616,14 @@ func getPutObjectTagsResponse(session *models.Principal, params user_api.PutObje
 	defer cancel()
 	mClient, err := newMinioClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a minioClient interface implementation
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	err = putObjectTags(ctx, minioClient, params.BucketName, params.Prefix, params.VersionID, params.Body.Tags)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }

--- a/restapi/user_service_accounts.go
+++ b/restapi/user_service_accounts.go
@@ -97,7 +97,7 @@ func getCreateServiceAccountResponse(session *models.Principal, serviceAccount *
 
 	userAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO user Admin Client interface implementation
 	// defining the client to be used
@@ -105,7 +105,7 @@ func getCreateServiceAccountResponse(session *models.Principal, serviceAccount *
 
 	saCreds, err := createServiceAccount(ctx, userAdminClient, serviceAccount.Policy)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return saCreds, nil
 }
@@ -131,7 +131,7 @@ func getUserServiceAccountsResponse(session *models.Principal, user string) (mod
 
 	userAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	// create a MinIO user Admin Client interface implementation
 	// defining the client to be used
@@ -139,7 +139,7 @@ func getUserServiceAccountsResponse(session *models.Principal, user string) (mod
 
 	serviceAccounts, err := getUserServiceAccounts(ctx, userAdminClient, user)
 	if err != nil {
-		return nil, PrepareError(err)
+		return nil, prepareError(err)
 	}
 	return serviceAccounts, nil
 }
@@ -156,14 +156,14 @@ func getDeleteServiceAccountResponse(session *models.Principal, accessKey string
 
 	userAdmin, err := NewMinioAdminClient(session)
 	if err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	// create a MinIO user Admin Client interface implementation
 	// defining the client to be used
 	userAdminClient := AdminClient{Client: userAdmin}
 
 	if err := deleteServiceAccount(ctx, userAdminClient, accessKey); err != nil {
-		return PrepareError(err)
+		return prepareError(err)
 	}
 	return nil
 }

--- a/restapi/user_session.go
+++ b/restapi/user_session.go
@@ -39,7 +39,7 @@ func registerSessionHandlers(api *operations.ConsoleAPI) {
 func getSessionResponse(session *models.Principal) (*models.SessionResponse, *models.Error) {
 	// serialize output
 	if session == nil {
-		return nil, PrepareError(errorGenericInvalidSession)
+		return nil, prepareError(errorGenericInvalidSession)
 	}
 	sessionResp := &models.SessionResponse{
 		Pages:    acl.GetAuthorizedEndpoints(session.Actions),


### PR DESCRIPTION
This makes it so `restapi` code doesn't import any more `k8s` dependencies

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>