### PR TITLE
Fix access rule edit name display for the default prefix

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/EditAccessRule.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/EditAccessRule.tsx
@@ -95,7 +95,7 @@ const EditAccessRule = ({
     <React.Fragment>
       <ModalWrapper
         modalOpen={modalOpen}
-        title={`Edit Access Rule for ${toEdit}`}
+        title={`Edit Access Rule for ${`${bucket}/${toEdit || ""}`}`}
         onClose={onClose}
         titleIcon={<AddAccessRuleIcon />}
       >


### PR DESCRIPTION
 Fix access rule edit name display for the default prefix

Fixes #1403