### PR TITLE
Pod events bug fix

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/pods/PodDetails.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/pods/PodDetails.tsx
@@ -117,7 +117,7 @@ const PodDetails = ({ classes, match }: IPodDetailsProps) => {
             tenant={tenantName}
             namespace={tenantNamespace}
             podName={podName}
-            propLoading={loading}
+            propLoading={true}
           />
         )}
         {curTab === 1 && (
@@ -125,7 +125,7 @@ const PodDetails = ({ classes, match }: IPodDetailsProps) => {
             tenant={tenantName}
             namespace={tenantNamespace}
             podName={podName}
-            propLoading={loading}
+            propLoading={true}
           />
         )}
       </Grid>


### PR DESCRIPTION
Pod events will not disappear anymore if you return to the pod events tab. Fixing If there are events for a pod, when switching tabs from Events to Logs in PodDetails, the events are lost #205.