### PR TITLE
[WIP] Add Notify Postgres End Point as a test in order to subscribe events …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,8 @@ test-integration:
 	@(docker network create --subnet=173.18.0.0/29 mynet123)
 	@echo "docker run with MinIO Version below:"
 	@echo $(MINIO_VERSION)
-	@(docker run -d --name minio --rm -p 9000:9000 $(MINIO_VERSION) server /data{1...4} && sleep 5)
+	@(docker run --net=mynet123 -d --name minio --rm -p 9000:9000 $(MINIO_VERSION) server /data{1...4} && sleep 5)
+	@(docker run --net=mynet123 --ip=173.18.0.3 --name pgsqlcontainer --rm -p 5432:5432 -e POSTGRES_PASSWORD=password -d postgres && sleep 5)
 	@(GO111MODULE=on go test -race -v github.com/minio/console/integration/...)
 	@(docker stop minio)
 

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,8 @@ assets:
 	@(cd portal-ui; yarn install; make build-static; yarn prettier --write . --loglevel warn; cd ..)
 
 test-integration:
+	@echo "create docker network to communicate containers MinIO & PostgreSQL"
+	@(docker network create --subnet=173.18.0.0/29 mynet123)
 	@echo "docker run with MinIO Version below:"
 	@echo $(MINIO_VERSION)
 	@(docker run -d --name minio --rm -p 9000:9000 $(MINIO_VERSION) server /data{1...4} && sleep 5)

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,9 @@ assets:
 	@(cd portal-ui; yarn install; make build-static; yarn prettier --write . --loglevel warn; cd ..)
 
 test-integration:
-	@echo "create docker network to communicate containers MinIO & PostgreSQL"
-	@(docker network create --subnet=173.18.0.0/29 mynet123)
 	@echo "docker run with MinIO Version below:"
 	@echo $(MINIO_VERSION)
-	@(docker run --net=mynet123 -d --name minio --rm -p 9000:9000 $(MINIO_VERSION) server /data{1...4} && sleep 5)
-	@(docker run --net=mynet123 --ip=173.18.0.3 --name pgsqlcontainer --rm -p 5432:5432 -e POSTGRES_PASSWORD=password -d postgres && sleep 5)
+	@(docker run -d --name minio --rm -p 9000:9000 $(MINIO_VERSION) server /data{1...4} && sleep 5)
 	@(GO111MODULE=on go test -race -v github.com/minio/console/integration/...)
 	@(docker stop minio)
 

