### PR TITLE
Adding IDs for Operator tests

### DIFF
--- a/portal-ui/src/screens/Console/Common/CredentialsPrompt/CredentialsPrompt.tsx
+++ b/portal-ui/src/screens/Console/Common/CredentialsPrompt/CredentialsPrompt.tsx
@@ -174,6 +174,7 @@ const CredentialsPrompt = ({
         </Grid>
         <Grid item xs={12} className={classes.buttonContainer}>
           <Button
+            id={"done-button"}
             variant="outlined"
             className={classes.buttonSpacer}
             onClick={() => {
@@ -186,6 +187,7 @@ const CredentialsPrompt = ({
 
           {!idp && (
             <Button
+              id={"download-button"}
               onClick={() => {
                 let consoleExtras = {};
 

--- a/portal-ui/src/screens/Console/Common/GenericWizard/GenericWizard.tsx
+++ b/portal-ui/src/screens/Console/Common/GenericWizard/GenericWizard.tsx
@@ -165,6 +165,7 @@ const GenericWizard = ({
           {wizardSteps.map((step, index) => {
             return (
               <ListItem
+                id={"wizard-step-" + step.label}
                 button
                 disableRipple
                 onClick={() => pageChange(index)}

--- a/portal-ui/src/screens/Console/Common/GenericWizard/WizardPage.tsx
+++ b/portal-ui/src/screens/Console/Common/GenericWizard/WizardPage.tsx
@@ -105,6 +105,7 @@ const WizardPage = ({
           {page.buttons.map((btn) => {
             return (
               <Button
+                id={"wizard-button-" + btn.label}
                 variant="contained"
                 color="primary"
                 size="small"

--- a/portal-ui/src/screens/Console/Menu/ConsoleMenuList.tsx
+++ b/portal-ui/src/screens/Console/Menu/ConsoleMenuList.tsx
@@ -157,6 +157,7 @@ const ConsoleMenuList = ({
           </ListItemIcon>
           <ListItemText
             primary="Logout"
+            id={"logout"}
             sx={{ ...menuItemTextStyles }}
             className={stateClsName}
           />

--- a/portal-ui/src/screens/Console/Tenants/ListTenants/ListTenants.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/ListTenants.tsx
@@ -208,6 +208,7 @@ const ListTenants = ({ classes, setErrorSnackMessage }: ITenantsList) => {
             />
 
             <RBIconButton
+              id={"refresh-tenant-list"}
               tooltip={"Refresh Tenant List"}
               text={""}
               onClick={() => {

--- a/portal-ui/src/screens/Console/Tenants/ListTenants/TenantListItem.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/TenantListItem.tsx
@@ -177,6 +177,7 @@ const TenantListItem = ({ tenant, classes }: ITenantListItem) => {
           </Grid>
           <Grid item xs={4} textAlign={"end"}>
             <RBIconButton
+              id={"manage-tenant-" + tenant.name}
               tooltip={"Manage Tenant"}
               text={"Manage"}
               disabled={!tenantIsOnline(tenant)}
@@ -190,6 +191,7 @@ const TenantListItem = ({ tenant, classes }: ITenantListItem) => {
               variant={"outlined"}
             />
             <RBIconButton
+              id={"view-tenant-" + tenant.name}
               tooltip={"View Tenant"}
               text={"View"}
               onClick={() => {


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/534

I am preparing all CSS selectors for Operator tests.
It is easier to click or text over an element when is easy to find.
In most cases, CSS selector can be created with current attributes like:
```js
document.querySelector("a[href=\"/tenants\"]").click()
Tenant name: #tenant-name
Namespace: #namespace
Storage class: input[name="storage_class"]
Number of servers number of nodes; #nodes
#drivesps <--- Drives per Server
Total Size*: #volume_size / input[name="size_factor"]
input[name="ec_parity"] <-- Erasure Code Parity
#resourcesCPURequest
#resourcesMemoryRequest
input[name="resourcesSpecifyLimit"]
```
But in other cases, this is just not possible, and I was having my mind in Python/Selenium where Xpath Selectors were used in my other projects, I read a bit on XPATH in TestCafe and found some repos... Nevertheless, since our React architecture allow id additions, then I found this approach easier for now. Later in the future we can re-evaluate and see if we should rather use xpath selectors or keep improving our DOM Attributes.