### PR TITLE
Update Integration tests on console to build MinIO from master

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,31 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      # To build minio image, we need to clone the repository first
+      - name: clone https://github.com/minio/minio
+        uses: actions/checkout@master
+        with:
+
+          # Repository name with owner. For example, actions/checkout
+          # Default: ${{ github.repository }}
+          repository: minio/minio
+          
+          # Relative path under $GITHUB_WORKSPACE to place the repository
+          # To have two repositories under the same test
+          path: 'minio_repository'
+
       - name: Build on ${{ matrix.os }}
         run: |
-          make test-integration
+          echo "The idea is to build minio image from downloaded repository";
+          cd $GITHUB_WORKSPACE/minio_repository;
+          echo "Get git version to build MinIO Image";
+          VERSION=`git rev-parse HEAD`;
+          echo $VERSION;
+          echo "Create minio image";
+          make docker VERSION=$VERSION;
+          echo "Jumping back to console repository to run the integration test"
+          cd $GITHUB_WORKSPACE;
+          echo "We are going to use the built image on test-integration";
+          VERSION="minio/minio:$VERSION";
+          echo $VERSION;
+          make test-integration MINIO_VERSION=$VERSION;

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ GOPATH := $(shell go env GOPATH)
 BUILD_VERSION:=$(shell git describe --exact-match --tags $(git log -n1 --pretty='%h') 2>/dev/null || git rev-parse --abbrev-ref HEAD 2>/dev/null)
 BUILD_TIME:=$(shell date 2>/dev/null)
 TAG ?= "minio/console:$(BUILD_VERSION)-dev"
+MINIO_VERSION ?= "quay.io/minio/minio:latest"
 
 default: console
 
@@ -64,7 +65,9 @@ assets:
 	@(cd portal-ui; yarn install; make build-static; yarn prettier --write . --loglevel warn; cd ..)
 
 test-integration:
-	@(docker run -d --name minio --rm -p 9000:9000 quay.io/minio/minio:latest server /data{1...4} && sleep 5)
+	@echo "docker run with MinIO Version below:"
+	@echo $(MINIO_VERSION)
+	@(docker run -d --name minio --rm -p 9000:9000 $(MINIO_VERSION) server /data{1...4} && sleep 5)
 	@(GO111MODULE=on go test -race -v github.com/minio/console/integration/...)
 	@(docker stop minio)
 


### PR DESCRIPTION
Fixes miniohq/engineering#372

The idea is to build MinIO from Master and use that image on Console Integration Tests.
As my first step, I want to try checking out (cloning) minio repository to get files locally
As noted in:
https://github.com/actions/checkout/issues/24
Once that is done, then I will proceed to create the docker image and finally use that image
to run the test against the image created from the minio repo, that way we will test against
the generated image on the fly if I am not mistaken.