### PR TITLE
Enabled Delete button for sub resources

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ObjectDetailPanel.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ObjectDetailPanel.tsx
@@ -543,6 +543,7 @@ const ObjectDetailPanel = ({
           scopes={[IAM_SCOPES.S3_DELETE_OBJECT]}
           matchAll
           errorProps={{ disabled: true }}
+          containsResource
         >
           <Button
             startIcon={<DeleteIcon />}


### PR DESCRIPTION
## What does this do?

Enabled Delete button for sub resources. This is a temporal bypass for policies that contains Read-only permissions for buckets but allow sub elements to have all the S3 Permissions.

 In case the user doesn't have a real permission to delete an object, an access denied error will be shown.

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>