### PR TITLE
Allowing distributed mode in MinIO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test-integration:
 	@(docker stop minio)
 
 test-permissions:
-	@(docker run -d --name minio --rm -p 9000:9000 quay.io/minio/minio:latest server /data{1...4})
+	@(docker run -v /data1 -v /data2 -v /data3 -v /data4 -d --name minio --rm -p 9000:9000 quay.io/minio/minio:latest server /data{1...4})
 	@(env bash $(PWD)/portal-ui/tests/scripts/permissions.sh)
 	@(docker stop minio)
 
@@ -80,7 +80,7 @@ test-apply-permissions:
 	@(env bash $(PWD)/portal-ui/tests/scripts/initialize-env.sh)
 
 test-start-docker-minio:
-	@(docker run -d --name minio --rm -p 9000:9000 quay.io/minio/minio:latest server /data{1...4})
+	@(docker run -v /data1 -v /data2 -v /data3 -v /data4 -d --name minio --rm -p 9000:9000 quay.io/minio/minio:latest server /data{1...4})
 
 initialize-permissions: test-start-docker-minio test-apply-permissions
 	@echo "Done initializing permissions test"


### PR DESCRIPTION
To allow MinIO Distributed on all of our tests.
Added missing tests here.
This will solve current issue:
```sh
mc: <ERROR> Unable to initialize new alias from the provided credentials. Get "http://127.0.0.1:9000/probe-bucket-sign-21imjcu2azlv/?location=": dial tcp 127.0.0.1:9000: connect: connection refused.
```