### PR TITLE
Get objects in a bucket for a rewind date Test

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1065,7 +1065,7 @@ jobs:
           result=${result%\%}
           echo "result:"
           echo $result
-          threshold=52.7
+          threshold=53.00
           if (( $(echo "$result >= $threshold" |bc -l) )); then
             echo "It is equal or greater than threshold, passed!"
           else

--- a/integration/user_api_bucket_test.go
+++ b/integration/user_api_bucket_test.go
@@ -3573,3 +3573,47 @@ func TestAccessRule(t *testing.T) {
 	}
 
 }
+
+func GetBucketRewind(bucketName string, date string) (*http.Response, error) {
+	/*
+		Helper function to get objects in a bucket for a rewind date
+		HTTP Verb: GET
+		URL: /buckets/{bucket_name}/rewind/{date}
+	*/
+	request, err := http.NewRequest(
+		"GET",
+		"http://localhost:9090/api/v1/buckets/"+bucketName+"/rewind/"+date,
+		nil,
+	)
+	if err != nil {
+		log.Println(err)
+	}
+	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+	request.Header.Add("Content-Type", "application/json")
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	response, err := client.Do(request)
+	return response, err
+}
+
+func TestGetBucketRewind(t *testing.T) {
+
+	// Variables
+	assert := assert.New(t)
+	bucketName := "test-get-bucket-rewind"
+	date := "2006-01-02T15:04:05Z"
+
+	// Test
+	resp, err := GetBucketRewind(bucketName, date)
+	assert.Nil(err)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	if resp != nil {
+		assert.Equal(
+			200, resp.StatusCode, inspectHTTPResponse(resp))
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/447
### Objective: Test end point below:
```yaml
  /buckets/{bucket_name}/rewind/{date}:
    get:
      summary: Get objects in a bucket for a rewind date
      operationId: GetBucketRewind
      parameters:
        - name: bucket_name
          in: path
          required: true
          type: string
        - name: date
          in: path
          required: true
          type: string
        - name: prefix
          in: query
          required: false
          type: string
      responses:
        200:
          description: A successful response.
          schema:
            $ref: "#/definitions/rewindResponse"
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - UserAPI
```
### Coverage:
From: `threshold=52.7`
To: `threshold=53.00`
