### PR TITLE
Add support for matching multiple resources in SecureComponent

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/ListBuckets.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/ListBuckets.tsx
@@ -176,7 +176,6 @@ const ListBuckets = ({
 
   const renderItemLine = (index: number) => {
     const bucket = filteredRecords[index] || null;
-
     if (bucket) {
       return (
         <BucketListItem
@@ -188,9 +187,11 @@ const ListBuckets = ({
         />
       );
     }
-
     return null;
   };
+
+  const createBucketButtonResources: string[] =
+    Array.from(Object.keys(session.permissions)) || [];
 
   return (
     <Fragment>
@@ -263,7 +264,7 @@ const ListBuckets = ({
 
             <SecureComponent
               scopes={[IAM_SCOPES.S3_CREATE_BUCKET]}
-              resource={CONSOLE_UI_RESOURCE}
+              resource={createBucketButtonResources}
               errorProps={{ disabled: true }}
             >
               <RBIconButton

--- a/portal-ui/src/screens/Console/Console.tsx
+++ b/portal-ui/src/screens/Console/Console.tsx
@@ -219,6 +219,14 @@ const Console = ({
     {
       component: Buckets,
       path: IAM_PAGES.ADD_BUCKETS,
+      customPermissionFnc: () => {
+        const createBucketResources: string[] =
+          Array.from(Object.keys(session.permissions)) || [];
+        return hasPermission(
+          createBucketResources,
+          IAM_PAGES_PERMISSIONS[IAM_PAGES.ADD_BUCKETS]
+        );
+      },
     },
     {
       component: Buckets,


### PR DESCRIPTION
# How to test

1. create a policy like this and assign it to a user:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:*"
            ],
            "Resource": [
                "arn:aws:s3:::b03658cb-9703-40a4-b1aa-73c0d88a8566-etl/*"
            ]
        },
        {
            "Effect": "Allow",
            "Action": [
                "s3:CreateBucket"
            ],
            "Resource": [
                "arn:aws:s3:::b03658cb-9703-40a4-b1aa-73c0d88a8566-etl"
            ]
        }
    ]
}
```
2. login to console using the new user
3. try to create a new bucket named `invalid-bucket`, you should get an error
4. try to create a new bucket named `b03658cb-9703-40a4-b1aa-73c0d88a8566-etl`, bucket should be created correctly


Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>

