### PR TITLE
Removed error snack bar message for status calls

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -383,7 +383,8 @@ const ListObjects = ({
 
           setQuota(quotaVals);
         })
-        .catch(() => {
+        .catch((err) => {
+          console.error("Error Getting Quota Status: ", err.detailedError);
           setQuota(null);
         });
     }
@@ -453,7 +454,7 @@ const ListObjects = ({
             setLoadingVersioning(false);
           })
           .catch((err: ErrorResponseHandler) => {
-            setErrorSnackMessage(err);
+            console.error("Error Getting Object Versioning Status: ", err.detailedError);
             setLoadingVersioning(false);
           });
       } else {
@@ -473,7 +474,7 @@ const ListObjects = ({
             setLoadingLocking(false);
           })
           .catch((err: ErrorResponseHandler) => {
-            setErrorSnackMessage(err);
+            console.error("Error Getting Object Locking Status: ", err.detailedError);
             setLoadingLocking(false);
           });
       } else {


### PR DESCRIPTION
## Wat does this do?

Removed error snack bar message & returned `console.error` instead for versioning, quota & object locking API calls in List Objects panel

## How does it look?
<img width="810" alt="Screen Shot 2022-05-07 at 23 16 23" src="https://user-images.githubusercontent.com/33497058/167281529-7894f372-09d6-4f11-8bc7-8ae3918f253f.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>