### PR TITLE
Fix route navigation paths to match menus

### DIFF
--- a/portal-ui/src/common/SecureComponent/permissions.ts
+++ b/portal-ui/src/common/SecureComponent/permissions.ts
@@ -113,21 +113,21 @@ export const IAM_SCOPES = {
 export const IAM_PAGES = {
   /* Buckets */
   BUCKETS: "/buckets",
-  ADD_BUCKETS: "/add-bucket",
+  ADD_BUCKETS: "/buckets/add-bucket",
   BUCKETS_ADMIN_VIEW: "/buckets/:bucketName/admin*",
   BUCKETS_BROWSE_VIEW: "/buckets/:bucketName/browse*",
   /* Identity */
   IDENTITY: "/identity",
   USERS: "/identity/users",
-  USERS_VIEW: "/identity/users/:userName+",
-  USER_ADD: "/identity/add-user",
+  USERS_VIEW: "/identity/users/:userName",
+  USER_ADD: "/identity/users/add-user",
   GROUPS: "/identity/groups",
-  GROUPS_ADD: "/identity/create-group",
+  GROUPS_ADD: "/identity/groups/create-group",
   GROUPS_VIEW: "/identity/groups/:groupName+",
   ACCOUNT: "/identity/account",
-  ACCOUNT_ADD: "/identity/new-account",
-  USER_ACCOUNT: "/identity/new-user-sa",
-  USER_ACCOUNT_ADD: "/identity/new-user-sa/:userName+",
+  ACCOUNT_ADD: "/identity/account/new-account",
+  USER_SA_ACCOUNT_ADD: "/identity/users/new-user-sa/:userName",
+
   /* Access */
   POLICIES: "/access/policies",
   POLICY_ADD: "/access/add-policy",
@@ -316,7 +316,7 @@ export const IAM_PAGES_PERMISSIONS = {
     IAM_SCOPES.ADMIN_DISABLE_USER,
     IAM_SCOPES.ADMIN_DELETE_USER,
   ],
-  [IAM_PAGES.USER_ACCOUNT_ADD]: [
+  [IAM_PAGES.USER_SA_ACCOUNT_ADD]: [
     IAM_SCOPES.ADMIN_CREATE_SERVICEACCOUNT,
     IAM_SCOPES.ADMIN_UPDATE_SERVICEACCOUNT,
     IAM_SCOPES.ADMIN_REMOVE_SERVICEACCOUNT,

--- a/portal-ui/src/screens/Console/Buckets/Buckets.tsx
+++ b/portal-ui/src/screens/Console/Buckets/Buckets.tsx
@@ -22,6 +22,7 @@ import { AppState } from "../../../store";
 import { setMenuOpen } from "../../../actions";
 import NotFoundPage from "../../NotFoundPage";
 import LoadingComponent from "../../../common/LoadingComponent";
+import { IAM_PAGES } from "../../../common/SecureComponent/permissions";
 
 const ListBuckets = React.lazy(() => import("./ListBuckets/ListBuckets"));
 const BucketDetails = React.lazy(() => import("./BucketDetails/BucketDetails"));
@@ -41,7 +42,7 @@ const Buckets = () => {
     <Router history={history}>
       <Switch>
         <Route
-          path="/add-bucket"
+          path={IAM_PAGES.ADD_BUCKETS}
           children={(routerProps) => (
             <Suspense fallback={<LoadingComponent />}>
               <AddBucket />

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/ListBuckets.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/ListBuckets.tsx
@@ -46,6 +46,7 @@ import SelectMultipleIcon from "../../../../icons/SelectMultipleIcon";
 import { SecureComponent } from "../../../../common/SecureComponent";
 import {
   CONSOLE_UI_RESOURCE,
+  IAM_PAGES,
   IAM_SCOPES,
 } from "../../../../common/SecureComponent/permissions";
 import PageLayout from "../../Common/Layout/PageLayout";
@@ -293,7 +294,7 @@ const ListBuckets = ({
             <RBIconButton
               tooltip={"Create Bucket"}
               onClick={() => {
-                history.push("/add-bucket");
+                history.push(IAM_PAGES.ADD_BUCKETS);
               }}
               text={"Create Bucket"}
               icon={<AddIcon />}
@@ -358,7 +359,7 @@ const ListBuckets = ({
                           To get started,&nbsp;
                           <AButton
                             onClick={() => {
-                              history.push("/add-bucket");
+                              history.push(IAM_PAGES.ADD_BUCKETS);
                             }}
                           >
                             Create a Bucket.

--- a/portal-ui/src/screens/Console/Console.tsx
+++ b/portal-ui/src/screens/Console/Console.tsx
@@ -424,7 +424,7 @@ const Console = ({
     },
     {
       component: UserSACreate,
-      path: IAM_PAGES.USER_ACCOUNT_ADD,
+      path: IAM_PAGES.USER_SA_ACCOUNT_ADD,
       forceDisplay: true, // user has implicit access to service-accounts
     },
     {

--- a/portal-ui/src/screens/Console/Users/UserServiceAccountsPanel.tsx
+++ b/portal-ui/src/screens/Console/Users/UserServiceAccountsPanel.tsx
@@ -41,9 +41,11 @@ import RBIconButton from "../Buckets/BucketDetails/SummaryItems/RBIconButton";
 import DeleteMultipleServiceAccounts from "./DeleteMultipleServiceAccounts";
 import { selectSAs } from "../../Console/Configurations/utils";
 import ServiceAccountPolicy from "../Account/ServiceAccountPolicy";
-import { IAM_PAGES,
-         CONSOLE_UI_RESOURCE,
-         IAM_SCOPES } from "../../../common/SecureComponent/permissions";
+import {
+  IAM_PAGES,
+  CONSOLE_UI_RESOURCE,
+  IAM_SCOPES,
+} from "../../../common/SecureComponent/permissions";
 import { SecureComponent } from "../../../common/SecureComponent";
 
 interface IUserServiceAccountsProps {
@@ -235,25 +237,30 @@ const UserServiceAccountsPanel = ({
             variant={"outlined"}
           />
           <SecureComponent
-            scopes={[IAM_SCOPES.ADMIN_CREATE_SERVICEACCOUNT,
+            scopes={[
+              IAM_SCOPES.ADMIN_CREATE_SERVICEACCOUNT,
               IAM_SCOPES.ADMIN_UPDATE_SERVICEACCOUNT,
               IAM_SCOPES.ADMIN_REMOVE_SERVICEACCOUNT,
-              IAM_SCOPES.ADMIN_LIST_SERVICEACCOUNTS]}
+              IAM_SCOPES.ADMIN_LIST_SERVICEACCOUNTS,
+            ]}
             resource={CONSOLE_UI_RESOURCE}
             matchAll
             errorProps={{ disabled: true }}
           >
-          <RBIconButton
-            tooltip={"Create service account"}
-            text={"Create service account"}
-            variant="contained"
-            color="primary"
-            icon={<AddIcon />}
-            onClick={() => {
-              history.push(`${IAM_PAGES.USER_ACCOUNT}/${user}`);
-            }}
-            disabled={!hasPolicy}
-          />
+            <RBIconButton
+              tooltip={"Create service account"}
+              text={"Create service account"}
+              variant="contained"
+              color="primary"
+              icon={<AddIcon />}
+              onClick={() => {
+                let newSAPath = `/identity/users/${user}/new-user-sa`;
+                newSAPath = `${IAM_PAGES.USER_SA_ACCOUNT_ADD}/${user}`;
+                newSAPath = `/identity/users/new-user-sa/${user}`;
+                history.push(newSAPath);
+              }}
+              disabled={!hasPolicy}
+            />
           </SecureComponent>
         </Box>
       </div>

--- a/portal-ui/src/screens/Console/kbar-actions.tsx
+++ b/portal-ui/src/screens/Console/kbar-actions.tsx
@@ -18,6 +18,7 @@ import { Action } from "kbar/lib/types";
 import history from "../../history";
 import { BucketsIcon } from "../../icons";
 import { validRoutes } from "./valid-routes";
+import { IAM_PAGES } from "../../common/SecureComponent/permissions";
 
 export const routesAsKbarActions = (
   features: string[] | null,
@@ -54,7 +55,7 @@ export const routesAsKbarActions = (
       id: `create-bucket`,
       name: "Create Bucket",
       section: "Buckets",
-      perform: () => history.push(`/add-bucket`),
+      perform: () => history.push(IAM_PAGES.ADD_BUCKETS),
       icon: <BucketsIcon />,
     };
     initialActions.push(a);


### PR DESCRIPTION
Fix route navigation paths  (route hierarchy) to match menus

Impacted menu/route paths:

- Buckets -> Add Bucket  ( Will highlight bucket sidebar menu)

- Users -> Create user (Will highlight Users sidebar menu)
  Users -> Click on a user -> Service Accounts ->  Create Service Account  (Will highlight Users sidebar menu)

- Service Accounts -> Create new Service account  ( will highlight the Service Accounts)

- Groups -> Create Group ( will highlight Groups)