### PR TITLE
fix:solve the problem of generating duplicate url encode for presignedUrl

### DIFF
--- a/restapi/client.go
+++ b/restapi/client.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
-	"path"
 	"strings"
 	"time"
 
@@ -383,17 +381,13 @@ func newS3BucketClient(claims *models.Principal, bucketName string, prefix strin
 		return nil, fmt.Errorf("the provided credentials are invalid")
 	}
 	endpoint := getMinIOServer()
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("the provided endpoint is invalid")
-	}
 	if strings.TrimSpace(bucketName) != "" {
-		u.Path = path.Join(u.Path, bucketName)
+		endpoint += fmt.Sprintf("/%s", bucketName)
 	}
 	if strings.TrimSpace(prefix) != "" {
-		u.Path = path.Join(u.Path, prefix)
+		endpoint += fmt.Sprintf("/%s", prefix)
 	}
-	s3Config := newS3Config(u.String(), claims.STSAccessKeyID, claims.STSSecretAccessKey, claims.STSSessionToken, false)
+	s3Config := newS3Config(endpoint, claims.STSAccessKeyID, claims.STSSecretAccessKey, claims.STSSessionToken, false)
 	client, pErr := mc.S3New(s3Config)
 	if pErr != nil {
 		return nil, pErr.Cause


### PR DESCRIPTION
When clicking an object to generate a shared link on the `console`, if the object name contains special characters, calling `url. String()` in the `client.newS3BucketClient` method will encode the characters, and the `*client.makeTargetURL` method in the `minio-go` module will encode again, which will lead to the unavailability of the generated link and report a exception `The specified key does not exist.`
such as:
```xml
<Error>
<Code>NoSuchKey</Code>
<Message>The specified key does not exist.</Message>
<Key>%E6%96%87%E7%A1%95%E8%80%83%E7%A0%94%EF%BC%9A2013%E5%B9%B4%E8%80%83%E7%A0%94%E6%95%B0%E5%AD%A6%E8%87%AA%E6%B5%8B%E9%A2%98%EF%BC%88%E4%B8%80%EF%BC%89.pdf</Key>
<BucketName>mybucket</BucketName>
<Resource>/mybucket/%E6%96%87%E7%A1%95%E8%80%83%E7%A0%94%EF%BC%9A2013%E5%B9%B4%E8%80%83%E7%A0%94%E6%95%B0%E5%AD%A6%E8%87%AA%E6%B5%8B%E9%A2%98%EF%BC%88%E4%B8%80%EF%BC%89.pdf</Resource>
<RequestId>16BCB09B6E9EFAB0</RequestId>
<HostId>99b18f5b-0179-460f-8bed-5a373401f10f</HostId>
</Error>
```
