### PR TITLE
Updated BasicDashboard UI to expand drives initially if single server

### DIFF
--- a/portal-ui/src/screens/Console/Dashboard/BasicDashboard/ServersList.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/BasicDashboard/ServersList.tsx
@@ -27,7 +27,7 @@ import { Box } from "@mui/material";
 import DriveInfoItem from "./DriveInfoItem";
 
 const ServersList = ({ data }: { data: ServerInfo[] }) => {
-  const [expanded, setExpanded] = React.useState<string>("");
+  const [expanded, setExpanded] = React.useState<string>(data.length >1 ? "" : data[0].endpoint+"-0");
 
   const handleClick = (key: string) => {
     setExpanded(key);


### PR DESCRIPTION
**How it looks:**

![Screenshot from 2022-03-25 11-54-03](https://user-images.githubusercontent.com/65002498/160183929-d97b06d3-0420-4609-bd00-d593d4bfec53.png)

Addresses https://github.com/miniohq/engineering/issues/659