### PR TITLE
Disabled restore button on delete marker = true

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ObjectDetails.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ObjectDetails.tsx
@@ -481,10 +481,7 @@ const ObjectDetails = ({
       },
       disableButtonFunction: (item: string) => {
         const element = versions.find((elm) => elm.version_id === item);
-        if (element && element.is_delete_marker) {
-          return true;
-        }
-        return false;
+        return (element && element.is_delete_marker)
       },
     },
   ];

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ObjectDetails.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ObjectDetails.tsx
@@ -479,7 +479,13 @@ const ObjectDetails = ({
         setRestoreVersion(item.version_id || "");
         setRestoreVersionOpen(true);
       },
-      disableButtonFunction: (_: any) => !distributedSetup,
+      disableButtonFunction: (item: string) => {
+        const element = versions.find((elm) => elm.version_id === item);
+        if (element && element.is_delete_marker) {
+          return true;
+        }
+        return false;
+      },
     },
   ];
 


### PR DESCRIPTION
## What does this do?

Disables restore button when delete_marker = true

## How does it look?

<img width="1060" alt="Screen Shot 2021-11-03 at 16 59 18" src="https://user-images.githubusercontent.com/33497058/140235399-4bac1188-c1c9-42f0-a7d3-900f0659b467.png">

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>