### PR TITLE
Correcting the testing package in Operator API Tests

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1142,7 +1142,7 @@ jobs:
           result=${result%\%}
           echo "result:"
           echo $result
-          threshold=54.00
+          threshold=35.20
           if (( $(echo "$result >= $threshold" |bc -l) )); then
             echo "It is equal or greater than threshold, passed!"
           else

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ test-sso-integration:
 test-operator-integration:
 	@(echo "Start cd operator-integration && go test:")
 	@(pwd)
-	@(cd operator-integration && go test -coverpkg=../restapi -c -tags testrunmain . && mkdir -p coverage && ./operator-integration.test -test.v -test.run "^Test*" -test.coverprofile=coverage/operator-api.out)
+	@(cd operator-integration && go test -coverpkg=../operatorapi -c -tags testrunmain . && mkdir -p coverage && ./operator-integration.test -test.v -test.run "^Test*" -test.coverprofile=coverage/operator-api.out)
 
 test-operator:
 	@(env bash $(PWD)/portal-ui/tests/scripts/operator.sh)


### PR DESCRIPTION
We need to properly test `operatorapi` instead of `restapi`:

<img width="1840" alt="Screen Shot 2022-04-09 at 10 03 48 AM" src="https://user-images.githubusercontent.com/6667358/162577607-361510e9-4cb6-458b-8561-fef6315cf4f5.png">

I found this issue while adding a new test and looking at the coverage output in the html file.
We were touching `restapi` but we should be touching `operatorapi` instead; so I will correct that even if the coverage get decreased because we need to include all go packages not only restapi package.

### Coverage
```yaml
-          threshold=54.00
+          threshold=35.20
```
This is because `54.00` comes from `restapi` only, while `35.20` is the union of `restapi` & `operatorapi`