### PR TITLE
Build frontend for homepage use

### DIFF
--- a/portal-ui/package.json
+++ b/portal-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portal-ui",
   "version": "0.1.0",
-  "homepage": ".",
+  "homepage": "/",
   "private": true,
   "dependencies": {
     "@date-io/moment": "1.x",


### PR DESCRIPTION
Since the minio maintainers are not interested in supporting "running on subpath" (per minio/minio#10162), then the url of the console should similarly be hardcoded. The [recently introduced change][1] uses a parameter that was [not originally recommended by facebook][2], and to be consistent, i am just setting the relative url generation to start from `/`.

Thanks for considering this change.

The motivation is that MinIO console users should be able to use the object browser, navigate into a "folder", and then hit the browser refresh, and return to the same screen rather than have the frontend application crash (it requests relative urls for the css/js assets - which fails because they are coded as relative and not absolute (relative to `/`)). This relates to issue #1023 (and the issue that is mentioned in 1023 as well). I have not actually tested this fix but with a little help i can add tests and build locally, I think.

edit 2: i realize that the original premise here is not quite accurate as the console [was intended][3] to be used on a subpath (per the discussion in #920 but as the console uses frontend routing (using "real urls" aka html5 pushstate rather than fragment/hashing) it seems that relative urls for assets would break either way.

[1]: https://github.com/minio/console/pull/920/files?file-filters%5B%5D=.json#diff-68649ced3bd316bfd7b4a302cc8c057c98d1338cf9d7987df446278158d7bf3dR4
[2]: https://github.com/facebook/create-react-app/issues/1487#issuecomment-277727669
[3]: https://github.com/minio/console/pull/920#issuecomment-891981438