### PR TITLE
Increased wide modal size & removed preview file width limit

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
@@ -36,7 +36,7 @@ const styles = () =>
         height: 500,
       },
       "&.text": {
-        height: 500,
+        height: 700,
       },
       "&.audio": {
         height: 150,

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileModal.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileModal.tsx
@@ -38,6 +38,7 @@ const PreviewFileModal = ({
         modalOpen={open}
         title={`Preview - ${object?.name}`}
         onClose={onClosePreview}
+        wideLimit={false}
       >
         <PreviewFileContent bucketName={bucketName} object={object} />
       </ModalWrapper>

--- a/portal-ui/src/screens/Console/Common/ModalWrapper/ModalWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/ModalWrapper/ModalWrapper.tsx
@@ -155,7 +155,7 @@ const ModalWrapper = ({
           paper: classes.customDialogSize,
         },
       }
-    : { maxWidth: "md" as const, fullWidth: true };
+    : { maxWidth: "lg" as const, fullWidth: true };
 
   let message = "";
 


### PR DESCRIPTION
fixes #1182 

## What does this do?

Increased wide modal size & removed preview file width limit

## How does it look?


<img width="1574" alt="Screen Shot 2021-11-11 at 18 40 24" src="https://user-images.githubusercontent.com/33497058/141389179-fde81f83-c9f4-4f95-b32c-90453fe392ac.png">
<img width="1518" alt="Screen Shot 2021-11-11 at 18 29 00" src="https://user-images.githubusercontent.com/33497058/141389181-93c5d37a-3800-41d8-8ac2-6ce25c5bbbca.png">

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>