### PR TITLE
Removed quota from versioning section & added inside summary page

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/BucketSummaryPanel.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/BucketSummaryPanel.tsx
@@ -510,6 +510,14 @@ const BucketSummary = ({
                     }
                   />
                 </Box>
+                <EditablePropertyItem
+                    iamScopes={[IAM_SCOPES.ADMIN_SET_BUCKET_QUOTA]}
+                    resourceName={bucketName}
+                    property={"Quota:"}
+                    value={quotaEnabled ? "Enabled" : "Disabled"}
+                    onEdit={setBucketQuota}
+                    isLoading={loadingQuota}
+                />
               </Box>
 
               <Box
@@ -520,6 +528,9 @@ const BucketSummary = ({
                 }}
               >
                 <ReportedUsage bucketSize={bucketSize} />
+                {quotaEnabled && quota ? (
+                    <BucketQuotaSize quota={quota} />
+                ) : null}
               </Box>
             </Box>
           </Grid>
@@ -546,31 +557,11 @@ const BucketSummary = ({
                   <EditablePropertyItem
                     iamScopes={[IAM_SCOPES.S3_PUT_BUCKET_VERSIONING]}
                     resourceName={bucketName}
-                    property={"Versioning:"}
-                    value={isVersioned ? "Enabled" : "Disabled"}
+                    property={"Current Status:"}
+                    value={isVersioned ? "Enabled" : "Unversioned (Default)"}
                     onEdit={setBucketVersioning}
                     isLoading={loadingVersioning}
                   />
-
-                  <EditablePropertyItem
-                    iamScopes={[IAM_SCOPES.ADMIN_SET_BUCKET_QUOTA]}
-                    resourceName={bucketName}
-                    property={"Quota:"}
-                    value={quotaEnabled ? "Enabled" : "Disabled"}
-                    onEdit={setBucketQuota}
-                    isLoading={loadingQuota}
-                  />
-                </Box>
-                <Box
-                  sx={{
-                    display: "grid",
-                    gridTemplateColumns: "1fr",
-                    alignItems: "flex-start",
-                  }}
-                >
-                  {quotaEnabled && quota ? (
-                    <BucketQuotaSize quota={quota} />
-                  ) : null}
                 </Box>
               </Box>
             </Grid>


### PR DESCRIPTION
## What does this do?

Applied some changes in versioning section for bucket details page. (Removed quota from that section & moved into summary)

## How does it look?

<img width="1549" alt="Screen Shot 2022-04-26 at 23 03 21" src="https://user-images.githubusercontent.com/33497058/165438470-6334449f-482b-40d3-a3a1-0a9592b9167b.png">
<img width="1565" alt="Screen Shot 2022-04-26 at 23 02 47" src="https://user-images.githubusercontent.com/33497058/165438473-e6582976-c033-4329-8d6a-a6d49cd0ae90.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>