### PR TITLE
Correcting sso port to use our console server and increment coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test-sso-integration:
 	@echo "Run Dex container using MinIO Image: quay.io/minio/dex:latest"
 	@(docker run \
 		-e DEX_ISSUER=http://dex:5556/dex \
-		-e DEX_CLIENT_REDIRECT_URI=http://127.0.0.1:9001/oauth_callback \
+		-e DEX_CLIENT_REDIRECT_URI=http://127.0.0.1:9090/oauth_callback \
 		-e DEX_LDAP_SERVER=openldap:389 \
 		--network my-net \
 		-p 5556:5556 \
@@ -163,7 +163,7 @@ test-sso-integration:
 	-e MINIO_IDENTITY_OPENID_CLIENT_SECRET="minio-client-app-secret" \
 	-e MINIO_IDENTITY_OPENID_CLAIM_NAME=name \
 	-e MINIO_IDENTITY_OPENID_CONFIG_URL=http://dex:5556/dex/.well-known/openid-configuration \
-	-e MINIO_IDENTITY_OPENID_REDIRECT_URI=http://127.0.0.1:9001/oauth_callback \
+	-e MINIO_IDENTITY_OPENID_REDIRECT_URI=http://127.0.0.1:9090/oauth_callback \
 	-e MINIO_ROOT_USER=minio \
 	-e MINIO_ROOT_PASSWORD=minio123 $(MINIO_VERSION) server /data{1...4} --address :9000 --console-address :9001)
 	@echo "run mc commands to set the policy"

--- a/sso-integration/dex-requests.py
+++ b/sso-integration/dex-requests.py
@@ -1,30 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import pdb
-import requests
+import pdb, sys, requests, pdb
 from bs4 import BeautifulSoup
-
-result = requests.get('http://localhost:9001/api/v1/login')
-redirect = result.json()['redirect']
-result = requests.get(redirect)
-soup = BeautifulSoup(result.text, "html.parser")
+from urllib.parse import unquote
 
 # Log in to Your Account via OpenLDAP Connector
+result = requests.get(sys.argv[1])
+soup = BeautifulSoup(result.text, "html.parser")
 url = "http://dex:5556" + soup.findAll('a')[1].get('href')
 result = requests.get(url)
 soup = BeautifulSoup(result.text, "html.parser")
 url = "http://dex:5556" + soup.form.get('action')
-
-# Post the credentials in the form
-# From https://github.com/minio/minio-iam-testing/blob/main/ldap/bootstrap.ldif
-myobj = {
-    'login': 'dillon@example.io',
-    'password': 'dillon',
-}
-result2 = requests.post(url, data = myobj)
-code  = result2.url.split("?code=")[1].split("&state=")[0]
-state = result2.url.split("?code=")[1].split("&state=")[1]
-
-print(code)
-print(state)
+print(url)

