### PR TITLE
Added support validation against subpaths to hasPermission & SecureComponent

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/UploadFilesButton.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/UploadFilesButton.tsx
@@ -109,8 +109,10 @@ const UploadFilesButton = ({
           horizontal: "center",
         }}
       >
+
         <SecureComponent
           resource={uploadPath}
+          containsResource
           scopes={[IAM_SCOPES.S3_PUT_OBJECT]}
           errorProps={{ disabled: true }}
         >


### PR DESCRIPTION
## What does this do?

Added support validation against subpaths to hasPermission & SecureComponent

**Note:** Please test roughly as this implies changes on how policies are processed in the application. 


One test policy:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:GetBucketPolicy",
                "s3:ListAllMyBuckets",
                "s3:ListBucket"
            ],
            "Resource": [
                "arn:aws:s3:::amq-notifications"
            ]
        },
        {
            "Effect": "Allow",
            "Action": [
                "s3:ListBucket",
                "s3:ListMultipartUploadParts",
                "s3:PutObject",
                "s3:AbortMultipartUpload",
                "s3:DeleteObject",
                "s3:GetObject"
            ],
            "Resource": [
                "arn:aws:s3:::amq-notifications/*"
            ]
        }
    ]
}
```


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>