### PR TITLE
Correcting error message to be same as our code

### DIFF
--- a/restapi/user_watch_test.go
+++ b/restapi/user_watch_test.go
@@ -167,7 +167,7 @@ func TestWatch(t *testing.T) {
 				}
 				wo.Events() <- info
 			}
-			wo.Errors() <- &probe.Error{Cause: fmt.Errorf("error on Watch")}
+			wo.Errors() <- &probe.Error{Cause: fmt.Errorf("error on watch")}
 		}(wo)
 		return wo, nil
 	}
@@ -175,19 +175,19 @@ func TestWatch(t *testing.T) {
 		return nil
 	}
 	if err := startWatch(ctx, mockWSConn, client, testOptions); assert.Error(err) {
-		assert.Equal("error on Watch", err.Error())
+		assert.Equal("error on watch", err.Error())
 	}
 
 	// Test-4: error happens on Watch, watch should stop
 	// and error shall be returned.
 	mcWatchMock = func(ctx context.Context, params mc.WatchOptions) (*mc.WatchObject, *probe.Error) {
-		return nil, &probe.Error{Cause: fmt.Errorf("error on Watch")}
+		return nil, &probe.Error{Cause: fmt.Errorf("error on watch")}
 	}
 	if err := startWatch(ctx, mockWSConn, client, testOptions); assert.Error(err) {
-		assert.Equal("error on Watch", err.Error())
+		assert.Equal("error on watch", err.Error())
 	}
 
-	// Test-5: return nil on error on Watch
+	// Test-5: return nil on error on watch
 	mcWatchMock = func(ctx context.Context, params mc.WatchOptions) (*mc.WatchObject, *probe.Error) {
 		wo := &mc.WatchObject{
 			EventInfoChan: make(chan []mc.EventInfo),


### PR DESCRIPTION
I believe this is important specially because when looking for the error across our repo, case sensitive becomes important, example: `grep -R "error on Watch" . ` will be misleading since only test will expose the error. Let's be consistent with our tests in this sense. 