### PR TITLE
Constraint PageLayout to max 1220px on large resolutions

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -1212,7 +1212,7 @@ const ListObjects = ({
           onClosePreview={closePreviewWindow}
         />
       )}
-      <PageLayout>
+      <PageLayout variant={"full"}>
         <Grid item xs={12} className={classes.screenTitleContainer}>
           <ScreenTitle
             className={classes.screenTitle}

--- a/portal-ui/src/screens/Console/Common/Layout/PageLayout.tsx
+++ b/portal-ui/src/screens/Console/Common/Layout/PageLayout.tsx
@@ -13,14 +13,21 @@ const styles = (theme: Theme) =>
 type PageLayoutProps = {
   className?: string;
   classes?: any;
+  variant?: "constrained" | "full";
   children: any;
 };
 
-const PageLayout = ({ classes, className = "", children }: PageLayoutProps) => {
+const PageLayout = ({
+  classes,
+  className = "",
+  children,
+  variant = "constrained",
+}: PageLayoutProps) => {
+  let style = variant === "constrained" ? { maxWidth: 1220 } : {};
   return (
     <div className={classes.contentSpacer}>
       <Grid container>
-        <Grid item xs={12} className={className}>
+        <Grid item xs={12} className={className} style={style}>
           {children}
         </Grid>
       </Grid>


### PR DESCRIPTION
All pages constrained
<img width="2672" alt="Screen Shot 2022-04-28 at 12 55 13 PM" src="https://user-images.githubusercontent.com/18384552/165834997-cf9870ea-9066-401a-80b6-ea682ea5e211.png">
<img width="2672" alt="Screen Shot 2022-04-28 at 12 55 06 PM" src="https://user-images.githubusercontent.com/18384552/165834998-fbfe9e94-2edc-45e2-91d8-69b4c7f55bc1.png">

Except object browser

<img width="2672" alt="Screen Shot 2022-04-28 at 12 55 27 PM" src="https://user-images.githubusercontent.com/18384552/165834992-580988de-cd23-4859-afa0-d76aa5114152.png">

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>