### PR TITLE
Fix Login Box height while loading

### DIFF
--- a/portal-ui/src/screens/LoginPage/LoginPage.tsx
+++ b/portal-ui/src/screens/LoginPage/LoginPage.tsx
@@ -213,15 +213,6 @@ const styles = (theme: Theme) =>
     linearPredef: {
       height: 10,
     },
-
-    loaderAlignment: {
-      display: "flex",
-      width: "100%",
-      height: "100%",
-      justifyContent: "center",
-      alignItems: "center",
-      flexDirection: "column",
-    },
     retryButton: {
       alignSelf: "flex-end",
     },
@@ -562,7 +553,7 @@ const Login = ({ classes }: ILoginProps) => {
     }
     default:
       loginComponent = (
-        <div className={classes.loaderAlignment}>
+        <div style={{ textAlign: "center" }}>
           {loadingFetchConfiguration ? (
             <Loader className={classes.loadingLoginStrategy} />
           ) : (


### PR DESCRIPTION
Now:
<img width="1366" alt="Screen Shot 2022-05-31 at 3 23 08 PM" src="https://user-images.githubusercontent.com/18384552/171294222-03a64b78-fc18-4e3f-b1b0-4f06cd98fae3.png">


Before:

<img width="1366" alt="Screen Shot 2022-05-31 at 3 23 02 PM" src="https://user-images.githubusercontent.com/18384552/171294214-d1bb66e3-cac6-4283-9e3a-d9e082c16b46.png">


Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>