### PR TITLE
Upload coverage to play

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1340,6 +1340,17 @@ jobs:
           go build gocovmerge.go
           echo "put together the outs for final coverage resolution"
           ./gocovmerge ../integration/coverage/system.out ../replication/coverage/replication.out ../sso-integration/coverage/sso-system.out ../restapi/coverage/coverage.out ../pkg/coverage/coverage-pkg.out ../operator-integration/coverage/operator-api.out > all.out
+          echo "Download mc for Ubuntu"
+          wget https://dl.min.io/client/mc/release/linux-amd64/mc
+          echo "Change the permissions to execute mc command"
+          chmod +x mc
+          echo "Create the folder to put the all.out file"
+          ./mc mb --ignore-existing play/builds/
+          echo "Copy the all.out file to play bucket"
+          echo ${{ github.repository }}
+          echo ${{ github.event.number }}
+          echo ${{ github.run_id }}
+          ./mc cp all.out play/builds/${{ github.repository }}/${{ github.event.number }}/${{ github.run_id }}/
           echo "grep to obtain the result"
           go tool cover -func=all.out | grep total > tmp2
           result=`cat tmp2 | awk 'END {print $3}'`


### PR DESCRIPTION
Fixes: https://github.com/miniohq/engineering/issues/834

The idea is to place our coverage file in Play bucket for easy access to it.

### How to use it:

```sh
$ mc cp play/builds/minio/console/1972/2303764870/all.out ./all.out
...1972/2303764870/all.out:  342.31 KiB / 342.31 KiB  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  424.82 KiB/s 0s/Users/cniackz/console $ go tool cover -html=all.out     
```

> You can get the values from the result of the test

<img width="1840" alt="Screen Shot 2022-05-10 at 6 02 00 PM" src="https://user-images.githubusercontent.com/6667358/167738589-781bc8b9-9e8e-4dd7-9c58-2dc72fa62a9a.png">

Then with this file you can get the html version like this:

```sh
$ go tool cover -html=all.out 
```

<img width="1840" alt="Screen Shot 2022-05-10 at 6 04 32 PM" src="https://user-images.githubusercontent.com/6667358/167738768-f9dd8ea8-e9e9-430d-9127-691d8b8e27c3.png">

Thank you @dvaldivia for bringing this idea!

