### PR TITLE
Using Kustomize to get YAML files

### DIFF
--- a/portal-ui/tests/operator/list-tenants.ts
+++ b/portal-ui/tests/operator/list-tenants.ts
@@ -1,10 +1,26 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import { diagnosticsElement, supportElement } from "../utils/elements-menu";
 import { Selector } from 'testcafe';
 
 
 fixture("For user with default permissions").page("http://localhost:9090");
 
-test("Create Tenant", async (t) => {
+test("Create Tenant and List Tenants", async (t) => {
 
 	const osCount = Selector(`#root > div > main > div[class] > div > div > div > div:nth-child(1) > div > div > div`).count;
 

--- a/portal-ui/tests/scripts/operator.sh
+++ b/portal-ui/tests/scripts/operator.sh
@@ -43,8 +43,8 @@ function setup_kind() {
 
 function install_operator() {
 
-	echo "Installing Current Operator"
-	try kubectl apply -k "${SCRIPT_DIR}/../../../operator/resources"
+	echo "Installing Current Operator from kustomization.yaml"
+	try kubectl apply -k "${SCRIPT_DIR}/resources"
 
 	echo "key, value for pod selector in kustomize test"
 	key=name
@@ -142,7 +142,7 @@ function install_tenant() {
 	value=storage-lite
 	echo "Installing lite tenant"
 
-	try kubectl apply -k "${SCRIPT_DIR}/../../../operator/examples/kustomization/tenant-lite"
+	try kubectl apply -k "${SCRIPT_DIR}/tenant"
 
 	echo "Waiting for the tenant statefulset, this indicates the tenant is being fulfilled"
 	echo $namespace

--- a/portal-ui/tests/scripts/resources/kustomization.yaml
+++ b/portal-ui/tests/scripts/resources/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: minio-operator
+
+images:
+  - name: minio/operator
+
+resources:
+  - github.com/minio/operator/resources/

--- a/portal-ui/tests/scripts/tenant/kustomization.yaml
+++ b/portal-ui/tests/scripts/tenant/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tenant-lite
+
+images:
+  - name: minio/operator
+
+resources:
+  - github.com/minio/operator/examples/kustomization/tenant-lite


### PR DESCRIPTION
The idea is to use `Kustomize` to get `resources` and `tenant` folders from `operator` repo to deploy the `tenant` using `kind`.

Two `yaml` files is all we need now:
For `resources`
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: minio-operator

images:
  - name: minio/operator

resources:
  - github.com/minio/operator/resources/
```

For `tenant` folder:
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: tenant-lite

images:
  - name: minio/operator

resources:
  - github.com/minio/operator/examples/kustomization/tenant-lite
```

Additional Info:
Fixes https://github.com/miniohq/engineering/issues/513 <--- Was already added in previous PR.