### PR TITLE
Fixed multiple issues on object browser upload

### DIFF
--- a/portal-ui/src/screens/Console/ObjectBrowser/actions.ts
+++ b/portal-ui/src/screens/Console/ObjectBrowser/actions.ts
@@ -37,6 +37,7 @@ import {
   REWIND_RESET_REWIND,
   REWIND_SET_ENABLE,
   BUCKET_BROWSER_SET_SELECTED_OBJECT,
+  BUCKET_BROWSER_SET_SIMPLE_PATH,
   IFileItem,
 } from "./types";
 
@@ -197,5 +198,12 @@ export const setSelectedObjectView = (object: string | null) => {
   return {
     type: BUCKET_BROWSER_SET_SELECTED_OBJECT,
     object,
+  };
+};
+
+export const setSimplePathHandler = (path: string | null) => {
+  return {
+    type: BUCKET_BROWSER_SET_SIMPLE_PATH,
+    path,
   };
 };

--- a/portal-ui/src/screens/Console/ObjectBrowser/reducers.ts
+++ b/portal-ui/src/screens/Console/ObjectBrowser/reducers.ts
@@ -39,6 +39,7 @@ import {
   OBJECT_MANAGER_SET_LOADING,
   OBJECT_MANAGER_ERROR_IN_OBJECT,
   OBJECT_MANAGER_CANCEL_OBJECT,
+  BUCKET_BROWSER_SET_SIMPLE_PATH,
 } from "./types";
 
 const defaultRewind = {
@@ -67,6 +68,7 @@ const initialState: ObjectBrowserState = {
   selectedVersion: "",
   showDeleted: false,
   selectedInternalPaths: null,
+  simplePath: null,
 };
 
 export function objectBrowserReducer(
@@ -295,11 +297,19 @@ export function objectBrowserReducer(
       return {
         ...state,
         objectDetailsOpen: action.status,
+        selectedInternalPaths: action.status
+          ? state.selectedInternalPaths
+          : null,
       };
     case BUCKET_BROWSER_SET_SELECTED_OBJECT:
       return {
         ...state,
         selectedInternalPaths: action.object,
+      };
+    case BUCKET_BROWSER_SET_SIMPLE_PATH:
+      return {
+        ...state,
+        simplePath: action.path,
       };
     default:
       return state;

--- a/portal-ui/src/screens/Console/ObjectBrowser/types.ts
+++ b/portal-ui/src/screens/Console/ObjectBrowser/types.ts
@@ -47,6 +47,8 @@ export const BUCKET_BROWSER_OBJECT_DETAILS_STATE =
   "BUCKET_BROWSER/OBJECT_DETAILS_STATE";
 export const BUCKET_BROWSER_SET_SELECTED_OBJECT =
   "BUCKET_BROWSER/SET_SELECTED_OBJECT";
+export const BUCKET_BROWSER_SET_SIMPLE_PATH =
+  "BUCKET_BROWSER/SET_SIMPLE_PATH";
 
 export interface Route {
   route: string;
@@ -74,6 +76,7 @@ export interface ObjectBrowserState {
   showDeleted: boolean;
   objectDetailsOpen: boolean;
   selectedInternalPaths: string | null;
+  simplePath: string | null;
 }
 
 export interface ObjectBrowserReducer {
@@ -209,6 +212,11 @@ interface CancelObjectInManager {
   instanceID: string;
 }
 
+interface SetBrowserPath {
+  type: typeof BUCKET_BROWSER_SET_SIMPLE_PATH;
+  path: string;
+}
+
 export type ObjectBrowserActionTypes =
   | RewindSetEnabled
   | RewindReset
@@ -231,4 +239,5 @@ export type ObjectBrowserActionTypes =
   | SetObjectDetailsState
   | SetSelectedObject
   | SetObjectManagerLoading
-  | CancelObjectInManager;
+  | CancelObjectInManager
+  | SetBrowserPath;


### PR DESCRIPTION
fixes #1946

## What does this do?

- Fixed issue with double slashes on upload manager
- Fixed sub folders not uploading in the correct subpaths location
- Fixed an issue upload when a file is already selected
- Fixed an issue with create path button with paths finished on slash
- Simplified path handling  for object browser

## How does it look?

<img width="465" alt="Screen Shot 2022-05-04 at 22 13 47" src="https://user-images.githubusercontent.com/33497058/166858872-5e05767f-36b2-47ac-a579-743239530f78.png">
<img width="1608" alt="Screen Shot 2022-05-04 at 22 14 53" src="https://user-images.githubusercontent.com/33497058/166858873-53174981-f3c3-4445-9e5c-511d9b91381e.png">
<img width="424" alt="Screen Shot 2022-05-04 at 22 14 08" src="https://user-images.githubusercontent.com/33497058/166858875-55567678-384c-4f7c-8ded-f5fa852cd409.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>