### PR TITLE
Added fallback to default dashboard in case Prometheus is not accesible

### DIFF
--- a/models/admin_info_response.go
+++ b/models/admin_info_response.go
@@ -42,6 +42,9 @@ type AdminInfoResponse struct {
 	// objects
 	Objects int64 `json:"objects,omitempty"`
 
+	// prometheus not ready
+	PrometheusNotReady bool `json:"prometheusNotReady,omitempty"`
+
 	// servers
 	Servers []*ServerProperties `json:"servers"`
 

--- a/portal-ui/src/common/utils.ts
+++ b/portal-ui/src/common/utils.ts
@@ -472,7 +472,12 @@ export const getTimeFromTimestamp = (
   timestamp: string,
   fullDate: boolean = false
 ) => {
-  const dateObject = new Date(parseInt(timestamp) * 1000);
+  const timestampToInt = parseInt(timestamp);
+
+  if (isNaN(timestampToInt)) {
+    return "";
+  }
+  const dateObject = new Date(timestampToInt * 1000);
 
   if (fullDate) {
     return `${dateObject.getFullYear()}-${String(

--- a/portal-ui/src/screens/Console/Dashboard/BasicDashboard/BasicDashboard.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/BasicDashboard/BasicDashboard.tsx
@@ -133,6 +133,31 @@ const BasicDashboard = ({ classes, usage }: IDashboardProps) => {
   return (
     <Fragment>
       <div className={classes.dashboardBG} />
+      {usage?.prometheusNotReady && (
+        <Grid
+          container
+          justifyContent={"center"}
+          alignContent={"center"}
+          alignItems={"center"}
+        >
+          <Grid item xs={8}>
+            <HelpBox
+              iconComponent={<PrometheusIcon />}
+              title={"We can't retrieve advanced metrics at this time"}
+              help={
+                <Fragment>
+                  MinIO Dashboard will display basic metrics as we couldn't
+                  connect to Prometheus successfully.
+                  <br /> <br />
+                  Please try again in a few minutes. If the problem persists,
+                  you can review your configuration and confirm that Prometheus
+                  server is up and running.
+                </Fragment>
+              }
+            />
+          </Grid>
+        </Grid>
+      )}
       <Grid container spacing={2}>
         <Grid item xs={12} className={classes.generalStatusTitle}>
           General Status
@@ -241,45 +266,47 @@ const BasicDashboard = ({ classes, usage }: IDashboardProps) => {
           </TabPanel>
         </Grid>
       </Grid>
-      <Grid
-        container
-        justifyContent={"center"}
-        alignContent={"center"}
-        alignItems={"center"}
-      >
-        <Grid item xs={8}>
-          <HelpBox
-            iconComponent={<PrometheusIcon />}
-            title={"Monitoring"}
-            help={
-              <Fragment>
-                The MinIO Dashboard is displaying basic metrics only due to
-                missing the{" "}
-                <a
-                  href="https://docs.min.io/minio/baremetal/console/minio-console.html?ref=con#configuration"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  necessary settings
-                </a>{" "}
-                for displaying extended metrics.
-                <br />
-                <br />
-                See{" "}
-                <a
-                  href="https://docs.min.io/minio/baremetal/monitoring/metrics-alerts/collect-minio-metrics-using-prometheus.html?ref=con#minio-metrics-collect-using-prometheus"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Collect MinIO Metrics Using Prometheus
-                </a>{" "}
-                for a complete tutorial on scraping and visualizing MinIO
-                metrics with Prometheus.
-              </Fragment>
-            }
-          />
+      {!usage?.prometheusNotReady && (
+        <Grid
+          container
+          justifyContent={"center"}
+          alignContent={"center"}
+          alignItems={"center"}
+        >
+          <Grid item xs={8}>
+            <HelpBox
+              iconComponent={<PrometheusIcon />}
+              title={"Monitoring"}
+              help={
+                <Fragment>
+                  The MinIO Dashboard is displaying basic metrics only due to
+                  missing the{" "}
+                  <a
+                    href="https://docs.min.io/minio/baremetal/console/minio-console.html?ref=con#configuration"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    necessary settings
+                  </a>{" "}
+                  for displaying extended metrics.
+                  <br />
+                  <br />
+                  See{" "}
+                  <a
+                    href="https://docs.min.io/minio/baremetal/monitoring/metrics-alerts/collect-minio-metrics-using-prometheus.html?ref=con#minio-metrics-collect-using-prometheus"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Collect MinIO Metrics Using Prometheus
+                  </a>{" "}
+                  for a complete tutorial on scraping and visualizing MinIO
+                  metrics with Prometheus.
+                </Fragment>
+              }
+            />
+          </Grid>
         </Grid>
-      </Grid>
+      )}
     </Fragment>
   );
 };

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/LinearGraphWidget.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/LinearGraphWidget.tsx
@@ -154,7 +154,12 @@ const LinearGraphWidget = ({
               if (key === "name") {
                 continue;
               }
-              const val = parseInt(dp[key]);
+              let val = parseInt(dp[key]);
+
+              if (isNaN(val)) {
+                val = 0;
+              }
+
               if (maxVal < val) {
                 maxVal = val;
               }

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/SingleRepWidget.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/SingleRepWidget.tsx
@@ -111,6 +111,18 @@ const SingleRepWidget = ({
   }, [loading, panelItem, timeEnd, timeStart, displayErrorMessage, apiPrefix]);
   const gradientID = `colorGradient-${title.split(" ").join("-")}`;
 
+  let repNumber = "";
+
+  if (result) {
+    const resultRep = parseInt(result.innerLabel || "0");
+
+    if (!isNaN(resultRep)) {
+      repNumber = representationNumber(resultRep);
+    } else {
+      repNumber = "0";
+    }
+  }
+
   return (
     <div className={classes.singleValueContainer}>
       <div className={classes.titleContainer}>{title}</div>
@@ -150,7 +162,7 @@ const SingleRepWidget = ({
                 fill={"#07193E"}
               >
                 {result
-                  ? representationNumber(parseInt(result.innerLabel || "0"))
+                  ? repNumber
                   : ""}
               </text>
             </AreaChart>

--- a/portal-ui/src/screens/Console/Dashboard/types.ts
+++ b/portal-ui/src/screens/Console/Dashboard/types.ts
@@ -20,6 +20,7 @@ export interface Usage {
   usage: number;
   buckets: number;
   objects: number;
+  prometheusNotReady?: boolean;
   widgets?: any;
   servers: ServerInfo[];
 }

--- a/portal-ui/src/screens/Console/NotificationEndpoints/CustomForms/EditConfiguration.tsx
+++ b/portal-ui/src/screens/Console/NotificationEndpoints/CustomForms/EditConfiguration.tsx
@@ -89,22 +89,27 @@ const EditConfiguration = ({
     useState<boolean>(false);
   //Effects
   useEffect(() => {
-    const configId = get(selectedConfiguration, "configuration_id", false);
+    if (loadingConfig) {
+      const configId = get(selectedConfiguration, "configuration_id", false);
 
-    if (configId) {
-      api
-        .invoke("GET", `/api/v1/configs/${configId}`)
-        .then((res) => {
-          const keyVals = get(res, "key_values", []);
-          setConfigValues(keyVals);
-        })
-        .catch((err: ErrorResponseHandler) => {
-          setLoadingConfig(false);
-          setErrorSnackMessage(err);
-        });
+      if (configId) {
+        api
+          .invoke("GET", `/api/v1/configs/${configId}`)
+          .then((res) => {
+            const keyVals = get(res, "key_values", []);
+            setConfigValues(keyVals);
+            setLoadingConfig(false);
+          })
+          .catch((err: ErrorResponseHandler) => {
+            setLoadingConfig(false);
+            setErrorSnackMessage(err);
+          });
+
+        return;
+      }
+      setLoadingConfig(false);
     }
-    setLoadingConfig(false);
-  }, [selectedConfiguration, setErrorSnackMessage]);
+  }, [loadingConfig, selectedConfiguration, setErrorSnackMessage]);
 
   useEffect(() => {
     if (saving) {
@@ -153,6 +158,9 @@ const EditConfiguration = ({
   const continueReset = (restart: boolean) => {
     setResetConfigurationOpen(false);
     serverNeedsRestart(restart);
+    if (restart) {
+      setLoadingConfig(true);
+    }
   };
 
   return (

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -3655,6 +3655,9 @@ func init() {
         "objects": {
           "type": "integer"
         },
+        "prometheusNotReady": {
+          "type": "boolean"
+        },
         "servers": {
           "type": "array",
           "items": {
@@ -9502,6 +9505,9 @@ func init() {
         },
         "objects": {
           "type": "integer"
+        },
+        "prometheusNotReady": {
+          "type": "boolean"
         },
         "servers": {
           "type": "array",

--- a/swagger-console.yml
+++ b/swagger-console.yml
@@ -3228,6 +3228,8 @@ definitions:
         type: integer
       usage:
         type: integer
+      prometheusNotReady:
+        type: boolean
       widgets:
         type: array
         items:


### PR DESCRIPTION
fixes #1139 

## What does this do?

- Added fallback to basic dashboard & added fallback to 0 when NaN is received in prometheus widgets.
- Reloaded settings page info after clicking restore defaults

## How does it look?
<img width="1692" alt="Screen Shot 2021-12-07 at 13 47 43" src="https://user-images.githubusercontent.com/33497058/145097645-b95af51b-d7bd-48c8-9b95-161a79a3753d.png">


![2021-12-07 14-01-16 2021-12-07 14_03_14](https://user-images.githubusercontent.com/33497058/145098750-fa4a8be6-2f6c-4cfe-a0d5-14eb0ff927a0.gif)
Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>