### PR TITLE
Improving bucket tests in Console API

### DIFF
--- a/integration/buckets_test.go
+++ b/integration/buckets_test.go
@@ -170,34 +170,40 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func TestAddBucket(t *testing.T) {
-	assert := assert.New(t)
-
-	client := &http.Client{
-		Timeout: 2 * time.Second,
-	}
-
+func AddBucket(BucketName string, Versioning bool, Locking bool) (*http.Response, error) {
+	/*
+	   This is an atomic function that we can re-use to create a bucket on any
+	   desired test.
+	*/
+	// Needed Parameters for API Call
 	requestDataAdd := map[string]interface{}{
-		"name":       "test1",
-		"versioning": false,
-		"locking":    false,
+		"name":       BucketName,
+		"versioning": Versioning,
+		"locking":    Locking,
 	}
 
+	// Creating the Call by adding the URL and Headers
 	requestDataJSON, _ := json.Marshal(requestDataAdd)
-
 	requestDataBody := bytes.NewReader(requestDataJSON)
-
-	// get list of buckets
 	request, err := http.NewRequest("POST", "http://localhost:9090/api/v1/buckets", requestDataBody)
 	if err != nil {
 		log.Println(err)
-		return
 	}
-
 	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
 	request.Header.Add("Content-Type", "application/json")
 
+	// Performing the call
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
 	response, err := client.Do(request)
+	return response, err
+}
+
+func TestAddBucket(t *testing.T) {
+	assert := assert.New(t)
+
+	response, err := AddBucket("test1", false, false)
 	assert.Nil(err)
 	if err != nil {
 		log.Println(err)
@@ -217,37 +223,12 @@ func TestAddBucketLocking(t *testing.T) {
 	*/
 	assert := assert.New(t)
 
-	client := &http.Client{
-		Timeout: 2 * time.Second,
-	}
-
 	/*
 		This is invalid, versioning has to be true for locking to be true, but
 		test will see and make sure this is not allowed and that we get proper
 		error for this scenario.
 	*/
-	requestDataAdd := map[string]interface{}{
-		"name":       "test1",
-		"versioning": false,
-		"locking":    true,
-	}
-
-	requestDataJSON, _ := json.Marshal(requestDataAdd)
-
-	requestDataBody := bytes.NewReader(requestDataJSON)
-
-	// create an object locking bucket without versioning flag
-	request, err := http.NewRequest(
-		"POST", "http://localhost:9090/api/v1/buckets", requestDataBody)
-	if err != nil {
-		log.Println(err)
-		return
-	}
-
-	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
-	request.Header.Add("Content-Type", "application/json")
-
-	response, err := client.Do(request)
+	response, err := AddBucket("test1", false, true)
 	assert.Nil(err)
 	if err != nil {
 		log.Println(err)
@@ -264,28 +245,7 @@ func TestAddBucketLocking(t *testing.T) {
 	/*
 		This is valid, versioning is true, then locking can be true as well.
 	*/
-	requestDataAdd = map[string]interface{}{
-		"name":       "thujan",
-		"versioning": true,
-		"locking":    true,
-	}
-
-	requestDataJSON, _ = json.Marshal(requestDataAdd)
-
-	requestDataBody = bytes.NewReader(requestDataJSON)
-
-	// create an object locking bucket with versioning flag
-	request, err = http.NewRequest(
-		"POST", "http://localhost:9090/api/v1/buckets", requestDataBody)
-	if err != nil {
-		log.Println(err)
-		return
-	}
-
-	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
-	request.Header.Add("Content-Type", "application/json")
-
-	response, err = client.Do(request)
+	response, err = AddBucket("thujun", true, true)
 	assert.Nil(err)
 	if err != nil {
 		log.Println(err)
@@ -319,27 +279,7 @@ func TestGetBucket(t *testing.T) {
 		Timeout: 2 * time.Second,
 	}
 
-	requestDataAdd := map[string]interface{}{
-		"name":       "test3",
-		"versioning": false,
-		"locking":    false,
-	}
-
-	requestDataJSON, _ := json.Marshal(requestDataAdd)
-
-	requestDataBody := bytes.NewReader(requestDataJSON)
-
-	// put bucket
-	request, err := http.NewRequest("POST", "http://localhost:9090/api/v1/buckets", requestDataBody)
-	if err != nil {
-		log.Println(err)
-		return
-	}
-
-	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
-	request.Header.Add("Content-Type", "application/json")
-
-	response, err := client.Do(request)
+	response, err := AddBucket("test3", false, false)
 	assert.Nil(err)
 	if err != nil {
 		log.Println(err)
@@ -347,7 +287,7 @@ func TestGetBucket(t *testing.T) {
 	}
 
 	// get bucket
-	request, err = http.NewRequest("GET", "http://localhost:9090/api/v1/buckets/test3", nil)
+	request, err := http.NewRequest("GET", "http://localhost:9090/api/v1/buckets/test3", nil)
 	if err != nil {
 		log.Println(err)
 		return
@@ -375,28 +315,8 @@ func TestSetBucketTags(t *testing.T) {
 		Timeout: 2 * time.Second,
 	}
 
-	requestDataAdd := map[string]interface{}{
-		"name":       "test4",
-		"versioning": false,
-		"locking":    false,
-	}
-
-	requestDataJSON, _ := json.Marshal(requestDataAdd)
-
-	requestDataBody := bytes.NewReader(requestDataJSON)
-
 	// put bucket
-	request, err := http.NewRequest("POST", "http://localhost:9090/api/v1/buckets", requestDataBody)
-	request.Close = true
-	if err != nil {
-		log.Println(err)
-		return
-	}
-
-	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
-	request.Header.Add("Content-Type", "application/json")
-
-	response, err := client.Do(request)
+	response, err := AddBucket("test4", false, false)
 	assert.Nil(err)
 	if err != nil {
 		log.Println(err)
@@ -413,7 +333,7 @@ func TestSetBucketTags(t *testing.T) {
 
 	requestTagsBody := bytes.NewBuffer(requestTagsJSON)
 
-	request, err = http.NewRequest(http.MethodPut, "http://localhost:9090/api/v1/buckets/test4/tags", requestTagsBody)
+	request, err := http.NewRequest(http.MethodPut, "http://localhost:9090/api/v1/buckets/test4/tags", requestTagsBody)
 	request.Close = true
 	if err != nil {
 		log.Println(err)
@@ -506,16 +426,7 @@ func TestBucketVersioning(t *testing.T) {
 
 	requestDataBody := bytes.NewReader(requestDataJSON)
 
-	request, err = http.NewRequest("POST", "http://localhost:9090/api/v1/buckets", requestDataBody)
-	if err != nil {
-		log.Println(err)
-		return
-	}
-
-	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
-	request.Header.Add("Content-Type", "application/json")
-
-	response, err = client.Do(request)
+	response, err = AddBucket("test2", true, false)
 	assert.Nil(err)
 	if err != nil {
 		log.Println(err)
@@ -529,9 +440,9 @@ func TestBucketVersioning(t *testing.T) {
 		assert.NotEqual(201, response.StatusCode, "Versioning test Status Code is incorrect -  versioned bucket created on non-distributed system")
 	}
 
-	request, err = http.NewRequest("DELETE", "http://localhost:9090/api/v1/buckets/test2", requestDataBody)
-	if err != nil {
-		log.Println(err)
+	request, error := http.NewRequest("DELETE", "http://localhost:9090/api/v1/buckets/test2", requestDataBody)
+	if error != nil {
+		log.Println(error)
 		return
 	}
 


### PR DESCRIPTION
There is no task yet for this activity.
But I think we need to re-use the code in buckets_test.go since the same code is being called over and over in different spots. This is my first attempt to make this better. Let's see if the tests pass first.

Notice `AddBucket` is an atomic test that will only add a bucket and can be reused in many spots with the same result.