### PR TITLE
Center the constrained layout like SUBNET

### DIFF
--- a/portal-ui/src/screens/Console/Common/Layout/PageLayout.tsx
+++ b/portal-ui/src/screens/Console/Common/Layout/PageLayout.tsx
@@ -23,10 +23,20 @@ const PageLayout = ({
   children,
   variant = "constrained",
 }: PageLayoutProps) => {
-  let style = variant === "constrained" ? { maxWidth: 1220 } : {};
+  let style =
+    variant === "constrained"
+      ? { maxWidth: 1220, width: "100%" }
+      : { width: "100%" };
   return (
     <div className={classes.contentSpacer}>
-      <Grid container>
+      <Grid
+        container
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          flexFlow: "column",
+        }}
+      >
         <Grid item xs={12} className={className} style={style}>
           {children}
         </Grid>


### PR DESCRIPTION
Minor tweak to make the content area spaced evenly on the left and right similar to SUBNET.

![image](https://user-images.githubusercontent.com/23444145/165883629-93610c84-8775-4987-8b6b-ca2b4d3d8397.png)

![image](https://user-images.githubusercontent.com/23444145/165883657-dd2614b1-221d-42f5-8b3e-eeb8072fda09.png)

![image](https://user-images.githubusercontent.com/23444145/165883676-91c9ea6d-c92e-4ca2-853b-7c33963115fa.png)
