### PR TITLE
Use default storage class for postgre/prometheus if not user specified

### DIFF
--- a/operatorapi/operator_tenants.go
+++ b/operatorapi/operator_tenants.go
@@ -1243,10 +1243,10 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 
 	//Default class name for Log search
 	diskSpaceFromAPI := int64(5) * humanize.GiByte // Default is 5Gi
-	logSearchStorageClass := ""                    // Default is ""
 	logSearchImage := ""
 	logSearchPgImage := ""
 	logSearchPgInitImage := ""
+	var logSearchStorageClass *string // Nil means use default storage class
 	var logSearchSecurityContext *corev1.PodSecurityContext
 	var logSearchPgSecurityContext *corev1.PodSecurityContext
 
@@ -1255,7 +1255,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 			diskSpaceFromAPI = int64(*tenantReq.LogSearchConfiguration.StorageSize) * humanize.GiByte
 		}
 		if tenantReq.LogSearchConfiguration.StorageClass != "" {
-			logSearchStorageClass = tenantReq.LogSearchConfiguration.StorageClass
+			logSearchStorageClass = stringPtr(tenantReq.LogSearchConfiguration.StorageClass)
 		}
 		if tenantReq.LogSearchConfiguration.Image != "" {
 			logSearchImage = tenantReq.LogSearchConfiguration.Image
@@ -1308,7 +1308,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 							corev1.ResourceStorage: *logSearchDiskSpace,
 						},
 					},
-					StorageClassName: &logSearchStorageClass,
+					StorageClassName: logSearchStorageClass,
 				},
 			},
 		},
@@ -1331,17 +1331,18 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 	}
 
 	prometheusDiskSpace := 5      // Default is 5 by API
-	prometheusStorageClass := ""  // Default is ""
 	prometheusImage := ""         // Default is ""
 	prometheusSidecardImage := "" // Default is ""
 	prometheusInitImage := ""     // Default is ""
+
+	var prometheusStorageClass *string // Nil means default storage class
 
 	if tenantReq.PrometheusConfiguration != nil {
 		if tenantReq.PrometheusConfiguration.StorageSize != nil {
 			prometheusDiskSpace = int(*tenantReq.PrometheusConfiguration.StorageSize)
 		}
 		if tenantReq.PrometheusConfiguration.StorageClass != "" {
-			prometheusStorageClass = tenantReq.PrometheusConfiguration.StorageClass
+			prometheusStorageClass = stringPtr(tenantReq.PrometheusConfiguration.StorageClass)
 		}
 		if tenantReq.PrometheusConfiguration.Image != "" {
 			prometheusImage = tenantReq.PrometheusConfiguration.Image
@@ -1356,7 +1357,7 @@ func getTenantCreatedResponse(session *models.Principal, params operator_api.Cre
 
 	minInst.Spec.Prometheus = &miniov2.PrometheusConfig{
 		DiskCapacityDB:   swag.Int(prometheusDiskSpace),
-		StorageClassName: &prometheusStorageClass,
+		StorageClassName: prometheusStorageClass,
 	}
 	if prometheusImage != "" {
 		minInst.Spec.Prometheus.Image = prometheusImage

--- a/operatorapi/utils.go
+++ b/operatorapi/utils.go
@@ -63,3 +63,8 @@ func GenerateTenantConfigurationFile(configuration map[string]string) string {
 	}
 	return rawConfiguration
 }
+
+// Create a copy of a string and return its pointer
+func stringPtr(str string) *string {
+	return &str
+}


### PR DESCRIPTION
Currently we are using empty string as storage class for postgre and
prometheus pods when the user does not provide any value. However any
empty value as storage class has a special meaning in Kubernetes:

```
If storageClassName is set to an empty string ('') in the PVC, no
storage class will be used (i.e.; dynamic provisioning is disabled for
this PVC)

Existing, “Available”, PVs (that do not have a specified storageClassName)
will be considered for binding to the PVC.
```

This commit will avoid setting the storage class in the PVC declaration,
so the default storage class will be used.