### PR TITLE
Don't display "NaN B" in tenant capacity

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/ListTenants/TenantCapacity.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/TenantCapacity.tsx
@@ -123,7 +123,7 @@ const TenantCapacity = ({
           fontSize: 12,
         }}
       >
-        {niceBytesInt(totalUsedSpace)}
+        {!isNaN(totalUsedSpace) ? niceBytesInt(totalUsedSpace) : "N/A"}
       </span>
       <div>
         <PieChart width={110} height={110}>


### PR DESCRIPTION
## What does this do?

Don't display `NaN B` text when capacity information is not reachable

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>