### PR TITLE
Removed spaces next to breadcrumbs slashes

### DIFF
--- a/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
@@ -60,6 +60,9 @@ interface IObjectBrowser {
 const styles = (theme: Theme) =>
   createStyles({
     ...objectBrowserCommon,
+    slashSpacingStyle: {
+      margin: "0 5px",
+    }
   });
 
 const BrowserBreadcrumbs = ({
@@ -97,7 +100,7 @@ const BrowserBreadcrumbs = ({
 
     return (
       <Fragment key={`breadcrumbs-${index.toString()}`}>
-        <span> / </span>
+        <span className={classes.slashSpacingStyle}>/</span>
         {index === lastBreadcrumbsIndex ? (
           <span style={{ cursor: "default" }}>{objectItem}</span>
         ) : (
@@ -119,7 +122,7 @@ const BrowserBreadcrumbs = ({
   if (versionsMode) {
     versionsItem = [
       <Fragment key={`breadcrumbs-versionedItem`}>
-        <span> / {versionedFile} - Versions</span>
+        <span><span className={classes.slashSpacingStyle}>/</span>{versionedFile} - Versions</span>
       </Fragment>,
     ];
   }


### PR DESCRIPTION
fixes https://github.com/minio/console/issues/1793

## What does this do?

First step to allow people copy object browser path from breadcrumbs bar

## How does it look?

### BEFORE:
<img width="457" alt="Screen Shot 2022-04-25 at 14 50 41" src="https://user-images.githubusercontent.com/33497058/165164317-431c971b-b1b8-4fc5-bc7b-1be526fa05e5.png">

### AFTER:
<img width="637" alt="Screen Shot 2022-04-25 at 14 49 56" src="https://user-images.githubusercontent.com/33497058/165164361-6664c954-7daa-41be-8395-63538656a1e8.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>