### PR TITLE
Fixed loader issue object versions page

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/VersionsNavigator.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/VersionsNavigator.tsx
@@ -191,6 +191,12 @@ const VersionsNavigator = ({
   }
 
   useEffect(() => {
+    if (!loadingVersions && !actualInfo) {
+      setLoadingVersions(true);
+    }
+  }, [loadingVersions, actualInfo, setLoadingVersions]);
+
+  useEffect(() => {
     if (loadingVersions && internalPaths !== "") {
       api
         .invoke(


### PR DESCRIPTION
## What does this do?

Fixes an issue with loader in object versions page

## How does it look?

![2022-05-04 15-27-22 2022-05-04 15_29_34](https://user-images.githubusercontent.com/33497058/166820904-3e080e0a-b39c-4517-99db-40b59cb17929.gif)


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>