### PR TITLE
Added versions multiselection & delete selected versions buttons

### DIFF
--- a/portal-ui/src/icons/LinkIcon.tsx
+++ b/portal-ui/src/icons/LinkIcon.tsx
@@ -1,5 +1,5 @@
 // This file is part of MinIO Console Server
-// Copyright (c) 2021 MinIO, Inc.
+// Copyright (c) 2022 MinIO, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/DeleteSelectedVersions.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/DeleteSelectedVersions.tsx
@@ -1,0 +1,115 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { useState, useEffect } from "react";
+import { connect } from "react-redux";
+import { DialogContentText } from "@mui/material";
+import { setErrorSnackMessage } from "../../../../../../actions";
+import { ErrorResponseHandler } from "../../../../../../common/types";
+import ConfirmDialog from "../../../../Common/ModalWrapper/ConfirmDialog";
+import { ConfirmDeleteIcon } from "../../../../../../icons";
+import api from "../../../../../../common/api";
+
+interface IDeleteSelectedVersionsProps {
+  closeDeleteModalAndRefresh: (refresh: boolean) => void;
+  deleteOpen: boolean;
+  selectedVersions: string[];
+  selectedObject: string;
+  selectedBucket: string;
+  setErrorSnackMessage: typeof setErrorSnackMessage;
+}
+
+const DeleteObject = ({
+  closeDeleteModalAndRefresh,
+  deleteOpen,
+  selectedBucket,
+  selectedVersions,
+  selectedObject,
+  setErrorSnackMessage,
+}: IDeleteSelectedVersionsProps) => {
+  const [deleteLoading, setDeleteLoading] = useState<boolean>(false);
+
+  const onClose = () => closeDeleteModalAndRefresh(false);
+  const onConfirmDelete = () => {
+    setDeleteLoading(true);
+  };
+
+  useEffect(() => {
+    if (deleteLoading) {
+      const selectedObjectsRequest = selectedVersions.map((versionID) => {
+        return {
+          path: selectedObject,
+          versionID: versionID,
+          recursive: false,
+        };
+      });
+
+      if (selectedObjectsRequest.length > 0) {
+        api
+          .invoke(
+            "POST",
+            `/api/v1/buckets/${selectedBucket}/delete-objects?all_versions=false`,
+            selectedObjectsRequest
+          )
+          .then(() => {
+            setDeleteLoading(false);
+            closeDeleteModalAndRefresh(true);
+          })
+          .catch((error: ErrorResponseHandler) => {
+            setErrorSnackMessage(error);
+            setDeleteLoading(false);
+          });
+      }
+    }
+  }, [
+    deleteLoading,
+    closeDeleteModalAndRefresh,
+    selectedBucket,
+    selectedObject,
+    selectedVersions,
+    setErrorSnackMessage,
+  ]);
+
+  if (!selectedVersions) {
+    return null;
+  }
+
+  return (
+    <ConfirmDialog
+      title={`Delete Selected Versions`}
+      confirmText={"Delete"}
+      isOpen={deleteOpen}
+      titleIcon={<ConfirmDeleteIcon />}
+      isLoading={deleteLoading}
+      onConfirm={onConfirmDelete}
+      onClose={onClose}
+      confirmationContent={
+        <DialogContentText>
+          Are you sure you want to delete the selected {selectedVersions.length}{" "}
+          versions for <strong>{selectedObject}</strong>?
+        </DialogContentText>
+      }
+    />
+  );
+};
+
+const mapDispatchToProps = {
+  setErrorSnackMessage,
+};
+
+const connector = connect(null, mapDispatchToProps);
+
+export default connector(DeleteObject);

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/FileVersionItem.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/FileVersionItem.tsx
@@ -31,12 +31,16 @@ import {
 } from "../../../../../../icons";
 import { niceBytes } from "../../../../../../common/utils";
 import SpecificVersionPill from "./SpecificVersionPill";
