### PR TITLE
Changed link button component for MinIO Image

### DIFF
--- a/portal-ui/src/screens/Console/Common/AButton.tsx
+++ b/portal-ui/src/screens/Console/Common/AButton.tsx
@@ -31,6 +31,7 @@ const styles = (theme: Theme) =>
       cursor: "pointer",
       fontSize: "inherit",
       color: theme.palette.info.main,
+      fontFamily: "Lato, sans-serif",
     },
   });
 

--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantSummary.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantSummary.tsx
@@ -35,6 +35,7 @@ import { AppState } from "../../../../store";
 import history from "./../../../../history";
 import { CircleIcon } from "../../../../icons";
 import { tenantIsOnline } from "../ListTenants/utils";
+import AButton from "../../Common/AButton";
 
 interface ITenantsSummary {
   classes: any;
@@ -108,7 +109,9 @@ const styles = (theme: Theme) =>
         marginBottom: 2,
       },
     },
-
+    linkedSection: {
+      color: theme.palette.info.main,
+    },
     ...containerForHeader(theme.spacing(4)),
   });
 
@@ -200,6 +203,7 @@ const TenantSummary = ({
                       href={tenant?.endpoints?.minio}
                       target="_blank"
                       rel="noopener noreferrer"
+                      className={classes.linkedSection}
                     >
                       {tenant?.endpoints?.minio}
                     </a>
@@ -231,6 +235,7 @@ const TenantSummary = ({
                       href={tenant?.endpoints?.console}
                       target="_blank"
                       rel="noopener noreferrer"
+                      className={classes.linkedSection}
                     >
                       {tenant?.endpoints?.console}
                     </a>
@@ -242,15 +247,13 @@ const TenantSummary = ({
                 <div>
                   <b>MinIO:</b>
                   <i>
-                    <Button
-                      color="primary"
-                      className={classes.anchorButton}
+                    <AButton
                       onClick={() => {
                         setUpdateMinioVersion(true);
                       }}
                     >
                       {tenant ? tenant.image : ""}
-                    </Button>
+                    </AButton>
                   </i>
                   <div />
                 </div>


### PR DESCRIPTION
## What does this do?

Changed link button component for MinIO Image in tenant details page

## How does it look?

<img width="726" alt="Screen Shot 2021-11-09 at 21 05 14" src="https://user-images.githubusercontent.com/33497058/141042409-af2ea550-4a0f-4dd6-8be6-b86011fa50f9.png">

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>