### PR TITLE
Recalibrating our coverage threshold

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1142,7 +1142,7 @@ jobs:
           result=${result%\%}
           echo "result:"
           echo $result
-          threshold=36.5
+          threshold=36.3
           if (( $(echo "$result >= $threshold" |bc -l) )); then
             echo "It is equal or greater than threshold, passed!"
           else


### PR DESCRIPTION
The problem started back in https://github.com/minio/console/pull/1850/checks where code was merged regardless of the test failure. Then it got propagated to next PR and so on, affected PRs are:

- https://github.com/minio/console/pull/1865/checks
- https://github.com/minio/console/pull/1866/checks
- https://github.com/minio/console/pull/1808/checks
- https://github.com/minio/console/pull/1848/checks
- https://github.com/minio/console/pull/1850/checks

