### PR TITLE
Make Login assets and redirects relative

### DIFF
--- a/portal-ui/src/ProtectedRoutes.tsx
+++ b/portal-ui/src/ProtectedRoutes.tsx
@@ -72,7 +72,7 @@ const ProtectedRoute = ({
     return null;
   }
   // redirect user to the right page based on session status
-  return loggedIn ? <Component /> : <Redirect to={{ pathname: "/login" }} />;
+  return loggedIn ? <Component /> : <Redirect to={{ pathname: "login" }} />;
 };
 
 const mapState = (state: AppState) => ({

--- a/portal-ui/src/Routes.tsx
+++ b/portal-ui/src/Routes.tsx
@@ -46,7 +46,7 @@ const Routes = () => {
           children={(routerProps) => (
             <div
               style={{
-                backgroundImage: `url('/images/background-wave-orig2.svg'), url('/images/background.svg')`,
+                backgroundImage: `url('images/background-wave-orig2.svg'), url('images/background.svg')`,
                 backgroundPosition: "center 250px, center center",
                 backgroundRepeat: "no-repeat",
                 backgroundSize: "2547px 980px,cover",

--- a/portal-ui/src/common/api/index.ts
+++ b/portal-ui/src/common/api/index.ts
@@ -37,7 +37,7 @@ export class API {
           clearSession();
           // Refresh the whole page to ensure cache is clear
           // and we dont end on an infinite loop
-          window.location.href = "/login";
+          window.location.href = "login";
           return;
         }
         return this.onError(err);
@@ -71,7 +71,7 @@ export class API {
       return Promise.reject(throwMessage);
     } else {
       clearSession();
-      window.location.href = "/login";
+      window.location.href = "login";
     }
   }
 }

--- a/portal-ui/src/screens/Console/Menu/Menu.tsx
+++ b/portal-ui/src/screens/Console/Menu/Menu.tsx
@@ -107,7 +107,7 @@ const Menu = ({
       userLoggedIn(false);
       localStorage.setItem("userLoggedIn", "");
       resetSession();
-      history.push("/login");
+      history.push("login");
     };
     api
       .invoke("POST", `/api/v1/logout`)

--- a/portal-ui/src/screens/LoginPage/LoginCallback.tsx
+++ b/portal-ui/src/screens/LoginPage/LoginCallback.tsx
@@ -175,7 +175,7 @@ const LoginCallback = ({ classes }: ILoginCallBackProps) => {
             </Typography>
             <Button
               component={"a"}
-              href="/login"
+              href="login"
               type="submit"
               variant="contained"
               color="primary"


### PR DESCRIPTION
There's a bug when using `subpath` that prevents the login assets from loading relative to the serving path

Current:
<img width="1392" alt="Screen Shot 2022-04-15 at 6 54 27 PM" src="https://user-images.githubusercontent.com/18384552/163657535-63906505-f979-4e46-ae03-f50019649b99.png">


After Fix:

<img width="1392" alt="Screen Shot 2022-04-15 at 7 06 26 PM" src="https://user-images.githubusercontent.com/18384552/163657536-c8a31b7f-3712-45ec-a987-58843ca9fce0.png">


To test:

Run MinIO Like
```shell
MINIO_CONSOLE_SUBPATH="/console/quack/" CI=true ./minio server /tmp/newdisk{1...4} --address :9001 --console-address :9091
```

start nginx with the following config
```
events { worker_connections 1024; }

http {

server {
    listen 8000;

    location /console/quack/ {
        rewrite   ^/console/quack/(.*) /$1 break;
        proxy_pass http://localhost:9091;
    }
}

}
```

Visit http://localhost:8000/console/quack/


Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>