### PR TITLE
Fixed loader for LinearGraphWidget

### DIFF
--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/LinearGraphWidget.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/LinearGraphWidget.tsx
@@ -92,7 +92,10 @@ const styles = (theme: Theme) =>
       fontSize: 12,
     },
     loadingAlign: {
-      margin: "auto",
+      width: 40,
+      height: 40,
+      textAlign: "center",
+      margin: "15px auto",
     },
   });
 


### PR DESCRIPTION
## What does this do?

Fixes Loader size for LinearGraphWidget

## How does it look?

<img width="1306" alt="Screen Shot 2022-03-29 at 18 42 07" src="https://user-images.githubusercontent.com/33497058/160730143-70697105-87c7-4ca7-88da-d50a0261278d.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>