### PR TITLE
Update Operator API Test

### DIFF
--- a/.github/workflows/console-sa-secret.yaml
+++ b/.github/workflows/console-sa-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: console-sa-secret
+  namespace: minio-operator
+  annotations:
+    kubernetes.io/service-account.name: console-sa
+type: kubernetes.io/service-account-token

--- a/.github/workflows/deploy-tenant.sh
+++ b/.github/workflows/deploy-tenant.sh
@@ -66,6 +66,14 @@ function main() {
     check_tenant_status tenant-lite storage-lite
 
     kubectl proxy &
+
+    # Beginning  Kubernetes 1.24 ----> Service Account Token Secrets are not 
+    # automatically generated, to generate them manually, users must manually
+    # create the secret, for our examples where we lead people to get the JWT
+    # from the console-sa service account, they additionally need to manually
+    # generate the secret via
+    kubectl apply -f "${SCRIPT_DIR}/console-sa-secret.yaml"
+
 }
 
 main "$@"


### PR DESCRIPTION
@dvaldivia did an excellent Job in finding the root cause of this problem.
It was matter of updating `k8s` and `kind` to reproduce the issue locally.
To fix this problem, we should get token in a new way:

```sh
kubectl apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: console-sa-secret
  namespace: minio-operator
  annotations:
    kubernetes.io/service-account.name: console-sa
type: kubernetes.io/service-account-token
EOF


SA_TOKEN=$(kubectl -n minio-operator  get secret console-sa-secret -o jsonpath="{.data.token}" | base64 --decode)
echo $SA_TOKEN
```

Then assess whether we obtained the token or not and based on that we either fail or proceed with the test.