### PR TITLE
Remove of suspended traffic warning in profile page

### DIFF
--- a/portal-ui/src/screens/Console/Support/Profile.tsx
+++ b/portal-ui/src/screens/Console/Support/Profile.tsx
@@ -13,7 +13,6 @@ import {
   containerForHeader,
   inlineCheckboxes,
 } from "../Common/FormComponents/common/styleLibrary";
-import HelpBox from "../../../common/HelpBox";
 import WarnIcon from "../../../icons/WarnIcon";
 
 const styles = (theme: Theme) =>

--- a/portal-ui/src/screens/Console/Support/Profile.tsx
+++ b/portal-ui/src/screens/Console/Support/Profile.tsx
@@ -179,18 +179,6 @@ const Profile = ({ classes }: IProfileProps) => {
             </Button>
           </Grid>
         </Grid>
-        {!profilingStarted && (
-          <Fragment>
-            <br />
-            <HelpBox
-              title={
-                "During the profiling run all production traffic will be suspended."
-              }
-              iconComponent={<WarnIcon />}
-              help={<Fragment />}
-            />
-          </Fragment>
-        )}
       </PageLayout>
     </Fragment>
   );

--- a/portal-ui/src/screens/Console/Support/Profile.tsx
+++ b/portal-ui/src/screens/Console/Support/Profile.tsx
@@ -13,7 +13,6 @@ import {
   containerForHeader,
   inlineCheckboxes,
 } from "../Common/FormComponents/common/styleLibrary";
-import WarnIcon from "../../../icons/WarnIcon";
 
 const styles = (theme: Theme) =>
   createStyles({


### PR DESCRIPTION
## What does this do?

Removed suspended traffic warning in profile page as traffic doesn't get blocked & it is needed for this tool to work correctly

## How does it look?

<img width="1767" alt="Screen Shot 2022-04-28 at 19 44 49" src="https://user-images.githubusercontent.com/33497058/165869339-7e419d50-48ed-447e-b286-e9a133e8ea14.png">



Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>