### PR TITLE
Have TenantItem charts use capacity instead of raw capacity

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/ListTenants/TenantListItem.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/TenantListItem.tsx
@@ -210,7 +210,7 @@ const TenantListItem = ({ tenant, classes }: ITenantListItem) => {
             <Grid container>
               <Grid item xs={2}>
                 <TenantCapacity
-                  totalCapacity={tenant.capacity_raw || 0}
+                  totalCapacity={tenant.capacity || 0}
                   usedSpaceVariants={spaceVariants}
                   statusClass={healthStatusToClass(tenant.health_status)}
                 />


### PR DESCRIPTION
Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>