### PR TITLE
Multiple fixes for sub path and objects filename encoding

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/ListBuckets.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/ListBuckets.tsx
@@ -88,6 +88,9 @@ const styles = (theme: Theme) =>
     theaderSearchLabel: {
       color: theme.palette.grey["400"],
     },
+    addBucket: {
+      marginRight: 8,
+    },
     theaderSearch: {
       borderColor: theme.palette.grey["200"],
       "& .MuiInputBase-input": {
@@ -101,9 +104,6 @@ const styles = (theme: Theme) =>
             height: 14,
           },
         },
-      },
-      addBucket: {
-        marginRight: 8,
       },
       actionHeaderItems: {
         "@media (min-width: 320px)": {

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/RewindEnable.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/RewindEnable.tsx
@@ -107,7 +107,7 @@ const RewindEnable = ({
               name="status"
               checked={rewindEnableButton}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                setRewindEnableButton(false);
+                setRewindEnableButton(e.target.checked);
               }}
               label={"Current Status"}
               indicatorLabels={["Enabled", "Disabled"]}

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/SetLegalHoldModal.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/SetLegalHoldModal.tsx
@@ -76,7 +76,9 @@ const SetLegalHoldModal = ({
     api
       .invoke(
         "PUT",
-        `/api/v1/buckets/${bucketName}/objects/legalhold?prefix=${objectName}&version_id=${versionId}`,
+        `/api/v1/buckets/${bucketName}/objects/legalhold?prefix=${btoa(
+          objectName
+        )}&version_id=${versionId}`,
         { status: legalHoldEnabled ? "enabled" : "disabled" }
       )
       .then(() => {

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/SetRetention.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/SetRetention.tsx
@@ -119,7 +119,9 @@ const SetRetention = ({
     api
       .invoke(
         "PUT",
-        `/api/v1/buckets/${bucketName}/objects/retention?prefix=${selectedObject}&version_id=${versionId}`,
+        `/api/v1/buckets/${bucketName}/objects/retention?prefix=${btoa(
+          selectedObject
+        )}&version_id=${versionId}`,
         {
           expires: expireDate,
           mode: type,
@@ -142,7 +144,9 @@ const SetRetention = ({
     api
       .invoke(
         "DELETE",
-        `/api/v1/buckets/${bucketName}/objects/retention?prefix=${selectedObject}&version_id=${versionId}`
+        `/api/v1/buckets/${bucketName}/objects/retention?prefix=${btoa(
+          selectedObject
+        )}&version_id=${versionId}`
       )
       .then(() => {
         setIsSaving(false);

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ShareFile.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ShareFile.tsx
@@ -100,9 +100,9 @@ const ShareFile = ({
         api
           .invoke(
             "GET",
-            `/api/v1/buckets/${bucketName}/objects/share?prefix=${
+            `/api/v1/buckets/${bucketName}/objects/share?prefix=${btoa(
               dataObject.name
-            }&version_id=${versID || "null"}${
+            )}&version_id=${versID || "null"}${
               selectedDate !== "" ? `&expires=${diffDate}ms` : ""
             }`
           )

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
@@ -72,7 +72,7 @@ const PreviewFile = ({
   let path = "";
 
   if (object) {
-    const encodedPath = encodeURIComponent(object.name);
+    const encodedPath = btoa(object.name);
     path = `${window.location.origin}/api/v1/buckets/${bucketName}/objects/download?preview=true&prefix=${encodedPath}`;
     if (object.version_id) {
       path = path.concat(`&version_id=${object.version_id}`);

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { isNullOrUndefined } from "util";
-
 export const download = (
   bucketName: string,
   objectPath: string,
@@ -25,9 +23,9 @@ export const download = (
 ) => {
   const anchor = document.createElement("a");
   document.body.appendChild(anchor);
-  const encodedPath = encodeURIComponent(objectPath);
+  const encodedPath = btoa(objectPath);
   let path = `/api/v1/buckets/${bucketName}/objects/download?prefix=${encodedPath}`;
-  if (!isNullOrUndefined(versionID) && versionID !== "null") {
+  if (versionID) {
     path = path.concat(`&version_id=${versionID}`);
   }
   window.location.href = path;

--- a/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
@@ -55,20 +55,16 @@ const BrowserBreadcrumbs = ({
     paths = `/${internalPaths}`;
   }
 
-  const splitPaths = paths.split("/");
-
+  const splitPaths = paths.split("/").filter((path) => path !== "");
   const listBreadcrumbs = splitPaths.map(
     (objectItem: string, index: number) => {
-      const subSplit = splitPaths.slice(1, index + 1).join("/");
-
-      const route = `/buckets/${bucketName}/browse${
-        objectItem !== "" ? `/${subSplit}` : ""
+      const subSplit = splitPaths.slice(0, index + 1).join("/");
+      const route = `/buckets/${bucketName}/browse/${
+        subSplit ? `${btoa(subSplit)}` : ``
       }`;
-      const label = objectItem === "" ? bucketName : objectItem;
-
       return (
         <React.Fragment key={`breadcrumbs-${index.toString()}`}>
-          <Link to={route}>{label}</Link>
+          <Link to={route}>{objectItem}</Link>
           {index < splitPaths.length - 1 && <span> / </span>}
         </React.Fragment>
       );
@@ -95,6 +91,10 @@ const BrowserBreadcrumbs = ({
       )}
 
       <Grid item xs={12} className={classes.breadcrumbs}>
+        <React.Fragment>
+          <Link to={`/buckets/${bucketName}/browse`}>{bucketName}</Link>
+          {listBreadcrumbs.length > 0 && <span> / </span>}
+        </React.Fragment>
         {listBreadcrumbs}
       </Grid>
     </React.Fragment>

--- a/restapi/user_buckets.go
+++ b/restapi/user_buckets.go
@@ -18,6 +18,7 @@ package restapi
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -835,13 +836,15 @@ func getBucketObjectLockingResponse(session *models.Principal, bucketName string
 func getBucketRewindResponse(session *models.Principal, params user_api.GetBucketRewindParams) (*models.RewindResponse, *models.Error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
 	defer cancel()
-
 	var prefix = ""
-
 	if params.Prefix != nil {
-		prefix = *params.Prefix
+		encodedPrefix := *params.Prefix
+		decodedPrefix, err := base64.StdEncoding.DecodeString(encodedPrefix)
+		if err != nil {
+			return nil, prepareError(err)
+		}
+		prefix = string(decodedPrefix)
 	}
-
 	s3Client, err := newS3BucketClient(session, params.BucketName, prefix)
 	if err != nil {
 		LogError("error creating S3Client: %v", err)


### PR DESCRIPTION
- fix: objects with special characters (ie: /,&,%,*) won't open
- fix: create subdolders with special characters won't work, ie: /,&,%,*
- fix: view subfolders with special characters (ie: /,&,%,*) won't work
- refactor: browser breadcrumb
- fix: rewind enable/disable toggle button not working
- fix: undefined style for add bucket button in buckets page
- Added: validation for folder path naming
- refactor: encode prefix parameter using base64 to avoid url encode
  issues
- fix: share link for versioned object won't work because of wrong
  version_id

ie:

https://user-images.githubusercontent.com/1795553/135047244-b0adb088-cf1b-494b-b07d-7f3f85ad9691.mov

<img width="431" alt="Screen Shot 2021-09-27 at 13 51 07" src="https://user-images.githubusercontent.com/1795553/134988308-9baaf5e8-dd6d-45df-8b9f-5d503c09a4c0.png">

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>