### PR TITLE
Adding unittest under user_watch.go

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1142,7 +1142,7 @@ jobs:
           result=${result%\%}
           echo "result:"
           echo $result
-          threshold=35.20
+          threshold=35.40
           if (( $(echo "$result >= $threshold" |bc -l) )); then
             echo "It is equal or greater than threshold, passed!"
           else


### PR DESCRIPTION
Prior this test, the coverage was:

<img width="1840" alt="Screen Shot 2022-04-12 at 11 08 07 AM" src="https://user-images.githubusercontent.com/6667358/162994120-1510aba3-46d8-4bbf-a59f-153767580fac.png">

After this test the coverage is:

<img width="1840" alt="Screen Shot 2022-04-12 at 11 08 29 AM" src="https://user-images.githubusercontent.com/6667358/162994208-e9054af2-077c-4c0d-a225-ee9104f74b52.png">

So the area of code covered by this test under `user_watch.go` is:
```go
                case <-ctx.Done():
                        close(wo.DoneChan)
                        return nil
```
