### PR TITLE
Add bucket replication test

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1368,7 +1368,22 @@ jobs:
           echo "We are going to use the built image on test-integration";
           VERSION="minio/minio:$VERSION";
           echo $VERSION;
-          make test-integration MINIO_VERSION=$VERSION;
+          
+          echo "Create bucket for replication with versioning"
+          echo "Download mc for Ubuntu"
+          wget -q https://dl.min.io/client/mc/release/linux-amd64/mc
+          echo "Change the permissions to execute mc command"
+          chmod +x mc
+          echo "Create the folder to put the all.out file"
+          TARGET_BUCKET=`echo $RANDOM | md5sum | head -c 20; echo;`
+          echo "TARGET_BUCKET: ${TARGET_BUCKET}"
+          ./mc mb --ignore-existing play/${TARGET_BUCKET}/
+          ./mc version enable play/${TARGET_BUCKET}
+          # Via API we are going to test:
+          # mc admin bucket remote add myminio/source https://minioadmin:minioadmin@play.min.io/target --service "replication"
+          # expected output is: Remote ARN = `arn:minio:replication::f5bdb8d7-541d-415e-aaf4-592979484ba9:target`.
+          
+          make test-integration MINIO_VERSION=$VERSION TARGET_BUCKET=$TARGET_BUCKET;
 
       - uses: actions/cache@v2
         id: coverage-cache
@@ -1521,7 +1536,7 @@ jobs:
           go tool cover -func=all.out | grep total > tmp2
           result=`cat tmp2 | awk 'END {print $3}'`
           result=${result%\%}
-          threshold=51.00
+          threshold=51.40
           echo "Result:"
           echo "$result%"
           if (( $(echo "$result >= $threshold" |bc -l) )); then

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BUILD_VERSION:=$(shell git describe --exact-match --tags $(git log -n1 --pretty=
 BUILD_TIME:=$(shell date 2>/dev/null)
 TAG ?= "minio/console:$(BUILD_VERSION)-dev"
 MINIO_VERSION ?= "quay.io/minio/minio:latest"
+TARGET_BUCKET ?= "target"
 
 default: console
 
@@ -74,8 +75,8 @@ test-integration:
 	@echo $(MINIO_VERSION)
 	@(docker run -v /data1 -v /data2 -v /data3 -v /data4 --net=mynet123 -d --name minio --rm -p 9000:9000 -p 9001:9001 -e MINIO_KMS_SECRET_KEY=my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw= $(MINIO_VERSION) server /data{1...4} --console-address ':9001' && sleep 5)
 	@(docker run --net=mynet123 --ip=173.18.0.3 --name pgsqlcontainer --rm -p 5432:5432 -e POSTGRES_PASSWORD=password -d postgres && sleep 5)
-	@echo "execute test and get coverage"
-	@(cd integration && go test -coverpkg=../restapi -c -tags testrunmain . && mkdir -p coverage && ./integration.test -test.v -test.run "^Test*" -test.coverprofile=coverage/system.out)
+	@echo "execute test and get coverage for test-integration:"
+	@(cd integration && go test -coverpkg=../restapi -c -tags testrunmain . && mkdir -p coverage && export THETARGET=$(TARGET_BUCKET) && echo "THETARGET: ${THETARGET}" && ./integration.test -test.v -test.run "^Test*" -test.coverprofile=coverage/system.out)
 	@(docker stop pgsqlcontainer)
 	@(docker stop minio)
 	@(docker network rm mynet123)


### PR DESCRIPTION
To test these endpoints using `https://play.min.io` as our remote bucket:

```yaml
  /remote-buckets:
    get:
      summary: List Remote Buckets
      operationId: ListRemoteBuckets
      responses:
        200:
          description: A successful response.
          schema:
            $ref: "#/definitions/listRemoteBucketsResponse"
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - Bucket
    post:
      summary: Add Remote Bucket
      operationId: AddRemoteBucket
      parameters:
        - name: body
          in: body
          required: true
          schema:
            $ref: "#/definitions/createRemoteBucket"
      responses:
        201:
          description: A successful response.
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - Bucket
```

I believe this `play` approach is better and easier than having to create two internal containers with two internal servers because `play` is already configured and easy to use, we require less lines of code to perform the same testing and it will actually test a real remote bucket connection rather than having two containers under the same or different network. Plus we are already using `play` for coverage and it has been proven useful.


### To test this in IntelliJ or GoLand

Make sure to set the environment variable as our `Makefile` does, to do so edit the configurations and set the environmental variables:

<img width="1152" alt="Screen Shot 2022-06-03 at 2 38 31 PM" src="https://user-images.githubusercontent.com/6667358/171926101-1d0a3bc5-1201-46f9-a159-dbd685cc98d2.png">

Where you should get the bucket from play: `TARGET_BUCKET=d39b1f1167408636e0ae`

### Coverage:

```sh
-          threshold=51.00
+          threshold=51.40
```