--- a/sso-integration/sso_test.go
+++ b/sso-integration/sso_test.go
@@ -20,10 +20,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -36,8 +38,12 @@ import (
 
 var token string
 
-func initConsoleServer() (*restapi.Server, error) {
-	// os.Setenv("CONSOLE_MINIO_SERVER", "localhost:9000")
+func initConsoleServer(consoleIDPURL string) (*restapi.Server, error) {
+	// Configure Console Server with vars to get the idp config from the container
+	os.Setenv("CONSOLE_IDP_URL", consoleIDPURL)
+	os.Setenv("CONSOLE_IDP_CLIENT_ID", "minio-client-app")
+	os.Setenv("CONSOLE_IDP_SECRET", "minio-client-app-secret")
+	os.Setenv("CONSOLE_IDP_CALLBACK", "http://127.0.0.1:9090/oauth_callback")
 
 	swaggerSpec, err := loads.Embedded(restapi.SwaggerJSON, restapi.FlatSwaggerJSON)
 	if err != nil {
@@ -58,10 +64,9 @@ func initConsoleServer() (*restapi.Server, error) {
 	server := restapi.NewServer(api)
 	// register all APIs
 	server.ConfigureAPI()
-	consolePort, _ := strconv.Atoi("9090")
 
 	server.Host = "0.0.0.0"
-	server.Port = consolePort
+	server.Port = 9090
 	restapi.Port = "9090"
 	restapi.Hostname = "0.0.0.0"
 
@@ -74,7 +79,7 @@ func TestMain(t *testing.T) {
 	// start console server
 	go func() {
 		fmt.Println("start server")
-		srv, err := initConsoleServer()
+		srv, err := initConsoleServer("http://dex:5556/dex/.well-known/openid-configuration")
 		if err != nil {
 			log.Println(err)
 			log.Println("init fail")
@@ -90,43 +95,79 @@ func TestMain(t *testing.T) {
 		Timeout: 2 * time.Second,
 	}
 
-	// execute script to get the code and state
-	cmd, err := exec.Command("python3", "dex-requests.py").Output()
-	if err != nil {
-		fmt.Printf("error %s", err)
+	// Let's move this API here to increment our coverage
+	getRequest, getError := http.NewRequest("GET", "http://localhost:9090/api/v1/login", nil)
+	if getError != nil {
+		log.Println(getError)
+		return
 	}
-	output := string(cmd)
-
-	fmt.Println(" ")
-	fmt.Println(" ")
-	fmt.Println("output:")
-	fmt.Println(output)
-	fmt.Println(" ")
-	fmt.Println(" ")
-
-	temp := strings.Split(output, "\n")
-
-	fmt.Println(" ")
-	fmt.Println(" ")
-	fmt.Println("temp:")
-	fmt.Println(temp)
-	fmt.Println(" ")
-	fmt.Println(" ")
-
-	fmt.Println("index0")
-	fmt.Println(temp[0])
-
-	if len(temp) >= 2 {
-		fmt.Println("index 1")
-		fmt.Println(temp[1])
-	} else {
-		assert.Fail("temp len is less than 2", len(temp))
+	getRequest.Header.Add("Content-Type", "application/json")
+	getResponse, getErr := client.Do(getRequest)
+	// current value:
+	// {"loginStrategy":"form"}
+	// but we want our console server to provide loginStrategy = redirect for SSO
+	if getErr != nil {
+		log.Println(getErr)
 		return
 	}
 
+	body, err := io.ReadAll(getResponse.Body)
+	getResponse.Body.Close()
+	if getResponse.StatusCode > 299 {
+		log.Fatalf("Response failed with status code: %d and\nbody: %s\n", getResponse.StatusCode, body)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+	var jsonMap map[string]interface{}
+	json.Unmarshal(body, &jsonMap)
+	fmt.Println(jsonMap["redirect"])
+	redirect := jsonMap["redirect"]
+	redirectAsString := fmt.Sprint(redirect)
+	fmt.Println(redirectAsString)
+
+	// execute script to get the code and state
+	cmd, err := exec.Command("python3", "dex-requests.py", redirectAsString).Output()
+	if err != nil {
+		fmt.Printf("error %s", err)
+	}
+	urlOutput := string(cmd)
+	requestLoginBody := bytes.NewReader([]byte("login=dillon%40example.io&password=dillon"))
+
+	// parse url remove carriage return
+	temp2 := strings.Split(urlOutput, "\n")
+	fmt.Println("temp2: ", temp2)
+	urlOutput = temp2[0] // remove carriage return to avoid invalid control character in url
+
+	// validate url
+	urlParseResult, urlParseError := url.Parse(urlOutput)
+	if urlParseError != nil {
+		panic(urlParseError)
+	}
+	fmt.Println(urlParseResult)
+
+	// prepare for post
+	httpRequestLogin, newRequestError := http.NewRequest(
+		"POST",
+		urlOutput,
+		requestLoginBody,
+	)
+	fmt.Println(newRequestError)
+	httpRequestLogin.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	responseLogin, errorLogin := client.Do(httpRequestLogin)
+	if errorLogin != nil {
+		log.Println(errorLogin)
+	}
+	rawQuery := responseLogin.Request.URL.RawQuery
+	fmt.Println(rawQuery)
+	splitRawQuery := strings.Split(rawQuery, "&state=")
+	codeValue := strings.ReplaceAll(splitRawQuery[0], "code=", "")
+	stateValue := splitRawQuery[1]
+	fmt.Println("stop", splitRawQuery, codeValue, stateValue)
+
 	// get login credentials
-	codeVarIable := strings.TrimSpace(temp[0])
-	stateVarIabl := strings.TrimSpace(temp[1])
+	codeVarIable := strings.TrimSpace(codeValue)
+	stateVarIabl := strings.TrimSpace(stateValue)
 	requestData := map[string]string{
 		"code":  codeVarIable,
 		"state": stateVarIabl,
@@ -137,7 +178,7 @@ func TestMain(t *testing.T) {
 
 	request, _ := http.NewRequest(
 		"POST",
-		"http://localhost:9001/api/v1/login/oauth2/auth",
+		"http://localhost:9090/api/v1/login/oauth2/auth",
 		requestDataBody,
 	)
 	request.Header.Add("Content-Type", "application/json")
@@ -146,7 +187,6 @@ func TestMain(t *testing.T) {
 	if err != nil {
 		log.Println(err)
 	}
-
 	if response != nil {
 		for _, cookie := range response.Cookies() {
 			if cookie.Name == "token" {
@@ -161,4 +201,50 @@ func TestMain(t *testing.T) {
 	} else {
 		fmt.Println(token)
 	}
+}
+
+func TestBadLogin(t *testing.T) {
+	assert := assert.New(t)
+
+	// start console server
+	go func() {
+		fmt.Println("start server")
+		srv, err := initConsoleServer("http://dex:5556")
+		if err != nil {
+			log.Println(err)
+			log.Println("init fail")
+			return
+		}
+		srv.Serve()
+	}()
+	fmt.Println("sleeping")
+	time.Sleep(2 * time.Second)
+
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+
+	// get login credentials
+	codeVarIable := "invalidCode"
+	stateVarIabl := "invalidState"
+	requestData := map[string]string{
+		"code":  codeVarIable,
+		"state": stateVarIabl,
+	}
+	requestDataJSON, _ := json.Marshal(requestData)
+
+	requestDataBody := bytes.NewReader(requestDataJSON)
+
+	request, _ := http.NewRequest(
+		"POST",
+		"http://localhost:9090/api/v1/login/oauth2/auth",
+		requestDataBody,
+	)
+	request.Header.Add("Content-Type", "application/json")
+
+	response, err := client.Do(request)
+	fmt.Println(response)
+	fmt.Println(err)
+	expectedError := response.Status
+	assert.Equal("500 Internal Server Error", expectedError)
 }


### PR DESCRIPTION
Daniel found that our current SSO test is not incrementing our coverage.
Then I realized that the problem might be related to the port, we have created the server at 9090 port but token is obtained from 9001 port. I am going to correct that and make sure coverage is actually being impacted in a positive way.

### The code that is not covered with current SSO test:

File: `~/console/restapi/user_login.go`

![image](https://user-images.githubusercontent.com/6667358/167885760-0f572c70-2f10-4a58-98c4-3bd904036a7b.png)

### The code is covered after fix in SSO test:

http://play.min.io/builds/minio/console/1981/latest/coverage.html#file60

<img width="1840" alt="Screen Shot 2022-05-12 at 3 14 07 PM" src="https://user-images.githubusercontent.com/6667358/168160345-85c95f0f-3812-4837-9ba0-7196b9abc367.png">


### Current Status:

Ok in GoLang, I am able to create the Console Server configured with SSO and then when calling login api, I can get the login strategy to be redirect now, so first problem is solved.

Then, in python there is still something wrong, that I need to investigate since it is getting stuck my code in this line:

```py
result2 = requests.post(url, data = myobj)
```

The way I was testing is:

```sh
python3 dex-requests.py "http://dex:5556/dex/auth?client_id=minio-client-app&redirect_uri=http%3A%2F%2F127.0.0.1%3A9090%2Foauth_callback&response_type=code&scope=openid+profile+email+openid&state=QkQ1QkNMMktDU0pLMkcyTkExREVCWEcxTzpuaXl0djlKMHExNDIvdWhIdDR1eEFJTmFJd21taGdTTEVKY1hHRGhqUzJ3PQ%3D%3D"
```

After putting a breakpoint at line:

```go
cmd, err := exec.Command("python3", "dex-requests.py", redirectAsString).Output()
```

I suspect this is due to HTML not being parsed properly for the URL. But I am saving the context since there is another activity with more priority.

I spent a lot of time trying to configure console server to use port 9090 to increase coverage, but I haven't been able to achieve that yet. Some of the vars that might be involved for this config:

```go
	// Configure Console Server with vars to get the idp config from the container
	os.Setenv("CONSOLE_ACCESS_KEY", "minio")
	os.Setenv("CONSOLE_SECRET_KEY", "minio123")
	os.Setenv("CONSOLE_MINIO_SERVER", "localhost:9090")
	os.Setenv("CONSOLE_IDP_URL", "http://dex:5556/dex/.well-known/openid-configuration")
	os.Setenv("CONSOLE_IDP_CLIENT_ID", "minio-client-app")
	os.Setenv("CONSOLE_IDP_SECRET", "minio-client-app-secret")
	os.Setenv("CONSOLE_IDP_CALLBACK", "http://127.0.0.1:9090/oauth_callback")
	os.Setenv("CONSOLE_HMAC_JWT_SECRET", "YOURJWTSIGNINGSECRET")
	os.Setenv("CONSOLE_PBKDF_PASSPHRASE", "SECRET")
	os.Setenv("CONSOLE_PBKDF_SALT", "SECRET")
	os.Setenv("CONSOLE_M3_HOSTNAME", "http://localhost:8787")
	os.Setenv("CONSOLE_HOSTNAME", "0.0.0.0")
	os.Setenv("CONSOLE_IDP_HMAC_PASSPHRASE", "SECRET")
	os.Setenv("CONSOLE_IDP_HMAC_SALT", "SECRET")
```

But this has consumed already too much time on my end and I still need to research more.
I have many other things I want to do prior this task, so on hold here.

hehe sorry guys, I was lucky at the end, and after several attempts, ideas and experimentations, I discovered how to create the console server, and only 4 variables were needed:

```go
func initConsoleServer() (*restapi.Server, error) {
	// Configure Console Server with vars to get the idp config from the container
	os.Setenv("CONSOLE_IDP_URL", "http://dex:5556/dex/.well-known/openid-configuration")
	os.Setenv("CONSOLE_IDP_CLIENT_ID", "minio-client-app")
	os.Setenv("CONSOLE_IDP_SECRET", "minio-client-app-secret")
	os.Setenv("CONSOLE_IDP_CALLBACK", "http://127.0.0.1:9090/oauth_callback")
```

I got this working locally and I am about to see if the same works in GitHub actions, the main thing that was missing is the change in the ports on the Makefile as well, where dex container and minio container has to point to our consoler server at port 9090 to get idp working properly and get the token.