### PR TITLE
[WIP] - Test login/logout in Operator API

### DIFF
--- a/operator-integration/tenant_test.go
+++ b/operator-integration/tenant_test.go
@@ -143,9 +143,6 @@ func TestMain(m *testing.M) {
 	fmt.Println("after 2 seconds sleep")
 
 	fmt.Println("creating the client")
-	client := &http.Client{
-		Timeout: 2 * time.Second,
-	}
 
 	// SA_TOKEN=$(kubectl -n minio-operator  get secret console-sa-secret -o jsonpath="{.data.token}" | base64 --decode)
 	fmt.Println("Where we have the secret already: ")
@@ -175,24 +172,8 @@ func TestMain(m *testing.M) {
 		fmt.Println("jwt cannot be empty string")
 		os.Exit(-1)
 	}
-	requestData := map[string]string{
-		"jwt": secret3,
-	}
-	fmt.Println("requestData: ", requestData)
 
-	requestDataJSON, _ := json.Marshal(requestData)
-
-	requestDataBody := bytes.NewReader(requestDataJSON)
-
-	request, err := http.NewRequest("POST", "http://localhost:9090/api/v1/login/operator", requestDataBody)
-	if err != nil {
-		log.Println(err)
-		return
-	}
-
-	request.Header.Add("Content-Type", "application/json")
-
-	response, err := client.Do(request)
+	response, err := LoginOperator(secret3)
 	if err != nil {
 		log.Println(err)
 		return
@@ -726,4 +707,32 @@ func TestListPVCsForTenant(t *testing.T) {
 	for i := 0; i < len(pvcArray); i++ {
 		assert.Equal(strings.Contains(listObjs.Pvcs[i].Name, pvcArray[i]), true)
 	}
+}
+
+func LoginOperator(jwt string) (*http.Response, error) {
+	/*
+		Description: Login to Operator Console.
+		URL: /login/operator
+		Params in the Body: jwt
+	*/
+	requestData := map[string]string{
+		"jwt": jwt,
+	}
+	fmt.Println("requestData: ", requestData)
+
+	requestDataJSON, _ := json.Marshal(requestData)
+
+	requestDataBody := bytes.NewReader(requestDataJSON)
+
+	request, err := http.NewRequest("POST", "http://localhost:9090/api/v1/login/operator", requestDataBody)
+	if err != nil {
+		log.Println(err)
+	}
+
+	request.Header.Add("Content-Type", "application/json")
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	response, err := client.Do(request)
+	return response, err
 }


### PR DESCRIPTION
The idea of this PR is to test both end points without affecting current tests:

Fixes https://github.com/miniohq/engineering/issues/609
Fixes https://github.com/miniohq/engineering/issues/611

```yaml
  /login/operator:
    post:
      summary: Login to Operator Console.
      operationId: LoginOperator
      parameters:
        - name: body
          in: body
          required: true
          schema:
            $ref: "#/definitions/loginOperatorRequest"
      responses:
        204:
          description: A successful login.
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      security: [ ]
      tags:
        - Auth
```

```yaml
  /logout:
    post:
      summary: Logout from Operator.
      operationId: Logout
      responses:
        200:
          description: A successful response.
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - Auth
```