### PR TITLE
Fixed assign policies screens

### DIFF
--- a/portal-ui/src/screens/Console/Groups/AddGroupMember.tsx
+++ b/portal-ui/src/screens/Console/Groups/AddGroupMember.tsx
@@ -80,17 +80,20 @@ const AddGroupMember = ({
       title={title}
       titleIcon={<AddMembersToGroupIcon />}
     >
-      <div className={classes.formFieldRow}>
-        <PredefinedList label={`Selected Group`} content={selectedGroup} />
-      </div>
-      <div className={classes.userSelector}>
-        <UsersSelectors
-          selectedUsers={selectedUsers}
-          setSelectedUsers={setSelectedUsers}
-          editMode={!selectedGroup}
-        />
-      </div>
-
+      <Grid container>
+        <Grid item xs={12}>
+          <div className={classes.formFieldRow}>
+            <PredefinedList label={`Selected Group`} content={selectedGroup} />
+          </div>
+          <div className={classes.userSelector}>
+            <UsersSelectors
+              selectedUsers={selectedUsers}
+              setSelectedUsers={setSelectedUsers}
+              editMode={!selectedGroup}
+            />
+          </div>
+        </Grid>
+      </Grid>
       <Grid item xs={12} className={classes.modalButtonBar}>
         <Button
           type="button"

--- a/portal-ui/src/screens/Console/Policies/SetPolicy.tsx
+++ b/portal-ui/src/screens/Console/Policies/SetPolicy.tsx
@@ -145,24 +145,28 @@ const SetPolicy = ({
       modalOpen={open}
       title="Set Policies"
     >
-      <Grid item xs={12}>
-        <PredefinedList
-          label={`Selected ${selectedGroup !== null ? "Group" : "User"}`}
-          content={selectedGroup !== null ? selectedGroup : userName}
-        />
+      <Grid container>
+        <Grid item xs={12}>
+          <PredefinedList
+            label={`Selected ${selectedGroup !== null ? "Group" : "User"}`}
+            content={selectedGroup !== null ? selectedGroup : userName}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <PredefinedList
+            label={"Current Policy"}
+            content={actualPolicy.join(", ")}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <div className={classes.tableBlock}>
+            <PolicySelectors
+              selectedPolicy={selectedPolicy}
+              setSelectedPolicy={setSelectedPolicy}
+            />
+          </div>
+        </Grid>
       </Grid>
-      <Grid item xs={12}>
-        <PredefinedList
-          label={"Current Policy"}
-          content={actualPolicy.join(", ")}
-        />
-      </Grid>
-      <div className={classes.tableBlock}>
-        <PolicySelectors
-          selectedPolicy={selectedPolicy}
-          setSelectedPolicy={setSelectedPolicy}
-        />
-      </div>
       <Grid item xs={12} className={classes.buttonContainer}>
         <Button
           type="button"

--- a/portal-ui/src/screens/Console/Users/SetUserPolicies.tsx
+++ b/portal-ui/src/screens/Console/Users/SetUserPolicies.tsx
@@ -1,20 +1,5 @@
 // This file is part of MinIO Console Server
-// Copyright (c) 2021 MinIO, Inc.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// This file is part of MinIO Console Server
-// Copyright (c) 2021 MinIO, Inc.
+// Copyright (c) 2022 MinIO, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -121,12 +106,13 @@ const SetUserPolicies = ({
       modalOpen={open}
       title="Set Policies"
     >
-      <PolicySelectors
-        selectedPolicy={selectedPolicy}
-        setSelectedPolicy={setSelectedPolicy}
-      />
-      <Grid item xs={12}>
-        <br />
+      <Grid container>
+        <Grid item xs={12}>
+          <PolicySelectors
+            selectedPolicy={selectedPolicy}
+            setSelectedPolicy={setSelectedPolicy}
+          />
+        </Grid>
       </Grid>
       <Grid item xs={12} className={classes.buttonContainer}>
         <button


### PR DESCRIPTION
fixes https://github.com/minio/console/issues/1814

## What does this do?

Fixed assign policies screens

- Add Users to policy
- Add Groups to policy
- Add Group member
- Set User Policies Modal

## How does it look?

<img width="994" alt="Screen Shot 2022-04-08 at 10 32 48" src="https://user-images.githubusercontent.com/33497058/162475203-cc364de5-0ed1-47c1-b78b-ad6460a40302.png">
<img width="1384" alt="Screen Shot 2022-04-08 at 10 30 38" src="https://user-images.githubusercontent.com/33497058/162475205-7583a2b7-5a3d-4def-9e7e-2f285a43f449.png">
<img width="1377" alt="Screen Shot 2022-04-08 at 10 30 26" src="https://user-images.githubusercontent.com/33497058/162475211-b581b5cf-5aeb-4b47-ba56-4c1e1d08a6a7.png">
<img width="1024" alt="Screen Shot 2022-04-08 at 10 29 08" src="https://user-images.githubusercontent.com/33497058/162475215-a3a83435-677f-40b3-947e-d7a320a834e6.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>