### PR TITLE
Add some missing config keys to settings panel

### DIFF
--- a/portal-ui/src/screens/Console/Configurations/utils.ts
+++ b/portal-ui/src/screens/Console/Configurations/utils.ts
@@ -39,6 +39,18 @@ export const configurationElements: IConfigurationElement[] = [
     configuration_id: "compression",
     configuration_label: "Edit Compression Configuration",
   },
+  {
+    configuration_id: "api",
+    configuration_label: "Edit API Configuration",
+  },
+  {
+    configuration_id: "heal",
+    configuration_label: "Edit Heal Configuration",
+  },
+  {
+    configuration_id: "scanner",
+    configuration_label: "Edit Scanner Configuration",
+  },
   { configuration_id: "etcd", configuration_label: "Edit Etcd Configuration" },
   {
     configuration_id: "identity_openid",
@@ -166,6 +178,95 @@ export const fieldsConfigurations: any = {
       type: "csv",
       placeholder: "Enter a Mime Type",
       withBorder: true,
+    },
+  ],
+  api: [
+    {
+      name: "requests_max",
+      required: false,
+      label: "Requests Max",
+      tooltip: "Maximum number of concurrent requests, e.g. '1600'",
+      type: "number",
+      placeholder: "Enter Requests Max",
+    },
+    {
+      name: "cors_allow_origin",
+      required: false,
+      label: "Cors Allow Origin",
+      tooltip: "list of origins allowed for CORS requests",
+      type: "csv",
+      placeholder: "Enter allowed origin e.g. https://example.com",
+    },
+    {
+      name: "replication_workers",
+      required: false,
+      label: "Replication Workers",
+      tooltip: "Number of replication workers, defaults to 100",
+      type: "number",
+      placeholder: "Enter Replication Workers",
+    },
+    {
+      name: "replication_failed_workers",
+      required: false,
+      label: "Replication Failed Workers",
+      tooltip:
+        "Number of replication workers for recently failed replicas, defaults to 4",
+      type: "number",
+      placeholder: "Enter Replication Failed Workers",
+    },
+  ],
+  heal: [
+    {
+      name: "bitrotscan",
+      required: false,
+      label: "Bitrot Scan",
+      tooltip:
+        "Perform bitrot scan on disks when checking objects during scanner",
+      type: "on|off",
+    },
+    {
+      name: "max_sleep",
+      required: false,
+      label: "Max Sleep",
+      tooltip:
+        "Maximum sleep duration between objects to slow down heal operation. eg. 2s",
+      type: "duration",
+      placeholder: "Enter Max Sleep duration",
+    },
+    {
+      name: "max_io",
+      required: false,
+      label: "Max IO",
+      tooltip:
+        "Maximum IO requests allowed between objects to slow down heal operation. eg. 3",
+      type: "number",
+      placeholder: "Enter Max IO",
+    },
+  ],
+  scanner: [
+    {
+      name: "delay",
+      required: false,
+      label: "Delay multiplier",
+      tooltip: "Scanner delay multiplier, defaults to '10.0'",
+      type: "number",
+      placeholder: "Enter Delay",
+    },
+    {
+      name: "max_wait",
+      required: false,
+      label: "Max Wait",
+      tooltip: "Maximum wait time between operations, defaults to '15s'",
+      type: "duration",
+      placeholder: "Enter Max Wait",
+    },
+    {
+      name: "cycle",
+      required: false,
+      label: "Cycle",
+      tooltip: "Time duration between scanner cycles, defaults to '1m'",
+      type: "duration",
+      placeholder: "Enter Cycle",
     },
   ],
   etcd: [


### PR DESCRIPTION
As #1062, adds the following elements to the settings panel: `api`, `heal`, `scanner`.

The keys `requests_deadline`, `cluster_deadline`, `remote_transport_deadline` and `list_quorum` under `api` were left out due to: https://github.com/minio/minio/pull/13255.   Not sure, but probably those aren't meant to be editable anyway.

![image](https://user-images.githubusercontent.com/50302/134096036-d97a59e3-14f8-4872-a73a-c83c9d363bf2.png)

![image](https://user-images.githubusercontent.com/50302/134096323-eaf6462f-eedd-4c1f-beae-f61b3501e16b.png)
