### PR TITLE
Test remote buckets WIP

### DIFF
--- a/integration/buckets_test.go
+++ b/integration/buckets_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 var token string
+var token2 string
 
 func encodeBase64(fileName string) string {
 	/*
@@ -93,7 +94,7 @@ func initConsoleServer() (*restapi.Server, error) {
 func TestMain(m *testing.M) {
 	// start console server
 	go func() {
-		fmt.Println("start server")
+		fmt.Println("start server 9090")
 		srv, err := initConsoleServer()
 		if err != nil {
 			log.Println(err)
@@ -102,6 +103,7 @@ func TestMain(m *testing.M) {
 		}
 		srv.Serve()
 	}()
+
 
 	fmt.Println("sleeping")
 	time.Sleep(2 * time.Second)

--- a/integration/remote_buckets_test.go
+++ b/integration/remote_buckets_test.go
@@ -1,0 +1,329 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/minio/console/models"
+	"github.com/minio/console/restapi"
+	"github.com/minio/madmin-go"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func AddRemoteBucket(accessKey string, secretKey string, targetURL string, sourceBucket string, targetBucket string) (string, error) {
+	ctx := context.Background()
+	mAdminClient, err := restapi.NewMinioAdminClient(&models.Principal{
+		STSAccessKeyID:     "minioadmin",
+		STSSecretAccessKey: "minioadmin",
+	})
+	u, err := url.Parse(targetURL)
+
+	host := u.Host
+	if u.Port() == "" {
+		port := 80
+		host = host + ":" + strconv.Itoa(port)
+	}
+	creds := &madmin.Credentials{AccessKey: accessKey, SecretKey: secretKey}
+	remoteBucket := &madmin.BucketTarget{
+		TargetBucket:    targetBucket,
+		Secure:          false,
+		Credentials:     creds,
+		Endpoint:        host,
+		Path:            "",
+		API:             "s3v4",
+		Type:            "replication",
+		Region:          "",
+		ReplicationSync: true,
+	}
+	bucketARN, err := mAdminClient.SetRemoteTarget(ctx, sourceBucket, remoteBucket)
+
+	return bucketARN, err
+
+}
+
+func Test_AddRemoteBucketAPI(t *testing.T) {
+	assert := assert.New(t)
+
+	AddBucket("remotebucketsource", false, true, nil, nil)
+
+	type args struct {
+		accessKey    string
+		secretKey    string
+		targetURL    string
+		sourceBucket string
+		targetBucket string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		expectedStatus int
+		expectedError  error
+	}{
+		{
+			name: "Create Remote Bucket - Valid",
+			args: args{
+				accessKey:    "minioadmin",
+				secretKey:    "minioadmin",
+				targetURL:    "https://play.min.io/",
+				sourceBucket: "remotebucketsource",
+				targetBucket: os.Getenv("THETARGET"),
+			},
+			expectedStatus: 201,
+			expectedError:  nil,
+		},
+		{
+			name: "Create Remote Bucket - Invalid",
+			args: args{
+				accessKey:    "minioadmin",
+				secretKey:    "minioadmin123",
+				targetURL:    "https://play.min.io/",
+				sourceBucket: "remotebucketsource",
+				targetBucket: os.Getenv("THETARGET"),
+			},
+			expectedStatus: 500,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			client := &http.Client{
+				Timeout: 3 * time.Second,
+			}
+
+			// Add policy
+
+			requestDataPolicy := map[string]interface{}{}
+			requestDataPolicy["accessKey"] = tt.args.accessKey
+			requestDataPolicy["secretKey"] = tt.args.secretKey
+			requestDataPolicy["targetURL"] = tt.args.targetURL
+			requestDataPolicy["sourceBucket"] = tt.args.sourceBucket
+			requestDataPolicy["targetBucket"] = tt.args.targetBucket
+
+			requestDataJSON, _ := json.Marshal(requestDataPolicy)
+			requestDataBody := bytes.NewReader(requestDataJSON)
+			request, err := http.NewRequest(
+				"POST", "http://localhost:9090/api/v1/remote-buckets", requestDataBody)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+			request.Header.Add("Content-Type", "application/json")
+			response, err := client.Do(request)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			if response != nil {
+				assert.Equal(tt.expectedStatus, response.StatusCode, "Status Code is incorrect")
+			}
+
+		})
+	}
+
+}
+
+func Test_ListRemoteBucketAPI(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name           string
+		expectedStatus int
+		expectedError  error
+	}{
+		{
+			name: "List Remote Bucket - Valid",
+			expectedStatus: 200,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			client := &http.Client{
+				Timeout: 3 * time.Second,
+			}
+
+			// Add policy
+
+			requestDataPolicy := map[string]interface{}{}
+
+			requestDataJSON, _ := json.Marshal(requestDataPolicy)
+			requestDataBody := bytes.NewReader(requestDataJSON)
+			request, err := http.NewRequest(
+				"GET", "http://localhost:9090/api/v1/remote-buckets", requestDataBody)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+			request.Header.Add("Content-Type", "application/json")
+			response, err := client.Do(request)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			if response != nil {
+				assert.Equal(tt.expectedStatus, response.StatusCode, "Status Code is incorrect")
+			}
+
+		})
+	}
+
+}
+
+func Test_GetRemoteBucketAPI(t *testing.T) {
+	assert := assert.New(t)
+
+	type args struct {
+		api            string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		expectedStatus int
+		expectedError  error
+	}{
+		{
+			name: "Get Remote Bucket - Valid",
+			args: args{
+				"remotebucketsource",
+				},
+			expectedStatus: 200,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			client := &http.Client{
+				Timeout: 3 * time.Second,
+			}
+
+			// Add policy
+
+			requestDataPolicy := map[string]interface{}{}
+
+			requestDataJSON, _ := json.Marshal(requestDataPolicy)
+			requestDataBody := bytes.NewReader(requestDataJSON)
+			request, err := http.NewRequest(
+				"GET", "http://localhost:9090/api/v1/remote-buckets", requestDataBody)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+			request.Header.Add("Content-Type", "application/json")
+			response, err := client.Do(request)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			if response != nil {
+				assert.Equal(tt.expectedStatus, response.StatusCode, "Status Code is incorrect")
+			}
+
+		})
+	}
+
+}
+
+func Test_DeleteRemoteBucketAPI(t *testing.T) {
+	assert := assert.New(t)
+
+	AddBucket("remotebucketdeletesource", false, true, map[string]interface{}{}, map[string]interface{}{})
+	arn, _ := AddRemoteBucket("minioadmin", "minioadmin", "https://play.min.io/", "remotebucketdeletesource", os.Getenv("THETARGET"))
+
+	type args struct {
+		api string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		expectedStatus int
+		expectedError  error
+		verb           string
+	}{
+		{
+			name: "Delete Remote Bucket - Valid",
+			args: args{
+				api: fmt.Sprintf("/remote-buckets/%s/%s", os.Getenv("THETARGET"), arn),
+			},
+			expectedStatus: 201,
+			expectedError:  nil,
+			verb:           "DELETE",
+		},
+		{
+			name: "Delete Remote Bucket - Invalid",
+			args: args{
+				api: "/remote-buckets/fakebucket/fakearn",
+			},
+			expectedStatus: 500,
+			expectedError:  nil,
+			verb:           "DELETE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			client := &http.Client{
+				Timeout: 3 * time.Second,
+			}
+
+			// Add policy
+
+			requestDataPolicy := map[string]interface{}{}
+
+			requestDataJSON, _ := json.Marshal(requestDataPolicy)
+			requestDataBody := bytes.NewReader(requestDataJSON)
+			request, err := http.NewRequest(
+				tt.verb, fmt.Sprintf("http://localhost:9090/api/v1/remote-buckets%s", tt.args.api), requestDataBody)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+			request.Header.Add("Content-Type", "application/json")
+			response, err := client.Do(request)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			if response != nil {
+				assert.Equal(tt.expectedStatus, response.StatusCode, "Status Code is incorrect")
+			}
+
+		})
+	}
+
+}

--- a/restapi/admin_remote_buckets.go
+++ b/restapi/admin_remote_buckets.go
@@ -270,6 +270,10 @@ func addRemoteBucket(ctx context.Context, client MinioAdmin, params models.Creat
 		host = host + ":" + strconv.Itoa(port)
 	}
 	creds := &madmin.Credentials{AccessKey: accessKey, SecretKey: secretKey}
+	sync := false
+	if params.SyncMode != nil && *params.SyncMode == "sync" {
+		sync = true
+	}
 	remoteBucket := &madmin.BucketTarget{
 		TargetBucket:    *params.TargetBucket,
 		Secure:          secure,
@@ -279,9 +283,9 @@ func addRemoteBucket(ctx context.Context, client MinioAdmin, params models.Creat
 		API:             "s3v4",
 		Type:            "replication",
 		Region:          params.Region,
-		ReplicationSync: *params.SyncMode == "sync",
+		ReplicationSync: sync,
 	}
-	if *params.SyncMode == "async" {
+	if params.SyncMode != nil && *params.SyncMode == "async" {
 		remoteBucket.BandwidthLimit = params.Bandwidth
 	}
 	if params.HealthCheckPeriod > 0 {


### PR DESCRIPTION
Test for adding remote bucket

This will test:

`~/console/swagger-console.yml`

```sh
  /remote-buckets:
    get:
      summary: List Remote Buckets
      operationId: ListRemoteBuckets
      responses:
        200:
          description: A successful response.
          schema:
            $ref: "#/definitions/listRemoteBucketsResponse"
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - Bucket
    post:
      summary: Add Remote Bucket
      operationId: AddRemoteBucket
      parameters:
        - name: body
          in: body
          required: true
          schema:
            $ref: "#/definitions/createRemoteBucket"
      responses:
        201:
          description: A successful response.
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - Bucket
```