### PR TITLE
Fix early context cancellation when downloading/previewing object

### DIFF
--- a/restapi/user_objects.go
+++ b/restapi/user_objects.go
@@ -367,7 +367,7 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 }
 
 func getDownloadObjectResponse(session *models.Principal, params user_api.DownloadObjectParams) (middleware.Responder, *models.Error) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
 
 	var prefix string
 	mClient, err := newMinioClient(session)
@@ -396,7 +396,6 @@ func getDownloadObjectResponse(session *models.Principal, params user_api.Downlo
 
 	return middleware.ResponderFunc(func(rw http.ResponseWriter, _ runtime.Producer) {
 		defer resp.Close()
-		defer cancel()
 
 		isPreview := params.Preview != nil && *params.Preview
 		// indicate it's a download / inline content to the browser, and the size of the object

--- a/restapi/user_objects.go
+++ b/restapi/user_objects.go
@@ -468,8 +468,8 @@ func getDownloadObjectResponse(session *models.Principal, params user_api.Downlo
 	}), nil
 }
 func getDownloadFolderResponse(session *models.Principal, params user_api.DownloadObjectParams) (middleware.Responder, *models.Error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := context.Background()
+
 	var prefix string
 	mClient, err := newMinioClient(session)
 	if params.Prefix != "" {

--- a/restapi/user_objects.go
+++ b/restapi/user_objects.go
@@ -368,7 +368,7 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 
 func getDownloadObjectResponse(session *models.Principal, params user_api.DownloadObjectParams) (middleware.Responder, *models.Error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+
 	var prefix string
 	mClient, err := newMinioClient(session)
 	if err != nil {
@@ -396,6 +396,7 @@ func getDownloadObjectResponse(session *models.Principal, params user_api.Downlo
 
 	return middleware.ResponderFunc(func(rw http.ResponseWriter, _ runtime.Producer) {
 		defer resp.Close()
+		defer cancel()
 
 		isPreview := params.Preview != nil && *params.Preview
 		// indicate it's a download / inline content to the browser, and the size of the object


### PR DESCRIPTION
Fixes https://github.com/minio/console/issues/1844

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>