### PR TITLE
Adding test for creating tenant via API

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -830,7 +830,7 @@ jobs:
           result=${result%\%}
           echo "result:"
           echo $result
-          threshold=50.5
+          threshold=51.0
           if (( $(echo "$result >= $threshold" |bc -l) )); then
             echo "It is equal or greater than threshold, passed!"
           else


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/592

# How it will looks:
```sh
cniackz:/Users/cniackz/console # make test-operator-integration
Start cd operator-integration && go test:
/Users/cniackz/console

.......................TestMain(): started
sleeping
start server

.......................TestListTenants(): started
storage-lite
.......................TestListTenants(): completed


.......................TestCreateTenant(): started
.......................TestCreateTenant(): completed

PASS
coverage: 5.3% of statements in ../restapi
.......................TestMain(): completed
```

# What it does
It creates a new tenant under `default` namespace called `new-tenant`

# Coverage
Coverage increased from `50.5` to `51`