### PR TITLE
Test list of claims

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1521,7 +1521,7 @@ jobs:
           go tool cover -func=all.out | grep total > tmp2
           result=`cat tmp2 | awk 'END {print $3}'`
           result=${result%\%}
-          threshold=50.6
+          threshold=50.9
           echo "Result:"
           echo "$result%"
           if (( $(echo "$result >= $threshold" |bc -l) )); then


### PR DESCRIPTION
Fixes https://github.com/miniohq/engineering/issues/607

The idea is to test that we can list the PVCs of a Tenant via API
And increment the coverage for that missing test
This is to test `swagger-operator.yml` since many endpoints are still missing to be tested there.

This will increment `.3%` our coverage:

```
-          threshold=50.6
+          threshold=50.9
```