--- a/integration/buckets_test.go
+++ b/integration/buckets_test.go
@@ -2237,7 +2237,7 @@ func TestNotifyPostgres(t *testing.T) {
 	assert.Nil(err)
 	if err != nil {
 		log.Println(err)
-		assert.Fail("Error creating the bucket")
+		assert.Fail("Error notifying postgresql")
 		return
 	}
 	if response != nil {

--- a/integration/buckets_test.go
+++ b/integration/buckets_test.go
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// this shouldn't affect, is our test broken for prev change?
 
 package integration
 
@@ -649,81 +650,6 @@ func BucketSetPolicy(bucketName string, access string, definition string) (*http
 	request, err := http.NewRequest(
 		"PUT",
 		"http://localhost:9090/api/v1/buckets/"+bucketName+"/set-policy",
-		requestDataBody,
-	)
-	if err != nil {
-		log.Println(err)
-	}
-	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
-	request.Header.Add("Content-Type", "application/json")
-	client := &http.Client{
-		Timeout: 2 * time.Second,
-	}
-	response, err := client.Do(request)
-	return response, err
-}
-
-func NotifyPostgres() (*http.Response, error) {
-	/*
-		Helper function to add Postgres Notification
-		HTTP Verb: PUT
-		URL: api/v1/configs/notify_postgres
-		Body:
-		{
-			"key_values":[
-				{
-					"key":"connection_string",
-					"value":"user=postgres password=password host=localhost dbname=postgres port=5432 sslmode=disable"
-				},
-				{
-					"key":"table",
-					"value":"accountsssss"
-				},
-				{
-					"key":"format",
-					"value":"namespace"
-				},
-				{
-					"key":"queue_limit",
-					"value":"10000"
-				},
-				{
-					"key":"comment",
-					"value":"comment"
-				}
-			]
-		}
-	*/
-	Body := models.SetConfigRequest{
-		KeyValues: []*models.ConfigurationKV{
-			{
-				Key:   "connection_string",
-				Value: "user=postgres password=password host=173.18.0.3 dbname=postgres port=5432 sslmode=disable",
-			},
-			{
-				Key:   "table",
-				Value: "accountsssss",
-			},
-			{
-				Key:   "format",
-				Value: "namespace",
-			},
-			{
-				Key:   "queue_limit",
-				Value: "10000",
-			},
-			{
-				Key:   "comment",
-				Value: "comment",
-			},
-		},
-	}
-
-	requestDataJSON, _ := json.Marshal(Body)
-	requestDataBody := bytes.NewReader(requestDataJSON)
-	request, err := http.NewRequest(
-		"PUT",
-		"http://localhost:9090/api/v1/configs/notify_postgres",
 		requestDataBody,
 	)
 	if err != nil {

--- a/integration/buckets_test.go
+++ b/integration/buckets_test.go
@@ -2226,21 +2226,3 @@ func TestBucketSetPolicy(t *testing.T) {
 		})
 	}
 }
-
-func TestNotifyPostgres(t *testing.T) {
-
-	// Variables
-	assert := assert.New(t)
-
-	// Test
-	response, err := NotifyPostgres()
-	assert.Nil(err)
-	if err != nil {
-		log.Println(err)
-		assert.Fail("Error notifying postgresql")
-		return
-	}
-	if response != nil {
-		assert.Equal(200, response.StatusCode, inspectHTTPResponse(response))
-	}
-}

--- a/integration/buckets_test.go
+++ b/integration/buckets_test.go
@@ -663,6 +663,81 @@ func BucketSetPolicy(bucketName string, access string, definition string) (*http
 	return response, err
 }
 
+func NotifyPostgres() (*http.Response, error) {
+	/*
+		Helper function to add Postgres Notification
+		HTTP Verb: PUT
+		URL: api/v1/configs/notify_postgres
+		Body:
+		{
+			"key_values":[
+				{
+					"key":"connection_string",
+					"value":"user=postgres password=password host=localhost dbname=postgres port=5432 sslmode=disable"
+				},
+				{
+					"key":"table",
+					"value":"accountsssss"
+				},
+				{
+					"key":"format",
+					"value":"namespace"
+				},
+				{
+					"key":"queue_limit",
+					"value":"10000"
+				},
+				{
+					"key":"comment",
+					"value":"comment"
+				}
+			]
+		}
+	*/
+	Body := models.SetConfigRequest{
+		KeyValues: []*models.ConfigurationKV{
+			{
+				Key:   "connection_string",
+				Value: "user=postgres password=password host=173.18.0.3 dbname=postgres port=5432 sslmode=disable",
+			},
+			{
+				Key:   "table",
+				Value: "accountsssss",
+			},
+			{
+				Key:   "format",
+				Value: "namespace",
+			},
+			{
+				Key:   "queue_limit",
+				Value: "10000",
+			},
+			{
+				Key:   "comment",
+				Value: "comment",
+			},
+		},
+	}
+
+	requestDataJSON, _ := json.Marshal(Body)
+	requestDataBody := bytes.NewReader(requestDataJSON)
+	request, err := http.NewRequest(
+		"PUT",
+		"http://localhost:9090/api/v1/configs/notify_postgres",
+		requestDataBody,
+	)
+	if err != nil {
+		log.Println(err)
+	}
+	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+	request.Header.Add("Content-Type", "application/json")
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	response, err := client.Do(request)
+	return response, err
+}
+
 func TestAddBucket(t *testing.T) {
 	assert := assert.New(t)
 	type args struct {
@@ -2149,5 +2224,23 @@ func TestBucketSetPolicy(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestNotifyPostgres(t *testing.T) {
+
+	// Variables
+	assert := assert.New(t)
+
+	// Test
+	response, err := NotifyPostgres()
+	assert.Nil(err)
+	if err != nil {
+		log.Println(err)
+		assert.Fail("Error creating the bucket")
+		return
+	}
+	if response != nil {
+		assert.Equal(200, response.StatusCode, inspectHTTPResponse(response))
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/433

This is still work in progress... But the idea is to be able to add events to buckets but first we need to add some notification; I decided to use postgresql notification. One container will be added and configured to share the network with minio container so we can test this api end point. For now I have only configured my docker instances locally, but I am creating this PR to see how to configure docker over GitHub Actions....