### PR TITLE
Fix failing tests and remove sleep statement for GitHub Actions

### DIFF
--- a/.github/workflows/permissions.yml
+++ b/.github/workflows/permissions.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Start Console, front-end app and initialize users/policies
         run: |
-          (./console server && sleep 180) & (make initialize-permissions && sleep 180)
+          (./console server) & (make initialize-permissions)
 
       - name: Run TestCafe Tests
         uses: DevExpress/testcafe-action@latest

--- a/portal-ui/tests/permissions/diagnostics.ts
+++ b/portal-ui/tests/permissions/diagnostics.ts
@@ -60,22 +60,20 @@ test("Start Diagnostic button can be clicked", async (t) => {
     .click(elements.startDiagnosticButton);
 });
 
-// TODO: Fix test failing sporadically on GitHub Actions
+test("Download button exists after Diagnostic is completed", async (t) => {
+  const downloadExists = elements.downloadButton.exists;
+  await t
+    .navigateTo("http://localhost:9090/support/diagnostics")
+    .click(elements.startDiagnosticButton)
+    .expect(downloadExists).ok();
+});
 
-// test("Download button exists after Diagnostic is completed", async (t) => {
-//   const downloadExists = elements.downloadButton.exists;
-//   await t
-//     .navigateTo("http://localhost:9090/support/diagnostics")
-//     .click(elements.startDiagnosticButton)
-//     .expect(downloadExists).ok();
-// });
-
-// test("Download button is clickable after Diagnostic is completed", async (t) => {
-//   await t
-//     .navigateTo("http://localhost:9090/support/diagnostics")
-//     .click(elements.startDiagnosticButton)
-//     .click(elements.downloadButton);
-// });
+test("Download button is clickable after Diagnostic is completed", async (t) => {
+  await t
+    .navigateTo("http://localhost:9090/support/diagnostics")
+    .click(elements.startDiagnosticButton)
+    .click(elements.downloadButton);
+});
 
 test("Start New Diagnostic button exists after Diagnostic is completed", async (t) => {
   const startNewDiagnosticButtonExists =


### PR DESCRIPTION
As we're running the tests from the Server URL now, we can remove the
redundant sleep statement in the GitHub Actions workflow. This commit
also fixes the Diagnostics tests that were only failing on GitHub
Actions.