### PR TITLE
Fix enable/disable delete button for object

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ObjectDetailPanel.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ObjectDetailPanel.tsx
@@ -539,11 +539,9 @@ const ObjectDetailPanel = ({
 
       <Grid item xs={12} sx={{ textAlign: "center" }}>
         <SecureComponent
-          resource={bucketName}
+          resource={[currentItem, [bucketName, actualInfo.name].join("/")]}
           scopes={[IAM_SCOPES.S3_DELETE_OBJECT]}
-          matchAll
           errorProps={{ disabled: true }}
-          containsResource
         >
           <Button
             startIcon={<DeleteIcon />}


### PR DESCRIPTION
- Pass the right resource to SecureComponent wrapper for delete button,
  bucket/object-full-path-including-prefix

![image](https://user-images.githubusercontent.com/1795553/159561089-0b1fe7ea-5d0e-4067-b7cf-85a679cdbf13.png)

![image](https://user-images.githubusercontent.com/1795553/159561124-69652c3a-6f07-4769-b6f4-dd8587ca2f4b.png)

### How to test

- Create a policy with the following claims

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:ListBucket"
            ],
            "Resource": [
                "arn:aws:s3:::test/*"
            ]
        },
        {
            "Effect": "Allow",
            "Action": [
                "s3:GetBucketLocation"
            ],
            "Resource": [
                "arn:aws:s3:::test"
            ]
        },
        {
            "Effect": "Allow",
            "Action": [
                "s3:*"
            ],
            "Resource": [
                "arn:aws:s3:::test/digitalinsights/xref_cust_guid_actd*"
            ]
        }
    ]
}
```
- Create bucket `test`
- Create a user and assign the policy, then upload a couple of objects
- Upload an object with prefix and name that matches `digitalinsights/xref_cust_guid_actd*`, ie `digitalinsights/xref_cust_guid_actd-v1.jpg` on the test bucket
- Login with the user you just created
- Delete button should be disabled for all other objects except `xref_cust_guid_actd-v1.jpg`

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>