### PR TITLE
Having Identity Provider configured via environment variables only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,18 +164,12 @@ test-sso-integration:
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-e MINIO_IDENTITY_OPENID_CLIENT_SECRET=0nfJuqIt0iPnRIUJkvetve5l38C6gi9W \
+	-e MINIO_IDENTITY_OPENID_CONFIG_URL=http://keycloak-container:8080/auth/realms/myrealm/.well-known/openid-configuration \
+	-e MINIO_IDENTITY_OPENID_CLIENT_ID="account" \
 	-e MINIO_ROOT_USER=minio \
 	-e MINIO_ROOT_PASSWORD=minio123 $(MINIO_VERSION) server /data{1...4} --address :9000 --console-address :9001)
-	@(sleep 60)
-	@echo "run mc commands"
-	@(docker run --name minio-client --network my-net -dit --entrypoint=/bin/sh minio/mc)
-	@(docker exec minio-client mc alias set myminio/ http://minio:9000 minio minio123)
-	@(docker exec minio-client mc admin config set myminio identity_openid config_url="http://keycloak-container:8080/auth/realms/myrealm/.well-known/openid-configuration" client_id="account")
-	@(docker exec minio-client mc admin service restart myminio)
 	@echo "starting bash script"
 	@(env bash $(PWD)/sso-integration/set-sso.sh)
-	@echo "install jq"
-	@(sudo apt install jq)
 	@echo "Executing the test:"
 	@(cd sso-integration && go test -coverpkg=../restapi -c -tags testrunmain . && mkdir -p coverage && ./sso-integration.test -test.v -test.run "^Test*" -test.coverprofile=coverage/sso-system.out)
 


### PR DESCRIPTION
This will fix our current SSO Failure in GitHub Actions...

@alevsk you were totally correct, SSO test is fixed by removing the mc commands and having all the configuration on the environment variables, not even needed to restart the minio server, which will save time and lines. Also responding more formally to your question, there is this beautiful java tool ran in keycloak-config-cli container that using a json located in `console/sso-integration/config/realm-export.json` configure the entire idp on the fly on every PR :slightly_smiling_face: but as you will notice it contains more than 2K lines and I am pretty sure, very few are actually needed, but I will need to be removing and selecting very carefully only those that are actually needed; like I don't think the ids are needed since they change on every new installation: `"id": "e8591a82-12bf-4fc1-8718-b1f9e1b9ca1b",` will try eventually to minimize the file as much as human possible :stuck_out_tongue:

Also there is a comment from @harshavardhana that I still need to follow up from last Sunday I think:

```
this entire test can be simplified by using https://github.com/minio/minio-iam-testing
IAM integration tests
this would give you some ideas
```

But in the meantime, let's have test running at least. 