### PR TITLE
List tenants by namespace test

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -830,7 +830,7 @@ jobs:
           result=${result%\%}
           echo "result:"
           echo $result
-          threshold=51.4
+          threshold=51.8
           if (( $(echo "$result >= $threshold" |bc -l) )); then
             echo "It is equal or greater than threshold, passed!"
           else

--- a/operator-integration/tenant_test.go
+++ b/operator-integration/tenant_test.go
@@ -432,3 +432,48 @@ func TestCreateTenant(t *testing.T) {
 
 	printEndFunc("TestCreateTenant")
 }
+
+func ListTenantsByNameSpace(namespace string) (*http.Response, error) {
+	/*
+		Helper function to list buckets
+		HTTP Verb: GET
+		URL: http://localhost:9090/api/v1/namespaces/{namespace}/tenants
+	*/
+	request, err := http.NewRequest(
+		"GET", "http://localhost:9090/api/v1/namespaces/"+namespace+"/tenants", nil)
+	if err != nil {
+		log.Println(err)
+	}
+	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+	request.Header.Add("Content-Type", "application/json")
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	response, err := client.Do(request)
+	return response, err
+}
+
+func TestListTenantsByNameSpace(t *testing.T) {
+	assert := assert.New(t)
+	namespace := "default"
+	resp, err := ListTenantsByNameSpace(namespace)
+	assert.Nil(err)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	if resp != nil {
+		assert.Equal(
+			200, resp.StatusCode, "Status Code is incorrect")
+	}
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	result := models.ListTenantsResponse{}
+	err = json.Unmarshal(bodyBytes, &result)
+	if err != nil {
+		log.Println(err)
+		assert.Nil(err)
+	}
+	TenantName := &result.Tenants[0].Name // The array has to be empty, no index accessible
+	fmt.Println(*TenantName)
+	assert.Equal("new-tenant", *TenantName, *TenantName)
+}


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/600

To test end point below:

```yaml
  /namespaces/{namespace}/tenants:
    get:
      summary: List Tenants by Namespace
      operationId: ListTenants
      parameters:
        - name: namespace
          in: path
          required: true
          type: string
        - name: sort_by
          in: query
          required: false
          type: string
        - name: offset
          in: query
          required: false
          type: integer
          format: int32
        - name: limit
          in: query
          required: false
          type: integer
          format: int32
      responses:
        200:
          description: A successful response.
          schema:
            $ref: "#/definitions/listTenantsResponse"
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - OperatorAPI
```

# Coverage
prior `threshold=51.4`
actual `threshold=51.8`