### PR TITLE
Added informative message for 413 error file too large

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -761,6 +761,9 @@ const ListObjects = ({
                 ) {
                   setSnackBarMessage(errorMessage);
                 }
+                if (xhr.status === 413) {
+                  setSnackBarMessage("Error - File size too large");
+                }
                 if (xhr.status === 200) {
                   completeObject(identity);
                   if (files.length === 0) {

--- a/restapi/error.go
+++ b/restapi/error.go
@@ -17,6 +17,7 @@ var (
 	ErrorGeneric               = errors.New("an error occurred, please try again")
 	errInvalidCredentials      = errors.New("invalid Login")
 	errForbidden               = errors.New("403 Forbidden")
+	errFileTooLarge            = errors.New("413 File too Large")
 	errorGenericInvalidSession = errors.New("invalid session")
 	// ErrorGenericNotFound Generic error for not found
 	ErrorGenericNotFound = errors.New("not found")
@@ -171,6 +172,10 @@ func prepareError(err ...error) *models.Error {
 		}
 		if err[0].Error() == errRemoteInvalidCredentials.Error() {
 			errorCode = 403
+			errorMessage = err[0].Error()
+		}
+		if err[0].Error() == errFileTooLarge.Error() {
+			errorCode = 413
 			errorMessage = err[0].Error()
 		}
 		// bucket already exists

--- a/restapi/user_objects.go
+++ b/restapi/user_objects.go
@@ -109,6 +109,9 @@ func registerObjectsHandlers(api *operations.ConsoleAPI) {
 	// upload object
 	api.UserAPIPostBucketsBucketNameObjectsUploadHandler = user_api.PostBucketsBucketNameObjectsUploadHandlerFunc(func(params user_api.PostBucketsBucketNameObjectsUploadParams, session *models.Principal) middleware.Responder {
 		if err := getUploadObjectResponse(session, params); err != nil {
+			if strings.Contains(*err.DetailedMessage, "413") {
+				return user_api.NewPostBucketsBucketNameObjectsUploadDefault(413).WithPayload(err)
+			}
 			return user_api.NewPostBucketsBucketNameObjectsUploadDefault(int(err.Code)).WithPayload(err)
 		}
 		return user_api.NewPostBucketsBucketNameObjectsUploadOK()


### PR DESCRIPTION
Displays informative error message in browser when upload fails due to overlarge size. Closes Issue #1148
![Screenshot from 2022-01-11 12-24-06](https://user-images.githubusercontent.com/65002498/149015825-2f065cf3-50e1-4a0a-8d7a-fc5c9e5fa816.png)
.