### PR TITLE
Fixed share/download object regression

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -661,7 +661,7 @@ const ListObjects = ({
           uploadUrl = `${uploadUrl}?prefix=${encodedPath}`;
         }
 
-        const identity = btoa(
+        const identity = encodeFileName(
           `${bucketName}-${encodedPath}-${new Date().getTime()}-${Math.random()}`
         );
 
@@ -754,7 +754,7 @@ const ListObjects = ({
   };
 
   const downloadObject = (object: BucketObject | RewindObject) => {
-    const identityDownload = btoa(
+    const identityDownload = encodeFileName(
       `${bucketName}-${object.name}-${new Date().getTime()}-${Math.random()}`
     );
 

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ObjectDetails.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ObjectDetails.tsx
@@ -391,7 +391,7 @@ const ObjectDetails = ({
   };
 
   const downloadObject = (object: IFileInfo) => {
-    const identityDownload = btoa(
+    const identityDownload = encodeFileName(
       `${bucketName}-${object.name}-${new Date().getTime()}-${Math.random()}`
     );
 

--- a/restapi/client_test.go
+++ b/restapi/client_test.go
@@ -1,0 +1,90 @@
+// This file is part of MinIO Orchestrator
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package restapi
+
+import "testing"
+
+func Test_computeObjectURLWithoutEncode(t *testing.T) {
+	type args struct {
+		bucketName string
+		prefix     string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "http://localhost:9000/bucket-1/小飼弾小飼弾小飼弾.jp",
+			args: args{
+				bucketName: "bucket-1",
+				prefix:     "小飼弾小飼弾小飼弾.jpg",
+			},
+			want:    "http://localhost:9000/bucket-1/小飼弾小飼弾小飼弾.jpg",
+			wantErr: false,
+		},
+		{
+			name: "http://localhost:9000/bucket-1/a a - a a & a a - a a a.jpg",
+			args: args{
+				bucketName: "bucket-1",
+				prefix:     "a a - a a & a a - a a a.jpg",
+			},
+			want:    "http://localhost:9000/bucket-1/a a - a a & a a - a a a.jpg",
+			wantErr: false,
+		},
+		{
+			name: "http://localhost:9000/bucket-1/02%20-%20FLY%20ME%20TO%20THE%20MOON%20.jpg",
+			args: args{
+				bucketName: "bucket-1",
+				prefix:     "02%20-%20FLY%20ME%20TO%20THE%20MOON%20.jpg",
+			},
+			want:    "http://localhost:9000/bucket-1/02%20-%20FLY%20ME%20TO%20THE%20MOON%20.jpg",
+			wantErr: false,
+		},
+		{
+			name: "http://localhost:9000/bucket-1/!@#$%^&*()_+.jpg",
+			args: args{
+				bucketName: "bucket-1",
+				prefix:     "!@#$%^&*()_+.jpg",
+			},
+			want:    "http://localhost:9000/bucket-1/!@#$%^&*()_+.jpg",
+			wantErr: false,
+		},
+		{
+			name: "http://localhost:9000/bucket-1/test/test2/小飼弾小飼弾小飼弾.jpg",
+			args: args{
+				bucketName: "bucket-1",
+				prefix:     "test/test2/小飼弾小飼弾小飼弾.jpg",
+			},
+			want:    "http://localhost:9000/bucket-1/test/test2/小飼弾小飼弾小飼弾.jpg",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := computeObjectURLWithoutEncode(tt.args.bucketName, tt.args.prefix)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("computeObjectURLWithoutEncode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("computeObjectURLWithoutEncode() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
There's one new issue this bug fix exposed which is downloading objects with Chinese characters goes from:

`小飼弾小飼弾小飼弾.jpg` -> `å°_é£¼å¼¾å°_é£¼å¼¾å°_é£¼å¼¾.jpeg`

I'll address this on the next PR

# Test

Please test by uploading an object with name `小飼弾小飼弾小飼弾.jpg`, then:

- download the object
- preview the object
- share the object
- create path prefix and upload the object again and repeat the first three steps

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>