### PR TITLE
to fail test when yarn does not build

### DIFF
--- a/portal-ui/check-warnings.sh
+++ b/portal-ui/check-warnings.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 
-if yarn build | grep "Compiled with warnings"; then
+yell() { echo "$0: $*" >&2; }
+
+die() {
+  yell "$*"
+  cat yarn.log
+  exit 111
+}
+
+try() { "$@" &> yarn.log || die "cannot $*"; }
+
+rm yarn.log
+try yarn build
+
+if cat yarn.log | grep "Compiled with warnings"; then
   echo "There are warnings in the code"
   exit 1
 fi

--- a/portal-ui/src/screens/Console/Common/VirtualizedList/VirtualizedList.tsx
+++ b/portal-ui/src/screens/Console/Common/VirtualizedList/VirtualizedList.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { Fragment, ReactElement, useState } from "react";
+import React, { Fragment, ReactElement } from "react";
 import { FixedSizeList as List } from "react-window";
 import InfiniteLoader from "react-window-infinite-loader";
 import { AutoSizer } from "react-virtualized";

--- a/portal-ui/src/screens/Console/Tenants/ListTenants/ListTenants.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/ListTenants.tsx
@@ -46,7 +46,6 @@ import AButton from "../../Common/AButton/AButton";
 
 import withSuspense from "../../Common/Components/withSuspense";
 import VirtualizedList from "../../Common/VirtualizedList/VirtualizedList";
-import BucketListItem from "../../Buckets/ListBuckets/BucketListItem";
 
 const CredentialsPrompt = withSuspense(
   React.lazy(() => import("../../Common/CredentialsPrompt/CredentialsPrompt"))


### PR DESCRIPTION
The idea is to fail the test when `yarn build` does not work
Currently, test is passing because we are not providing an exit when yarn is failing to build.
Fixes miniohq/engineering#362