### PR TITLE
Fixed issue where storage class resets when changing between tabs

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/NameTenantMain.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/NameTenantMain.tsx
@@ -121,10 +121,6 @@ const NameTenantMain = ({
   // Storage classes retrieval
   const getNamespaceInformation = useCallback(() => {
     setShowCreateButton(false);
-    updateField("selectedStorageClass", "");
-
-    setStorageClassesList([]);
-
     // Empty tenantValidation
     api
       .invoke("GET", `/api/v1/namespaces/${namespace}/tenants`)
@@ -157,14 +153,24 @@ const NameTenantMain = ({
             });
 
             setStorageClassesList(newStorage);
-            if (newStorage.length > 0) {
+
+            const stExists = newStorage.findIndex(
+              (storageClass) => storageClass.value === selectedStorageClass
+            );
+
+            if (newStorage.length > 0 && stExists === -1) {
               updateField("selectedStorageClass", newStorage[0].value);
+            } else if (newStorage.length === 0) {
+              updateField("selectedStorageClass", "");
+              setStorageClassesList([]);
             }
             setLoadingNamespaceInfo(false);
           })
           .catch((err: ErrorResponseHandler) => {
             setLoadingNamespaceInfo(false);
             setShowCreateButton(true);
+            updateField("selectedStorageClass", "");
+            setStorageClassesList([]);
             console.error("Namespace error: ", err);
           });
       })
@@ -180,6 +186,7 @@ const NameTenantMain = ({
     setModalErrorSnackMessage,
     setStorageClassesList,
     updateField,
+    selectedStorageClass,
   ]);
 
   const debounceNamespace = useMemo(


### PR DESCRIPTION
## What does this do?

Fixed an issue with storage class selector where the field resets after changing between tabs

## How does it look?
![2022-01-19 22-25-15 2022-01-19 22_27_47](https://user-images.githubusercontent.com/33497058/150273547-baa29031-9e02-451c-8d41-aba0a6e2c496.gif)



Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>