### PR TITLE
Detect basename for react router

### DIFF
--- a/portal-ui/src/history.ts
+++ b/portal-ui/src/history.ts
@@ -3,4 +3,10 @@ import { BrowserHistoryBuildOptions } from "history/createBrowserHistory";
 
 let browserHistoryOpts: BrowserHistoryBuildOptions = {};
 
+let basename = document.baseURI.replace(window.location.origin, "");
+
+if (basename !== "") {
+  browserHistoryOpts.basename = basename;
+}
+
 export default createBrowserHistory(browserHistoryOpts);

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
@@ -76,7 +76,8 @@ const PreviewFile = ({
 
   if (object) {
     const encodedPath = encodeFileName(object.name);
-    path = `${window.location.origin}/api/v1/buckets/${bucketName}/objects/download?preview=true&prefix=${encodedPath}`;
+    let basename = document.baseURI.replace(window.location.origin, "");
+    path = `${window.location.origin}${basename}api/v1/buckets/${bucketName}/objects/download?preview=true&prefix=${encodedPath}`;
     if (object.version_id) {
       path = path.concat(`&version_id=${object.version_id}`);
     }


### PR DESCRIPTION
fixes the routing subpath for react-router

To test:

- make assets
- start console with `CONSOLE_SUBPATH=/console/quack/`
- Using attached `nginx.conf` config start a nginx on port `8000` solving to console at `9090`
```shell
nginx -c /Users/dvaldivia/mindev/demos/subpath/nginx.conf -g "daemon off;"
```


config

```
events { worker_connections 1024; }

http {

server {
    listen 8000;

    location /console/quack/ {
        rewrite   ^/console/quack/(.*) /$1 break;
        proxy_pass http://localhost:9090;
    }
}

}
```


Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>