### PR TITLE
Upgrade Redux to Redux Toolkit

### DIFF
--- a/portal-ui/package.json
+++ b/portal-ui/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^5.4.0",
     "@mui/styled-engine-sc": "^5.3.0",
     "@mui/styles": "^5.3.0",
+    "@reduxjs/toolkit": "^1.8.1",
     "@types/history": "^4.7.3",
     "@types/jest": "27.4.0",
     "@types/lodash": "^4.14.149",
@@ -55,8 +56,6 @@
     "react-window": "^1.8.6",
     "react-window-infinite-loader": "^1.0.7",
     "recharts": "^2.1.1",
-    "redux": "^4.0.5",
-    "redux-thunk": "^2.3.0",
     "styled-components": "^5.3.1",
     "superagent": "^6.1.0",
     "use-debounce": "^7.0.1",
@@ -92,8 +91,8 @@
     "react-app-rewire-hot-loader": "^2.0.1",
     "react-app-rewired": "^2.1.6",
     "react-scripts": "5.0.1",
-    "typescript": "^4.4.3",
-    "testcafe": "^1.18.6"
+    "testcafe": "^1.18.6",
+    "typescript": "^4.4.3"
   },
   "resolutions": {
     "nth-check": "^2.0.1",

--- a/portal-ui/src/index.tsx
+++ b/portal-ui/src/index.tsx
@@ -18,7 +18,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import Routes from "./Routes";
-import configureStore from "./store";
+
 import * as serviceWorker from "./serviceWorker";
 import {
   StyledEngineProvider,
@@ -32,6 +32,7 @@ import "react-resizable/css/styles.css";
 
 import "./index.css";
 import theme from "./theme/main";
+import { store } from "./store";
 
 declare module "@mui/styles/defaultTheme" {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -127,7 +128,7 @@ const GlobalCss = withStyles({
 })(() => null);
 
 ReactDOM.render(
-  <Provider store={configureStore()}>
+  <Provider store={store}>
     <GlobalCss />
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>

--- a/portal-ui/src/store.ts
+++ b/portal-ui/src/store.ts
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { applyMiddleware, combineReducers, compose, createStore } from "redux";
-import thunk from "redux-thunk";
+import { combineReducers } from "redux";
 import { systemReducer } from "./reducer";
 import { traceReducer } from "./screens/Console/Trace/reducers";
 import { logReducer } from "./screens/Console/Logs/reducers";
@@ -27,6 +26,7 @@ import { objectBrowserReducer } from "./screens/Console/ObjectBrowser/reducers";
 import { tenantsReducer } from "./screens/Console/Tenants/reducer";
 import { directCSIReducer } from "./screens/Console/DirectCSI/reducer";
 import { dashboardReducer } from "./screens/Console/Dashboard/reducer";
+import { configureStore } from "@reduxjs/toolkit";
 
 const globalReducer = combineReducers({
   system: systemReducer,
@@ -42,21 +42,8 @@ const globalReducer = combineReducers({
   dashboard: dashboardReducer,
 });
 
-declare global {
-  interface Window {
-    __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: typeof compose;
-  }
-}
-
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-
 export type AppState = ReturnType<typeof globalReducer>;
 
-export const store = createStore(
-  globalReducer,
-  composeEnhancers(applyMiddleware(thunk))
-);
-
-export default function configureStore() {
-  return store;
-}
+export const store = configureStore({
+  reducer: globalReducer,
+});

--- a/portal-ui/yarn.lock
+++ b/portal-ui/yarn.lock
@@ -2018,6 +2018,16 @@
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
 
+"@reduxjs/toolkit@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.1.tgz#94ee1981b8cf9227cda40163a04704a9544c9a9f"
+  integrity sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==
+  dependencies:
+    immer "^9.0.7"
+    redux "^4.1.2"
+    redux-thunk "^2.4.1"
+    reselect "^4.1.5"
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -9820,15 +9830,22 @@ reduce-css-calc@^2.1.8:
     css-unit-converter "^1.1.1"
     postcss-value-parser "^3.3.0"
 
-redux-thunk@^2.3.0:
+redux-thunk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
   integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
 
-redux@^4.0.0, redux@^4.0.5:
+redux@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
   integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
+redux@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
+  integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
   dependencies:
     "@babel/runtime" "^7.9.2"
 
@@ -9946,7 +9963,7 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-reselect@^4.0.0:
+reselect@^4.0.0, reselect@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
   integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==


### PR DESCRIPTION
Upgrading the Redux library to the new recommended Redux Toolkit, which is compatible with the current code, replacing the current dependency and updating the create store function is enough to do this.

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>