### PR TITLE
Removing operator repository

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -57,11 +57,6 @@ jobs:
           node-version: '17'
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      - name: Check out operator as a nested repository
-        uses: actions/checkout@v2
-        with:
-          repository: minio/operator
-          path: operator
       - uses: actions/cache@v2
         name: Go Mod Cache
         with:
@@ -434,11 +429,6 @@ jobs:
           node-version: '17'
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      - name: Check out operator as a nested repository
-        uses: actions/checkout@v2
-        with:
-          repository: minio/operator
-          path: operator
       - uses: actions/cache@v2
         name: Go Mod Cache
         with:

--- a/portal-ui/tests/scripts/operator.sh
+++ b/portal-ui/tests/scripts/operator.sh
@@ -36,7 +36,16 @@ die() {
 try() { "$@" || die "cannot $*"; }
 
 function setup_kind() {
-	try kind create cluster --config "${SCRIPT_DIR}/../../../operator/testing/kind-config.yaml"
+	# TODO once feature is added: https://github.com/kubernetes-sigs/kind/issues/1300
+	echo "kind: Cluster" > kind-config.yaml
+	echo "apiVersion: kind.x-k8s.io/v1alpha4" >> kind-config.yaml
+	echo "nodes:" >> kind-config.yaml
+	echo "  - role: control-plane" >> kind-config.yaml
+	echo "  - role: worker" >> kind-config.yaml
+	echo "  - role: worker" >> kind-config.yaml
+	echo "  - role: worker" >> kind-config.yaml
+	echo "  - role: worker" >> kind-config.yaml
+	try kind create cluster --config kind-config.yaml
 	echo "Kind is ready"
 	try kubectl get nodes
 }


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/562

Is `operator` repository really needed?... I think it is not, let's remove it!.
Well, all is needed is `kind-config.yaml` but since `kind` does not support `http` as the config option:
https://github.com/kubernetes-sigs/kind/issues/1300
Then we can in the meantime, put the file on the fly and once the feature is implemented just get it directly from the repo.
At the end, for one file, we shouldn't have to clone an entire repo.

# Temporal solution
```sh
	# TODO once feature is added: https://github.com/kubernetes-sigs/kind/issues/1300
	echo "kind: Cluster" > kind-config.yaml
	echo "apiVersion: kind.x-k8s.io/v1alpha4" >> kind-config.yaml
	echo "nodes:" >> kind-config.yaml
	echo "  - role: control-plane" >> kind-config.yaml
	echo "  - role: worker" >> kind-config.yaml
	echo "  - role: worker" >> kind-config.yaml
	echo "  - role: worker" >> kind-config.yaml
	echo "  - role: worker" >> kind-config.yaml
```