### PR TITLE
List Policies With Given Bucket Test

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -988,7 +988,7 @@ jobs:
           result=${result%\%}
           echo "result:"
           echo $result
-          threshold=52.1
+          threshold=52.7
           if (( $(echo "$result >= $threshold" |bc -l) )); then
             echo "It is equal or greater than threshold, passed!"
           else

--- a/integration/admin_api_integration_test.go
+++ b/integration/admin_api_integration_test.go
@@ -169,3 +169,47 @@ func TestRestartService(t *testing.T) {
 	}
 
 }
+
+func ListPoliciesWithBucket(bucketName string) (*http.Response, error) {
+	/*
+		Helper function to List Policies With Given Bucket
+		HTTP Verb: GET
+		URL: /bucket-policy/{bucket}
+	*/
+	request, err := http.NewRequest(
+		"GET", "http://localhost:9090/api/v1/bucket-policy/"+bucketName, nil)
+	if err != nil {
+		log.Println(err)
+	}
+	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+	request.Header.Add("Content-Type", "application/json")
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	response, err := client.Do(request)
+	return response, err
+}
+
+func TestListPoliciesWithBucket(t *testing.T) {
+
+	// Test Variables
+	bucketName := "testlistpolicieswithbucket"
+	assert := assert.New(t)
+
+	// Test
+	response, err := ListPoliciesWithBucket(bucketName)
+	assert.Nil(err)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	parsedResponse := inspectHTTPResponse(response)
+	if response != nil {
+		assert.Equal(
+			200,
+			response.StatusCode,
+			parsedResponse,
+		)
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/448

To test end point below:
```yaml
  /bucket-policy/{bucket}:
    get:
      summary: List Policies With Given Bucket
      operationId: ListPoliciesWithBucket
      parameters:
        - name: bucket
          in: path
          required: true
          type: string
        - name: offset
          in: query
          required: false
          type: integer
          format: int32
        - name: limit
          in: query
          required: false
          type: integer
          format: int32
      responses:
        200:
          description: A successful response.
          schema:
            $ref: "#/definitions/listPoliciesResponse"
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - AdminAPI
```

## Coverage:
from: threshold=52.1
to: threshold=52.7
