### PR TITLE
Wait for PVC to be bounded

### DIFF
--- a/portal-ui/tests/operator/tenants.ts
+++ b/portal-ui/tests/operator/tenants.ts
@@ -78,10 +78,8 @@ const checkPodDescribeHasSections = async () => {
 };
 
 test("Test describe section for PVCs in new tenant", async (t) => {
-  const tenantName = `tenant-${Math.floor(Math.random() * 10000)}`;
+  const tenantName = `storage-lite`;
   await loginToOperator();
-  await createTenant(tenantName);
-  await t.wait(20000); // wait for PVCs to be created
   await testPvcDescribe(tenantName);
   await redirectToTenantsList();
   await deleteTenant(tenantName);

--- a/portal-ui/tests/scripts/operator.sh
+++ b/portal-ui/tests/scripts/operator.sh
@@ -165,6 +165,9 @@ function install_tenant() {
 	--selector $key=$value \
 	--timeout=300s
 
+	echo "Wait for Prometheus PVC to be bound"
+	while [[ $(kubectl get pvc storage-lite-prometheus-storage-lite-prometheus-0 -n tenant-lite -o 'jsonpath={..status.phase}') != "Bound" ]]; do echo "waiting for PVC status" && sleep 1 && kubectl get pvc -A; done
+
 	echo "Build passes basic tenant creation"
 
 }


### PR DESCRIPTION
Guys, I still see failures at `✖ Test describe section for PVCs in new tenant` even when the wait was incremented dramatically:
```tsx
await t.wait(20000); // wait for PVCs to be created
```
I have an idea that I would like to implement, rather than creating the tenant on the test, we should use a tenant already created during the setup and in the setup we can just wait for Prometheus PVC to be completed, that way our test will always get or be able to read those PVCs right away without having to wait for x amount of time.

By the way, by personal experience I know that PVC for Prometheus is the longest to be bounded, so once Prometheus PVC is bound all other are bound as well.