### PR TITLE
Removed Welcome to label from login screen

### DIFF
--- a/portal-ui/src/screens/LoginPage/LoginPage.tsx
+++ b/portal-ui/src/screens/LoginPage/LoginPage.tsx
@@ -617,7 +617,6 @@ const Login = ({
               <div className="left-logo">
                 <LoginMinIOLogo />
               </div>
-              <div className="text-line1">Welcome to</div>
               <div className="text-line2">{consoleText}</div>
               <div className="text-line3">Multi-Cloud Object Storage</div>
             </div>


### PR DESCRIPTION
## What does this do?

Removed `Welcome to` label as per requested

## How does it look?
<img width="1726" alt="Screen Shot 2022-03-07 at 23 26 52" src="https://user-images.githubusercontent.com/33497058/157172167-c43d0f63-b115-40f2-84c5-0f7790b4a4d1.png">
<img width="864" alt="Screen Shot 2022-03-07 at 23 26 31" src="https://user-images.githubusercontent.com/33497058/157172182-f2d69193-0c5f-42fb-abb7-c672d9e5c0a2.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>