### PR TITLE
Add test for List Bucket Events end point

### DIFF
--- a/integration/buckets_test.go
+++ b/integration/buckets_test.go
@@ -628,6 +628,30 @@ func RestoreObjectToASelectedVersion(bucketName string, prefix string, versionID
 	return response, err
 }
 
+func ListBucketEvents(bucketName string) (*http.Response, error) {
+	/*
+		Helper function to list bucket's events
+		Name: List Bucket Events
+		HTTP Verb: GET
+		URL: {{baseUrl}}/buckets/:bucket_name/events
+	*/
+	request, err := http.NewRequest(
+		"GET",
+		"http://localhost:9090/api/v1/buckets/"+bucketName+"/events",
+		nil,
+	)
+	if err != nil {
+		log.Println(err)
+	}
+	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+	request.Header.Add("Content-Type", "application/json")
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	response, err := client.Do(request)
+	return response, err
+}
+
 func TestAddBucket(t *testing.T) {
 	assert := assert.New(t)
 	type args struct {
@@ -2044,6 +2068,72 @@ func TestRestoreObjectToASelectedVersion(t *testing.T) {
 					finalResponse,
 				)
 			}
+		})
+	}
+}
+
+func TestListBucketEvents(t *testing.T) {
+
+	// Variables
+	assert := assert.New(t)
+	validBucket := "testlistbucketevents"
+
+	// 1. Create bucket
+	response, err := AddBucket(validBucket, true, true, nil, nil)
+	assert.Nil(err)
+	if err != nil {
+		log.Println(err)
+		assert.Fail("Error creating the bucket")
+		return
+	}
+	if response != nil {
+		assert.Equal(201, response.StatusCode, inspectHTTPResponse(response))
+	}
+
+	// 2. List bucket events
+	type args struct {
+		bucketName string
+	}
+	tests := []struct {
+		name           string
+		expectedStatus int
+		args           args
+	}{
+		{
+			name:           "Valid bucket when listing events",
+			expectedStatus: 200,
+			args: args{
+				bucketName: validBucket,
+			},
+		},
+		{
+			name:           "Invalid bucket when listing events",
+			expectedStatus: 500,
+			args: args{
+				bucketName: "alksdjalksdjklasjdklasjdlkasjdkljaslkdjaskldjaklsjd",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			restResp, restErr := ListBucketEvents(
+				tt.args.bucketName,
+			)
+			assert.Nil(restErr)
+			if restErr != nil {
+				log.Println(restErr)
+				return
+			}
+			finalResponse := inspectHTTPResponse(restResp)
+			if restResp != nil {
+				assert.Equal(
+					tt.expectedStatus,
+					restResp.StatusCode,
+					finalResponse,
+				)
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/432

Test for `List Bucket Events` end point

# Coverage increment:
```
Coverage in master is:
* coverage: 26.5% of integration tests
* coverage: 21.2% of unittest in restapi
* coverage: 42.3% of both areas above

Coverage in current branch is:
* coverage: 27.6% of integration tests
* coverage: 21.2% of unittest in restapi
* coverage  43.1% of both areas above
```

# How to get coverage from external tests in GoLang:
To get coverage: 
https://docs.google.com/document/d/1tEBMSmpoCftvtgUYjCSzAGqWM1T-1OsHk7AxvUoq0VM/edit?usp=sharing