### PR TITLE
Remove duplicated versioned item in breadcrumbs

### DIFF
--- a/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
@@ -83,11 +83,19 @@ const BrowserBreadcrumbs = ({
   }
 
   const splitPaths = paths.split("/").filter((path) => path !== "");
+  const lastBreadcrumbsIndex = splitPaths.length - 1;
+
+
   let breadcrumbsMap = splitPaths.map((objectItem: string, index: number) => {
     const subSplit = splitPaths.slice(0, index + 1).join("/");
     const route = `/buckets/${bucketName}/browse/${
       subSplit ? `${encodeFileName(subSplit)}` : ``
     }`;
+
+    if(index === lastBreadcrumbsIndex && objectItem === versionedFile) {
+      return null;
+    }
+
     return (
       <Fragment key={`breadcrumbs-${index.toString()}`}>
         <span> / </span>


### PR DESCRIPTION
## What does this do?

Removes duplicated versioned item in breadcrumbs

## How does it look?

### BEFORE:
<img width="1376" alt="Screen Shot 2022-04-08 at 14 58 58" src="https://user-images.githubusercontent.com/33497058/162517873-1290e0bc-7072-49ec-9d3a-bc51bb759b9a.png">

### AFTER:
<img width="1105" alt="Screen Shot 2022-04-08 at 14 58 29" src="https://user-images.githubusercontent.com/33497058/162517905-c66e519c-2216-410c-bb39-b6e197b2b470.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>