### PR TITLE
Test change password response

### DIFF
--- a/restapi/user_account_test.go
+++ b/restapi/user_account_test.go
@@ -22,9 +22,31 @@ import (
 	"testing"
 
 	"github.com/minio/console/models"
+	"github.com/minio/console/restapi/operations/user_api"
+	"github.com/stretchr/testify/assert"
 )
 
 var minioChangePasswordMock func(ctx context.Context, accessKey, secretKey string) error
+
+func Test_getChangePasswordResponse(t *testing.T) {
+	assert := assert.New(t)
+	session := &models.Principal{
+		AccountAccessKey: "TESTTEST",
+	}
+	CurrentSecretKey := "string"
+	NewSecretKey := "string"
+	changePasswordParameters := user_api.AccountChangePasswordParams{
+		Body: &models.AccountChangePasswordRequest{
+			CurrentSecretKey: &CurrentSecretKey,
+			NewSecretKey:     &NewSecretKey,
+		},
+	}
+	loginResponse, actualError := getChangePasswordResponse(session, changePasswordParameters)
+	expected := (*models.LoginResponse)(nil)
+	assert.Equal(expected, loginResponse)
+	expectedError := "error please check your current password" // errChangePassword
+	assert.Equal(expectedError, *actualError.DetailedMessage)
+}
 
 func Test_changePassword(t *testing.T) {
 	client := adminClientMock{}


### PR DESCRIPTION
Fixes: https://github.com/miniohq/engineering/issues/805

The idea is to cover a new region of code in `user_account.go` that is not covered yet:

<img width="1718" alt="Screen Shot 2022-04-20 at 11 12 13 AM" src="https://user-images.githubusercontent.com/6667358/164263601-7c9da788-70d2-41c2-ac71-26ff5cf9f73b.png">
