### PR TITLE
Hide redundant folder references in console

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -493,7 +493,12 @@ const ListObjects = ({
           .then((res: RewindObjectList) => {
             setLoadingRewind(false);
             if (res.objects) {
-              setRewind(res.objects);
+              // We omit files from the same path
+              const filteredObjects = res.objects.filter((object) => {
+                 return object.name !== decodeFileName(internalPaths)
+              })
+
+              setRewind(filteredObjects);
             } else {
               setRewind([]);
             }
@@ -558,12 +563,15 @@ const ListObjects = ({
             const files: BucketObject[] = [];
 
             records.forEach((record) => {
-              // this is a folder
-              if (record.name.endsWith("/")) {
-                folders.push(record);
-              } else {
-                // this is a file
-                files.push(record);
+              // We omit files from the same path
+              if (record.name !== decodeFileName(internalPaths)) {
+                // this is a folder
+                if (record.name.endsWith("/")) {
+                  folders.push(record);
+                } else {
+                  // this is a file
+                  files.push(record);
+                }
               }
             });
             const recordsInElement = [...folders, ...files];
@@ -1051,7 +1059,6 @@ const ListObjects = ({
   const currentPath = pageTitle.split("/").filter((i: string) => i !== "");
 
   const plSelect = rewindEnabled ? rewind : filteredRecords;
-
   const sortASC = plSelect.sort(sortListObjects(currentSortField));
 
   let payload: BucketObject[] | RewindObject[] = [];


### PR DESCRIPTION
## What does this do?

Hides objects with the same path as current location in object browser

## How to test?

1. Create a bucket called test using `mc mb myminio/test/ -l`
2. Create a folder inside of it using the mb command `mc mb myminio/test/prefix/`
3. Copy a file inside the created folder `mc cp file play/test/prefix/file`

## How does it look?

Before:
<img width="1197" alt="Screen Shot 2022-03-31 at 13 43 39" src="https://user-images.githubusercontent.com/33497058/161136397-86e3e700-21d6-4d29-9e88-c202e0e136c0.png">

After:
<img width="1382" alt="Screen Shot 2022-03-31 at 13 38 33" src="https://user-images.githubusercontent.com/33497058/161135878-c78feb12-9cf1-41ad-8780-b9c5b6359eac.png">


Observe prefix folder is not showing anymore  in the objects listing


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>