### PR TITLE
Reuse golang dependencies

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -57,15 +57,6 @@ jobs:
           node-version: '17'
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        name: Go Mod Cache
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -103,11 +94,8 @@ jobs:
         run: |
           ./check-warnings.sh
 
-  compile-job:
-    name: Compiles on Go ${{ matrix.go-version }} and ${{ matrix.os }}
-    needs:
-      - lint-job
-      - no-warnings-and-make-assets
+  reuse-golang-dependencies:
+    name: reuse golang dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -122,6 +110,50 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      - name: Build on ${{ matrix.os }}
+        env:
+          GO111MODULE: on
+          GOOS: linux
+        run: |
+          go mod download
+
+      - uses: actions/cache@v2
+        name: Go Mod Cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
+
+  compile-job:
+    name: Compiles on Go ${{ matrix.go-version }} and ${{ matrix.os }}
+    needs:
+      - lint-job
+      - no-warnings-and-make-assets
+      - reuse-golang-dependencies
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go-version: [ 1.17.x ]
+        os: [ ubuntu-latest ]
+    steps:
+      - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Go Mod Cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
 
       - name: Build on ${{ matrix.os }}
         env:
@@ -135,6 +167,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -149,6 +182,14 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Go Mod Cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
 
       - name: Build on ${{ matrix.os }}
         env:
@@ -162,6 +203,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -176,6 +218,14 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Go Mod Cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
 
       - name: Build on ${{ matrix.os }}
         env:
@@ -189,6 +239,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -203,6 +254,14 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Go Mod Cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
 
       - name: Build on ${{ matrix.os }}
         env:
@@ -216,6 +275,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -230,6 +290,14 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Go Mod Cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
 
       - name: Build on ${{ matrix.os }}
         env:
@@ -243,6 +311,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -258,6 +327,14 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - uses: actions/cache@v2
+        name: Go Mod Cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
+
       - name: Build on ${{ matrix.os }}
         env:
           GO111MODULE: on
@@ -270,6 +347,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -305,6 +383,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -319,6 +398,14 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Go Mod Cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
 
       - name: Build on ${{ matrix.os }}
         env:
@@ -340,6 +427,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ubuntu-latest
 
     strategy:
@@ -368,6 +456,14 @@ jobs:
           # Relative path under $GITHUB_WORKSPACE to place the repository
           # To have two repositories under the same test
           path: 'minio_repository'
+
+      - uses: actions/cache@v2
+        name: Go Mod Cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
 
       - name: Build on ${{ matrix.os }}
         run: |
@@ -398,6 +494,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -413,6 +510,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -435,9 +533,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ github.run_id }}
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -486,6 +582,7 @@ jobs:
     needs:
       - lint-job
       - no-warnings-and-make-assets
+      - reuse-golang-dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -502,15 +599,6 @@ jobs:
           node-version: '17'
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        name: Go Mod Cache
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -537,6 +625,14 @@ jobs:
           key: ${{ runner.os }}-assets-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-assets-
+
+      - uses: actions/cache@v2
+        name: Go Mod Cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
 
       - name: Build Console on ${{ matrix.os }}
         env:
@@ -585,13 +681,12 @@ jobs:
           repository: wadey/gocovmerge
           path: gocovmerge
       - uses: actions/cache@v2
+        name: Go Mod Cache
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ github.run_id }}
 
       - uses: actions/cache@v2
         id: coverage-cache

--- a/portal-ui/tests/scripts/cleanup-env.sh
+++ b/portal-ui/tests/scripts/cleanup-env.sh
@@ -54,7 +54,8 @@ __init__() {
   export GOPATH=/tmp/gopath
   export PATH=${PATH}:${GOPATH}/bin
 
-  go install github.com/minio/mc@latest
+  wget https://dl.min.io/client/mc/release/linux-amd64/mc
+  chmod +x mc
 
   add_alias
 }


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/563

To reuse GoLang Dependencies across the Jobs.
