### PR TITLE
Removing unnecessary error check

### DIFF
--- a/restapi/user_watch.go
+++ b/restapi/user_watch.go
@@ -51,13 +51,9 @@ func startWatch(ctx context.Context, conn WSConn, wsc MCClient, options *watchOp
 			}
 			for _, event := range events {
 				// Serialize message to be sent
-				bytes, err := json.Marshal(event)
-				if err != nil {
-					LogError("error on json.Marshal: %v", err)
-					return err
-				}
+				bytes, _ := json.Marshal(event)
 				// Send Message through websocket connection
-				err = conn.writeMessage(websocket.TextMessage, bytes)
+				err := conn.writeMessage(websocket.TextMessage, bytes)
 				if err != nil {
 					LogError("error writeMessage: %v", err)
 					return err


### PR DESCRIPTION
Fixes: https://github.com/miniohq/engineering/issues/742

Our `struct` in `watch.go` as is, will never breake `json.Marshal` in `startWatch()` there are only two possible scenarios that can break it, an unsupported type, which we don't have or an unsupported value like `math.Inf(1)` that we can't have since no `float` is being currently used. So as long as the type doesn't change, the err can safely be ignored. In return, this will increment our code coverage.

```go
type EventInfo struct {
	Time         string
	Size         int64
	UserMetadata map[string]string
	Path         string
	Host         string
	Port         string
	UserAgent    string
	Type         notification.EventType <---- This is string type
}
```

Reference: [What input will cause golang's json.Marshal to return an error?](https://stackoverflow.com/questions/33903552/what-input-will-cause-golangs-json-marshal-to-return-an-error)