### PR TITLE
Make view button for tenant available regardless of it being online

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/ListTenants/TenantListItem.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/TenantListItem.tsx
@@ -192,7 +192,6 @@ const TenantListItem = ({ tenant, classes }: ITenantListItem) => {
             <RBIconButton
               tooltip={"View Tenant"}
               text={"View"}
-              disabled={!tenantIsOnline(tenant)}
               onClick={() => {
                 history.push(
                   `/namespaces/${tenant.namespace}/tenants/${tenant.name}`


### PR DESCRIPTION
We need to allow this so users can debug why a tenant is not coming online.

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>