### PR TITLE
Added TableRow customized style option

### DIFF
--- a/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
+++ b/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
@@ -1266,3 +1266,12 @@ export const textStyleUtils: any = {
     color: "#8399AB",
   },
 };
+
+// These classes are meant to be used as React.CSSProperties for TableWrapper
+export const TableRowPredefStyles: any = {
+  deleted: {
+    color: "#ACACAC",
+    backgroundColor: "#FDFDFD",
+    fontStyle: "italic",
+  }
+}

--- a/portal-ui/src/screens/Console/Common/TableWrapper/TableWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/TableWrapper/TableWrapper.tsx
@@ -38,6 +38,7 @@ import history from "../../../../history";
 import {
   checkboxIcons,
   radioIcons,
+  TableRowPredefStyles,
 } from "../FormComponents/common/styleLibrary";
 
 //Interfaces for table Items
@@ -104,6 +105,11 @@ interface TableWrapperProps {
   sortConfig?: ISortConfig;
   disabled?: boolean;
   onSelectAll?: () => void;
+  rowStyle?: ({
+    index,
+  }: {
+    index: number;
+  }) => "deleted" | "" | React.CSSProperties;
 }
 
 const borderColor = "#9c9c9c80";
@@ -458,6 +464,7 @@ const TableWrapper = ({
   autoScrollToBottom = false,
   disabled = false,
   onSelectAll,
+  rowStyle,
 }: TableWrapperProps) => {
   const [columnSelectorOpen, setColumnSelectorOpen] = useState<boolean>(false);
   const [anchorEl, setAnchorEl] = React.useState<any>(null);
@@ -637,6 +644,19 @@ const TableWrapper = ({
                       scrollToIndex={
                         autoScrollToBottom ? records.length - 1 : -1
                       }
+                      rowStyle={(r) => {
+                        if (rowStyle) {
+                          const returnElement = rowStyle(r);
+
+                          if (typeof returnElement === "string") {
+                            return get(TableRowPredefStyles, returnElement, {});
+                          }
+
+                          return returnElement;
+                        }
+
+                        return {};
+                      }}
                     >
                       {hasSelect && (
                         <Column


### PR DESCRIPTION
## What does this do?

Adds an option to set custom styles to a row in TableViewWrapper. 

## How does it look?
<img width="381" alt="Screen Shot 2022-01-21 at 21 47 26" src="https://user-images.githubusercontent.com/33497058/150623699-da9815a1-2229-49ae-86be-8f8ab47ce23e.png">
<img width="976" alt="Screen Shot 2022-01-21 at 21 46 09" src="https://user-images.githubusercontent.com/33497058/150623700-e119116e-d4d0-4857-b08d-36dbb0f7126d.png">
<img width="1232" alt="Screen Shot 2022-01-21 at 21 43 27" src="https://user-images.githubusercontent.com/33497058/150623701-98088af4-2222-41d3-8676-20f421558d61.png">

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>