### PR TITLE
Delete remote bucket test

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1605,7 +1605,7 @@ jobs:
           go tool cover -func=all.out | grep total > tmp2
           result=`cat tmp2 | awk 'END {print $3}'`
           result=${result%\%}
-          threshold=52.20
+          threshold=52.60
           echo "Result:"
           echo "$result%"
           if (( $(echo "$result >= $threshold" |bc -l) )); then


### PR DESCRIPTION
It is testing end point(s):

```yaml
  /remote-buckets/{name}:
    get:
      summary: Remote Bucket Details
      operationId: RemoteBucketDetails
      parameters:
        - name: name
          in: path
          required: true
          type: string
      responses:
        200:
          description: A successful response.
          schema:
            $ref: "#/definitions/remoteBucket"
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - Bucket
```

```yaml
  /remote-buckets/{source-bucket-name}/{arn}:
    delete:
      summary: Delete Remote Bucket
      operationId: DeleteRemoteBucket
      parameters:
        - name: source-bucket-name
          in: path
          required: true
          type: string
        - name: arn
          in: path
          required: true
          type: string
      responses:
        204:
          description: A successful response.
        default:
          description: Generic error response.
          schema:
            $ref: "#/definitions/error"
      tags:
        - Bucket
```

### Coverage:

```sh
-          threshold=52.20
+          threshold=52.60
```