+import CheckboxWrapper from "../../../../Common/FormComponents/CheckboxWrapper/CheckboxWrapper";
 
 interface IFileVersionItem {
   fileName: string;
   versionInfo: IFileInfo;
   index: number;
   isSelected?: boolean;
+  checkable: boolean;
+  isChecked: boolean;
+  onCheck: (versionID: string) => void;
   onShare: (versionInfo: IFileInfo) => void;
   onDownload: (versionInfo: IFileInfo) => void;
   onRestore: (versionInfo: IFileInfo) => void;
@@ -112,6 +116,9 @@ const FileVersionItem = ({
   fileName,
   versionInfo,
   isSelected,
+  checkable,
+  isChecked,
+  onCheck,
   onShare,
   onDownload,
   onRestore,
@@ -180,6 +187,27 @@ const FileVersionItem = ({
           <Grid item xs={12} justifyContent={"space-between"}>
             <Grid container>
               <Grid item xs={4} className={classes.versionContainer}>
+                {checkable && (
+                  <CheckboxWrapper
+                    checked={isChecked}
+                    id={`select-${versionInfo.version_id}`}
+                    label={""}
+                    name={`select-${versionInfo.version_id}`}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      onCheck(versionInfo.version_id || "");
+                    }}
+                    value={versionInfo.version_id || ""}
+                    disabled={versionInfo.is_delete_marker}
+                    overrideCheckboxStyles={{
+                      paddingLeft: 0,
+                      height: 34,
+                      width: 25,
+                    }}
+                    noTopMargin
+                  />
+                )}
                 {displayFileIconName(fileName, true)} v{index.toString()}
                 {pill && <SpecificVersionPill type={pill} />}
               </Grid>

--- a/portal-ui/src/screens/Console/Common/FormComponents/CheckboxWrapper/CheckboxWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/CheckboxWrapper/CheckboxWrapper.tsx
@@ -35,6 +35,7 @@ interface CheckBoxProps {
   disabled?: boolean;
   tooltip?: string;
   overrideLabelClasses?: string;
+  overrideCheckboxStyles?: React.CSSProperties;
   index?: number;
   noTopMargin?: boolean;
   checked: boolean;
@@ -71,6 +72,7 @@ const CheckboxWrapper = ({
   noTopMargin = false,
   tooltip = "",
   overrideLabelClasses = "",
+  overrideCheckboxStyles,
   classes,
 }: CheckBoxProps) => {
   return (
@@ -94,6 +96,12 @@ const CheckboxWrapper = ({
             checkedIcon={<span className={classes.checkedIcon} />}
             icon={<span className={classes.unCheckedIcon} />}
             disabled={disabled}
+            disableRipple
+            disableFocusRipple
+            focusRipple={false}
+            centerRipple={false}
+            disableTouchRipple
+            style={overrideCheckboxStyles || {}}
           />
         </div>
         {label !== "" && (


### PR DESCRIPTION
## What does this do?

Added versions multi-selection & delete selected versions buttons

**NOTE:** There is an issue in latest versions of MinIO where deleting a version only sets a delete marker on it. Will debug this further as it is not related to this PR

## How does it look?
<img width="1194" alt="Screen Shot 2022-05-03 at 19 28 54" src="https://user-images.githubusercontent.com/33497058/166608295-3050c4f7-3212-4df6-9b8f-7e7685970226.png">
<img width="829" alt="Screen Shot 2022-05-03 at 19 28 47" src="https://user-images.githubusercontent.com/33497058/166608297-1ab07a81-293d-4d59-952a-27dd450db721.png">
<img width="1231" alt="Screen Shot 2022-05-03 at 19 28 43" src="https://user-images.githubusercontent.com/33497058/166608300-7ab59845-ea8c-4056-99a7-1e5e7fa19640.png">
<img width="1135" alt="Screen Shot 2022-05-03 at 19 28 37" src="https://user-images.githubusercontent.com/33497058/166608302-ec034f63-2077-4dba-92c8-9acd007ab77c.png">
<img width="319" alt="Screen Shot 2022-05-03 at 19 28 31" src="https://user-images.githubusercontent.com/33497058/166608303-fc20cd84-4415-4d5a-a97c-5b7d9d8767d8.png">

