### PR TITLE
fix: getTimeFromTimestamp() incorrect padding for days

### DIFF
--- a/portal-ui/src/common/utils.ts
+++ b/portal-ui/src/common/utils.ts
@@ -557,22 +557,13 @@ export const getTimeFromTimestamp = (
   fullDate: boolean = false
 ) => {
   const timestampToInt = parseInt(timestamp);
-
   if (isNaN(timestampToInt)) {
     return "";
   }
   const dateObject = new Date(timestampToInt * 1000);
 
   if (fullDate) {
-    return `${dateObject.getFullYear()}-${String(
-      dateObject.getMonth() + 1
-    ).padStart(2, "0")}-${String(dateObject.getDay()).padStart(
-      2,
-      "0"
-    )} ${dateObject.getHours()}:${String(dateObject.getMinutes()).padStart(
-      2,
-      "0"
-    )}:${String(dateObject.getSeconds()).padStart(2, "0")}`;
+    return dateObject.toLocaleString();
   }
   return `${dateObject.getHours()}:${String(dateObject.getMinutes()).padStart(
     2,


### PR DESCRIPTION
use a simpler function to return localeString() instead.