### PR TITLE
Fixed dashboards capacity Widgets

### DIFF
--- a/portal-ui/src/common/types.ts
+++ b/portal-ui/src/common/types.ts
@@ -456,3 +456,8 @@ export interface IRetentionConfig {
   unit: string;
   validity: number;
 }
+
+export interface IBytesCalc {
+  total: number;
+  unit: string;
+}

--- a/portal-ui/src/common/utils.ts
+++ b/portal-ui/src/common/utils.ts
@@ -16,6 +16,7 @@
 
 import storage from "local-storage-fallback";
 import {
+  IBytesCalc,
   ICapacity,
   IErasureCodeCalc,
   IStorageDistribution,
@@ -576,7 +577,7 @@ export const calculateBytes = (
   showDecimals = false,
   roundFloor = true,
   k8sUnit = false
-) => {
+): IBytesCalc => {
   let bytes;
 
   if (typeof x === "string") {
@@ -695,4 +696,16 @@ export const getCookieValue = (cookieName: string) => {
       .match("(^|;)\\s*" + cookieName + "\\s*=\\s*([^;]+)")
       ?.pop() || ""
   );
+};
+
+export const capacityColors = (usedSpace: number, maxSpace: number) => {
+  const percCalculate = (usedSpace * 100) / maxSpace;
+
+  if (percCalculate >= 90) {
+    return "#C83B51";
+  } else if (percCalculate >= 70) {
+    return "#FFAB0F";
+  }
+
+  return "#07193E";
 };

--- a/portal-ui/src/screens/Console/Dashboard/BasicDashboard/DriveInfoItem.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/BasicDashboard/DriveInfoItem.tsx
@@ -19,7 +19,11 @@ import { Theme } from "@mui/material/styles";
 import createStyles from "@mui/styles/createStyles";
 import withStyles from "@mui/styles/withStyles";
 import { IDriveInfo } from "../types";
-import { niceBytes, niceBytesInt } from "../../../../common/utils";
+import {
+  capacityColors,
+  niceBytes,
+  niceBytesInt,
+} from "../../../../common/utils";
 import { Box } from "@mui/material";
 import { Cell, Pie, PieChart } from "recharts";
 import { CircleIcon } from "../../../../icons";
@@ -48,11 +52,13 @@ const driveStatusColor = (health_status: string) => {
 };
 
 const DriveInfoItem = ({ drive }: ICardProps) => {
+  const freeSpace = drive.totalSpace - drive.usedSpace;
+
   const plotValues = [
-    { value: drive.totalSpace, color: "#D6D6D6", label: "Free Space" },
+    { value: freeSpace, color: "#D6D6D6", label: "Free Space" },
     {
       value: drive.usedSpace,
-      color: "#073052",
+      color: capacityColors(drive.usedSpace, drive.totalSpace),
       label: "Used Space",
     },
   ];

--- a/restapi/admin_info.go
+++ b/restapi/admin_info.go
@@ -27,14 +27,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/minio/madmin-go"
-
-	"github.com/go-openapi/swag"
-
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/swag"
 	"github.com/minio/console/models"
 	"github.com/minio/console/restapi/operations"
 	systemApi "github.com/minio/console/restapi/operations/system"
+	"github.com/minio/madmin-go"
 )
 
 func registerAdminInfoHandlers(api *operations.ConsoleAPI) {
@@ -222,7 +220,7 @@ var widgets = []Metric{
 	},
 	{
 		ID:            50,
-		Title:         "Current Usable Capacity",
+		Title:         "Current Usable Free Capacity",
 		Type:          "gauge",
 		MaxDataPoints: 100,
 		GridPos: GridPos{
@@ -240,7 +238,43 @@ var widgets = []Metric{
 		},
 		Targets: []Target{
 			{
+				Expr:         `topk(1, sum(minio_cluster_capacity_usable_total_bytes{$__query}) by (instance))`,
+				LegendFormat: "Total Usable",
+				Step:         300,
+			},
+			{
 				Expr:         `topk(1, sum(minio_cluster_capacity_usable_free_bytes{$__query}) by (instance))`,
+				LegendFormat: "Usable Free",
+				Step:         300,
+			},
+			{
+				Expr:         `topk(1, sum(minio_cluster_capacity_usable_total_bytes{$__query}) by (instance)) - topk(1, sum(minio_cluster_capacity_usable_free_bytes{$__query}) by (instance))`,
+				LegendFormat: "Used Space",
+				Step:         300,
+			},
+		},
+	},
+	{
+		ID:            51,
+		Title:         "Current Usable Total Bytes",
+		Type:          "gauge",
+		MaxDataPoints: 100,
+		GridPos: GridPos{
+			H: 6,
+			W: 3,
+			X: 6,
+			Y: 0,
+		},
+		Options: MetricOptions{
+			ReduceOptions: ReduceOptions{
+				Calcs: []string{
+					"lastNotNull",
+				},
+			},
+		},
+		Targets: []Target{
+			{
+				Expr:         `topk(1, sum(minio_cluster_capacity_usable_total_bytes{$__query}) by (instance))`,
 				LegendFormat: "",
 				Step:         300,
 			},


### PR DESCRIPTION
## What does this do?

- Added new calculation for prometheus capacity
- Added indicator colors to capacity widgets
- Adjusted capacity in drives for common dashboard

## How does it look?

<img width="675" alt="Screen Shot 2022-05-30 at 21 15 42" src="https://user-images.githubusercontent.com/33497058/171083811-bd663267-15f6-48b6-8262-2098c27b9d54.png">
<img width="293" alt="Screen Shot 2022-05-30 at 21 35 27" src="https://user-images.githubusercontent.com/33497058/171083805-d1739e17-cfb7-40ae-bea2-56f83baff116.png">
<img width="345" alt="Screen Shot 2022-05-30 at 21 33 41" src="https://user-images.githubusercontent.com/33497058/171083808-9e2d08a4-8957-4e45-91f0-1b4fb8802bde.png">
<img width="303" alt="Screen Shot 2022-05-30 at 21 56 38" src="https://user-images.githubusercontent.com/33497058/171083851-108d76f7-f1f9-45fe-a3bc-5ed4eeb2f07e.png">

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>