### PR TITLE
Add Tenant Log Test

### DIFF
--- a/operator-integration/tenant_test.go
+++ b/operator-integration/tenant_test.go
@@ -868,3 +868,131 @@ func TestLogout(t *testing.T) {
 		assert.Fail("authentication token not found in cookies response")
 	}
 }
+
+func GetTenantLogs(nameSpace, tenant string) (*http.Response, error) {
+	/*
+		URL: /namespaces/{namespace}/tenants/{tenant}/log
+		summary: Get Tenant Logs
+		HTTP Verb:GET
+	*/
+	request, err := http.NewRequest(
+		"GET",
+		"http://localhost:9090/api/v1/namespaces/"+nameSpace+"/tenants/"+tenant+"/log",
+		nil,
+	)
+	if err != nil {
+		log.Println(err)
+	}
+	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+	request.Header.Add("Content-Type", "application/json")
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	response, err := client.Do(request)
+	return response, err
+}
+
+func SetTenantLogs(labels, annotations, nodeSelector, dbLabels, dbAnnotations, dbNodeSelector []string, nameSpace, tenant, dbServiceAccountName, logMemRequest, logDBMemRequest, diskCapacityGB, serviceAccountName string) (*http.Response, error) {
+	/*
+		URL: /namespaces/{namespace}/tenants/{tenant}/log
+		summary: Set Tenant Logs
+		HTTP Verb: PUT
+	*/
+	requestDataAdd := map[string]interface{}{
+		"labels":               labels,
+		"annotations":          annotations,
+		"dbAnnotations":        dbAnnotations,
+		"dbLabels":             dbLabels,
+		"dbNodeSelector":       dbNodeSelector,
+		"diskCapacityGB":       diskCapacityGB,
+		"nodeSelector":         nodeSelector,
+		"serviceAccountName":   serviceAccountName,
+		"dbServiceAccountName": dbServiceAccountName,
+		"logMemRequest":        logMemRequest,
+		"logDBMemRequest":      logDBMemRequest,
+	}
+	requestDataJSON, _ := json.Marshal(requestDataAdd)
+	requestDataBody := bytes.NewReader(requestDataJSON)
+	request, err := http.NewRequest(
+		"PUT",
+		"http://localhost:9090/api/v1/namespaces/"+nameSpace+"/tenants/"+tenant+"/log",
+		requestDataBody,
+	)
+	if err != nil {
+		log.Println(err)
+	}
+	request.Header.Add("Cookie", fmt.Sprintf("token=%s", token))
+	request.Header.Add("Content-Type", "application/json")
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	response, err := client.Do(request)
+	return response, err
+}
+
+func TestGetTenantLogs(t *testing.T) {
+	// Vars
+	assert := assert.New(t)
+	namespace := "tenant-lite"
+	tenant := "storage-lite"
+
+	// Get Log Settings
+	resp, err := GetTenantLogs(namespace, tenant)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	if resp != nil {
+		assert.Equal(
+			200,
+			resp.StatusCode,
+			inspectHTTPResponse(resp),
+		)
+	}
+}
+
+func TestSetTenantLogs(t *testing.T) {
+	// Vars
+	assert := assert.New(t)
+	nameSpace := "tenant-lite"
+	tenant := "storage-lite"
+	var nodeSelector []string
+	var labels []string
+	var annotations []string
+	var dbAnnotations []string
+	var dbNodeSelector []string
+	var dbLabels []string
+	diskCapacityGB := "2"
+	dbServiceAccountName := ""
+	logMemRequest := "0Gi"
+	logDBMemRequest := "0Gi"
+	serviceAccountName := ""
+
+	// Set Tenant Logs
+	resp, err := SetTenantLogs(
+		labels,
+		annotations,
+		nodeSelector,
+		dbLabels,
+		dbAnnotations,
+		dbNodeSelector,
+		nameSpace,
+		tenant,
+		dbServiceAccountName,
+		logMemRequest,
+		logDBMemRequest,
+		diskCapacityGB,
+		serviceAccountName,
+	)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	if resp != nil {
+		assert.Equal(
+			200,
+			resp.StatusCode,
+			inspectHTTPResponse(resp),
+		)
+	}
+}


### PR DESCRIPTION
Fix https://github.com/miniohq/engineering/issues/602

To test end points:

```yaml
  /namespaces/{namespace}/tenants/{tenant}/log:
    get:
      summary: Get Tenant Logs
      operationId: GetTenantLogs
      parameters:
        - name: namespace
          in: path
          required: true
          type: string
        - name: tenant
          in: path
          required: true
          type: string
      responses:
        200:
          description: A successful response.
          schema:
            $ref: "#/definitions/tenantLogs"
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - OperatorAPI
    put:
      summary: Set Tenant Logs
      operationId: SetTenantLogs
      parameters:
        - name: namespace
          in: path
          required: true
          type: string
        - name: tenant
          in: path
          required: true
          type: string
        - name: data
          in: body
          required: true
          schema:
            $ref: "#/definitions/tenantLogs"
      responses:
        200:
          description: A successful response.
          schema:
            type: boolean
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - OperatorAPI
```