### PR TITLE
Fixed field reset for memory & cpu fields in new tenant size screen

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/AddTenant/AddTenant.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/AddTenant.tsx
@@ -29,7 +29,7 @@ import {
   wizardCommon,
 } from "../../Common/FormComponents/common/styleLibrary";
 import api from "../../../../common/api";
-import { generatePoolName } from "../../../../common/utils";
+import { generatePoolName, getBytes } from "../../../../common/utils";
 import GenericWizard from "../../Common/GenericWizard/GenericWizard";
 import { IWizardElement } from "../../Common/GenericWizard/types";
 import { NewServiceAccount } from "../../Common/CredentialsPrompt/types";
@@ -280,7 +280,7 @@ const AddTenant = ({
           }
           if (fields.tenantSize.resourcesMemoryRequest !== "") {
             dataSend.pools[0].resources.requests.memory = parseInt(
-              fields.tenantSize.resourcesMemoryRequest
+              getBytes(fields.tenantSize.resourcesMemoryRequest, "Gi", true)
             );
           }
         }
@@ -297,7 +297,7 @@ const AddTenant = ({
           }
           if (fields.tenantSize.resourcesMemoryLimit !== "") {
             dataSend.pools[0].resources.limits.memory = parseInt(
-              fields.tenantSize.resourcesMemoryLimit
+              getBytes(fields.tenantSize.resourcesMemoryLimit, "Gi", true)
             );
           }
         }

--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/SizePreview.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/SizePreview.tsx
@@ -74,21 +74,11 @@ const styles = (theme: Theme) =>
 
 const SizePreview = ({
   classes,
-  updateAddField,
-  isPageValid,
-  volumeSize,
-  sizeFactor,
-  drivesPerServer,
   nodes,
   memoryNode,
   ecParity,
-  ecParityChoices,
-  cleanECChoices,
-  resourcesSize,
   distribution,
   ecParityCalc,
-  limitSize,
-  selectedStorageClass,
   cpuToUse,
   integrationSelection,
 }: ISizePreviewProps) => {
@@ -253,7 +243,7 @@ const mapState = (state: AppState) => ({
   sizeFactor: state.tenants.createTenant.fields.tenantSize.sizeFactor,
   drivesPerServer: state.tenants.createTenant.fields.tenantSize.drivesPerServer,
   nodes: state.tenants.createTenant.fields.tenantSize.nodes,
-  memoryNode: state.tenants.createTenant.fields.tenantSize.memoryNode,
+  memoryNode: state.tenants.createTenant.fields.tenantSize.resourcesMemoryRequest,
   ecParity: state.tenants.createTenant.fields.tenantSize.ecParity,
   ecParityChoices: state.tenants.createTenant.fields.tenantSize.ecParityChoices,
   cleanECChoices: state.tenants.createTenant.fields.tenantSize.cleanECChoices,
@@ -263,7 +253,7 @@ const mapState = (state: AppState) => ({
   limitSize: state.tenants.createTenant.fields.tenantSize.limitSize,
   selectedStorageClass:
     state.tenants.createTenant.fields.nameTenant.selectedStorageClass,
-  cpuToUse: state.tenants.createTenant.fields.tenantSize.cpuToUse,
+  cpuToUse: state.tenants.createTenant.fields.tenantSize.resourcesCPURequest,
   integrationSelection:
     state.tenants.createTenant.fields.tenantSize.integrationSelection,
 });

--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/TenantSizeResources.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/TenantSizeResources.tsx
@@ -176,14 +176,19 @@ const TenantSizeResources = ({
         );
 
         const baseCpuUse = Math.max(1, floor(maxAllocatableCPU / 2));
-        updateField("resourcesCPURequest", baseCpuUse);
+        if (resourcesCPURequest === "") {
+          updateField("resourcesCPURequest", baseCpuUse);
+        }
 
         const baseMemoryUse = Math.max(2, floor(maxMemory / 2));
-        updateField("resourcesMemoryRequest", baseMemoryUse);
+        if (resourcesMemoryRequest === "") {
+          updateField("resourcesMemoryRequest", baseMemoryUse);
+        }
       })
       .catch((err: any) => {
         updateField("maxMemorySize", 0);
         updateField("resourcesCPURequest", "");
+        updateField("resourcesMemoryRequest", "");
 
         console.error(err);
       });


### PR DESCRIPTION
## What does this do?
Fixed field reset for memory & cpu fields in new tenant size screen
Also fixed an issue with memory limit selection in create tenant

## How does it look?

![2022-02-16 18-10-49 2022-02-16 18_13_11](https://user-images.githubusercontent.com/33497058/154383146-ddedb1d9-2772-44b4-a9f5-a88082738fcf.gif)
<img width="513" alt="Screen Shot 2022-02-16 at 18 49 37" src="https://user-images.githubusercontent.com/33497058/154383176-84b9b009-b0fb-4f31-9b06-3ae857eaad14.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>