### PR TITLE
Add missing Delete Pods roles for console-sa

### DIFF
--- a/k8s/operator-console/base/console-cluster-role.yaml
+++ b/k8s/operator-console/base/console-cluster-role.yaml
@@ -19,7 +19,6 @@ rules:
       - ""
     resources:
       - namespaces
-      - pods
       - services
       - events
       - resourcequotas
@@ -30,6 +29,18 @@ rules:
       - create
       - list
       - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - watch
+      - create
+      - list
+      - patch
+      - delete
+      - deletecollection
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
We are missing the Delete + DeleteCollection actions for Pods on the `console-sa` cluster role, this adds it

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>