### PR TITLE
Fix bug on opertator UI where metrics was showing the menu

### DIFF
--- a/portal-ui/src/common/SecureComponent/permissions.ts
+++ b/portal-ui/src/common/SecureComponent/permissions.ts
@@ -300,6 +300,9 @@ export const IAM_PAGES_PERMISSIONS = {
   [IAM_PAGES.DASHBOARD]: [
     IAM_SCOPES.ADMIN_SERVER_INFO, // displays dashboard information
   ],
+  [IAM_PAGES.METRICS]: [
+    IAM_SCOPES.ADMIN_SERVER_INFO, // displays dashboard information
+  ],
   [IAM_PAGES.POLICIES_VIEW]: [
     IAM_SCOPES.ADMIN_DELETE_POLICY,
     IAM_SCOPES.ADMIN_LIST_GROUPS,


### PR DESCRIPTION
Fixes a problem where we were not able to open `/metrics` which shows the dashboard without a menu in the operator UI.

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>