### PR TITLE
Fixed EC Parity field reset during tab change

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/TenantSize.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/TenantSize.tsx
@@ -238,8 +238,6 @@ const TenantSize = ({
   useEffect(() => {
     if (distribution.error === "") {
       // Get EC Value
-      updateField("ecParity", "");
-
       if (nodes.trim() !== "" && distribution.disks !== 0) {
         api
           .invoke("GET", `api/v1/get-parity/${nodes}/${distribution.disks}`)


### PR DESCRIPTION
## What does this do?

Fixes EC Parity field reset during tabs changes in simple add tenant screen

## How does it look?
![2022-01-28 21-18-16 2022-01-28 21_22_07](https://user-images.githubusercontent.com/33497058/151645513-611f8507-7206-4b44-8803-8fa240ae9700.gif)

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>