### PR TITLE
Added margin in date time picker to avoid jumpy effect

### DIFF
--- a/portal-ui/src/screens/Console/Common/FormComponents/DateTimePickerWrapper/DateTimePickerWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/DateTimePickerWrapper/DateTimePickerWrapper.tsx
@@ -172,6 +172,8 @@ const styles = (theme: Theme) =>
         borderTop: "#F0F3F5 1px solid",
       },
       "& .MuiClockPicker-arrowSwitcher": {
+        marginRight: 10,
+        marginTop: -1,
         "& > div": {
           width: 0,
         },
@@ -182,6 +184,8 @@ const styles = (theme: Theme) =>
           width: 255,
           height: 255,
           backgroundColor: "#fff",
+          marginTop: 30,
+          marginBottom: 14,
           border: "#F0F3F5 3px solid",
           "& > div:nth-child(2)": {
             backgroundColor: "#B4B5B4",


### PR DESCRIPTION
## What does this do?

Added margin in date time picker to avoid jumpy effect

## How does it look?

<img width="479" alt="Screen Shot 2022-05-06 at 17 03 51" src="https://user-images.githubusercontent.com/33497058/167222106-a388e1aa-6527-45c3-ab97-6c6596924909.png">
<img width="493" alt="Screen Shot 2022-05-06 at 17 03 47" src="https://user-images.githubusercontent.com/33497058/167222111-896fa286-d8a3-413a-bd38-c5114ce1374d.png">

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>