### PR TITLE
Fixed breadcrumbs container overflow in object browser

### DIFF
--- a/portal-ui/src/index.tsx
+++ b/portal-ui/src/index.tsx
@@ -102,7 +102,7 @@ const GlobalCss = withStyles({
     ul: {
       paddingLeft:20,
       listStyle: "none", /* Remove default bullets */
-      "& li::before": {
+      "& li::before:not(.Mui*)": {
         content: '"￭"',
         color: "#2781B0",
         fontSize: 20,
@@ -113,7 +113,7 @@ const GlobalCss = withStyles({
       },
       "& ul": {
         listStyle: "none", /* Remove default bullets */
-        "& li::before": {
+        "& li::before:not(.Mui*)": {
           content: '"￮"',
           color: "#2781B0",
           fontSize: 20,

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -1342,8 +1342,11 @@ const ListObjects = ({
                 resource={bucketName}
                 errorProps={{ disabled: true }}
               >
-                <Grid item xs={12}>
-                  <Grid item xs={12} className={classes.breadcrumbsContainer}>
+                <Grid
+                  item
+                  xs={12}
+                >
+                  <Grid item xs={12} className={classes.breadcrumbsContainer} >
                     <BrowserBreadcrumbs
                       bucketName={bucketName}
                       internalPaths={pageTitle}

--- a/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
+++ b/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
@@ -411,8 +411,12 @@ export const objectBrowserCommon = {
     textAlign: "left" as const,
     marginLeft: 15,
     marginRight: 10,
+    width: 0, // WA to avoid overflow if child elements in flexbox list.**
   },
 };
+
+// ** According to W3 spec, default minimum values for flex width flex-grow is "auto" (https://drafts.csswg.org/css-flexbox/#min-size-auto). So in this case we need to enforce the use of an absolute width.
+// "The preferred width of a box element child containing text content is currently the text without line breaks, leading to very unintuitive width and flex calculations → declare a width on a box element child with more than a few words (ever wonder why flexbox demos are all “1,2,3”?)"
 
 export const selectorsCommon = {
   multiSelectTable: {
@@ -1365,6 +1369,9 @@ export const detailsPanel: any = {
       },
       "&:last-of-type": {
         borderBottom: 0,
+      },
+      "&::before": {
+        content: "' '",
       },
     },
   },


### PR DESCRIPTION
## What does this do?

Fixed breadcrumbs container overflow in object browser for screen resolutions greater than 1062px. 

An upcoming PR will add special handlers for mobile devices

## How does it look?

<img width="1057" alt="Screen Shot 2022-04-20 at 20 30 41" src="https://user-images.githubusercontent.com/33497058/164353689-df03efc8-53ed-4cf8-bac1-de3cecdd1f42.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>