### PR TITLE
Eliminate usage of String.prototype.replaceAll to avoid incompatibility with old browsers

### DIFF
--- a/portal-ui/src/common/api/index.ts
+++ b/portal-ui/src/common/api/index.ts
@@ -22,7 +22,7 @@ import { ErrorResponseHandler } from "../types";
 
 export class API {
   invoke(method: string, url: string, data?: object) {
-    const targetURL = `${baseUrl}${url}`.replaceAll("//", "/");
+    const targetURL = `${baseUrl}${url}`.replace(/\/\//g, "/");
     return request(method, targetURL)
       .send(data)
       .then((res) => res.body)


### PR DESCRIPTION
Fix #939

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll), `String.prototype.replaceAll` is only available in Chrome 85+, Firefox 77+, this makes the console incompatible with older versions of Chrome/Firefox (used in some enterprise intranet).

Although supporting old browsers might not be a goal of this project (I didn't find any commitment of browser compatibility in this project), it's trivial to replace `replaceAll` with `replace`.