### PR TITLE
Replaced Usage bar in tenant details to display tiers information

### DIFF
--- a/portal-ui/src/screens/Console/Common/UsageBar/UsageBar.tsx
+++ b/portal-ui/src/screens/Console/Common/UsageBar/UsageBar.tsx
@@ -1,0 +1,65 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React from "react";
+
+export interface ISizeBarItem {
+  value: number;
+  itemName: string;
+  color: string;
+}
+
+export interface IUsageBar {
+  totalValue: number;
+  sizeItems: ISizeBarItem[];
+  bgColor?: string;
+}
+
+const UsageBar = ({
+  totalValue,
+  sizeItems,
+  bgColor = "#ededed",
+}: IUsageBar) => {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: 12,
+        backgroundColor: bgColor,
+        borderRadius: 30,
+        display: "flex",
+        transitionDuration: "0.3s",
+        overflow: "hidden",
+      }}
+    >
+      {sizeItems.map((sizeElement) => {
+        const itemPercentage = (sizeElement.value * 100) / totalValue;
+        return (
+          <div
+            style={{
+              width: `${itemPercentage}%`,
+              height: "100%",
+              backgroundColor: sizeElement.color,
+              transitionDuration: "0.3s",
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default UsageBar;

--- a/portal-ui/src/screens/Console/Tenants/ListTenants/ListTenants.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/ListTenants.tsx
@@ -21,7 +21,10 @@ import { LinearProgress } from "@mui/material";
 import { Theme } from "@mui/material/styles";
 import createStyles from "@mui/styles/createStyles";
 import withStyles from "@mui/styles/withStyles";
-import { ITenant, ITenantsResponse } from "./types";
+import {
+  ITenant,
+  ITenantsResponse,
+} from "./types";
 import { niceBytes } from "../../../../common/utils";
 import { NewServiceAccount } from "../../Common/CredentialsPrompt/types";
 import {

--- a/portal-ui/src/screens/Console/Tenants/ListTenants/TenantCapacity.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/TenantCapacity.tsx
@@ -19,17 +19,20 @@ import { Cell, Pie, PieChart } from "recharts";
 import { CapacityValue, CapacityValues } from "./types";
 import { niceBytesInt } from "../../../../common/utils";
 import { CircleIcon } from "../../../../icons";
+import UsageBar, { ISizeBarItem } from "../../Common/UsageBar/UsageBar";
 
 interface ITenantCapacity {
   totalCapacity: number;
   usedSpaceVariants: CapacityValues[];
   statusClass: string;
+  render?: "pie" | "bar";
 }
 
 const TenantCapacity = ({
   totalCapacity,
   usedSpaceVariants,
   statusClass,
+  render = "pie",
 }: ITenantCapacity) => {
   const colors = [
     "#8dacd3",
@@ -43,6 +46,8 @@ const TenantCapacity = ({
     "#e28cc1",
     "#2781B0",
   ];
+
+  const BGColor = "#ededed";
 
   const totalUsedSpace = usedSpaceVariants.reduce((acc, currValue) => {
     return acc + currValue.value;
@@ -88,14 +93,38 @@ const TenantCapacity = ({
   }
 
   const plotValues: CapacityValue[] = [
-    { value: emptySpace, color: "transparent", label: "Empty Space" },
     {
       value: standardTier.value,
       color: standardTierColor,
       label: "Used Space by Tenant",
     },
     ...tiersList,
+    {
+      value: emptySpace,
+      color: render === "bar" ? BGColor : "transparent",
+      label: "Empty Space",
+    },
   ];
+
+  if (render === "bar") {
+    const plotValuesForUsageBar: ISizeBarItem[] = plotValues.map((plotVal) => {
+      return {
+        value: plotVal.value,
+        color: plotVal.color,
+        itemName: plotVal.label,
+      };
+    });
+
+    return (
+      <div style={{ width: "100%", marginBottom: 15 }}>
+        <UsageBar
+          totalValue={totalCapacity}
+          sizeItems={plotValuesForUsageBar}
+          bgColor={BGColor}
+        />
+      </div>
+    );
+  }
 
   return (
     <div style={{ position: "relative", width: 110, height: 110 }}>
@@ -134,7 +163,7 @@ const TenantCapacity = ({
             dataKey="value"
             outerRadius={50}
             innerRadius={40}
-            fill="#ededed"
+            fill={BGColor}
             isAnimationActive={false}
             stroke={"none"}
           />

--- a/portal-ui/src/screens/Console/Tenants/ListTenants/types.ts
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/types.ts
@@ -148,7 +148,7 @@ export interface ITenant {
   image: string;
   pool_count: number;
   currentState: string;
-  instance_count: 4;
+  instance_count: number;
   creation_date: string;
   volume_size: number;
   volume_count: number;
@@ -269,4 +269,8 @@ export interface IEditPoolItem {
 
 export interface IEditPoolRequest {
   pools: IEditPoolItem[];
+}
+
+export interface IPlotBarValues {
+  [key: string]: CapacityValue;
 }

--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantSummary.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantSummary.tsx
@@ -123,10 +123,13 @@ const healthStatusToClass = (health_status: string = "red", classes: any) => {
 };
 
 const StorageSummary = ({ tenant, classes }: Partial<ITenantsSummary>) => {
+  if (!tenant) {
+    return null;
+  }
+
   return (
     <SummaryUsageBar
-      currValue={tenant?.status?.usage?.raw_usage}
-      maxValue={tenant?.status?.usage?.raw}
+      tenant={tenant}
       label={"Storage"}
       error={""}
       loading={false}


### PR DESCRIPTION
## What does this do?

Replaced Usage bar in tenant details to display tiers information

## How does it look?
<img width="1277" alt="Screen Shot 2022-04-13 at 22 35 14" src="https://user-images.githubusercontent.com/33497058/163309038-a10ed9b5-2587-4a53-a8e9-c180cc16405e.png">

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>