### PR TITLE
Reduce renders in User Name when adding a user

### DIFF
--- a/portal-ui/src/screens/Console/Policies/PolicySelectors.tsx
+++ b/portal-ui/src/screens/Console/Policies/PolicySelectors.tsx
@@ -36,11 +36,12 @@ import TableWrapper from "../Common/TableWrapper/TableWrapper";
 import SearchBox from "../Common/SearchBox";
 import { setModalErrorSnackMessage } from "../../../systemSlice";
 import { useAppDispatch } from "../../../store";
+import { setSelectedPolicies } from "../Users/AddUsersSlice";
+
 
 interface ISelectPolicyProps {
   classes: any;
   selectedPolicy?: string[];
-  setSelectedPolicy: any;
 }
 
 const styles = (theme: Theme) =>
@@ -77,7 +78,6 @@ const styles = (theme: Theme) =>
 const PolicySelectors = ({
   classes,
   selectedPolicy = [],
-  setSelectedPolicy,
 }: ISelectPolicyProps) => {
   const dispatch = useAppDispatch();
   // Local State
@@ -129,7 +129,7 @@ const PolicySelectors = ({
     // remove empty values
     elements = elements.filter((element) => element !== "");
 
-    setSelectedPolicy(elements);
+    dispatch(setSelectedPolicies(elements));
   };
 
   const filteredRecords = records.filter((elementItem) =>

--- a/portal-ui/src/screens/Console/Policies/SetPolicy.tsx
+++ b/portal-ui/src/screens/Console/Policies/SetPolicy.tsx
@@ -173,7 +173,6 @@ const SetPolicy = ({
           <div className={classes.tableBlock}>
             <PolicySelectors
               selectedPolicy={selectedPolicy}
-              setSelectedPolicy={setSelectedPolicy}
             />
           </div>
         </Grid>

--- a/portal-ui/src/screens/Console/Users/AddUsersSlice.tsx
+++ b/portal-ui/src/screens/Console/Users/AddUsersSlice.tsx
@@ -1,0 +1,105 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import {
+    createUserAsync,
+    resetFormAsync,
+} from "./thunk/AddUsersThunk";
+
+export interface ICreateUser {
+    userName: string;
+    secretKey: string;
+    selectedGroups: string[];
+    selectedPolicies: string[];
+    showPassword: boolean;
+    sendEnabled: boolean;
+    addLoading: boolean;
+    apinoerror: boolean;
+}
+
+const initialState: ICreateUser = {
+    addLoading: false,
+    showPassword: false,
+    sendEnabled: false,
+    apinoerror: false,
+    userName: "",
+    secretKey: "",
+    selectedGroups: [],
+    selectedPolicies: [],
+};
+
+export const createUserSlice = createSlice({
+    name: "createUser",
+    initialState,
+    reducers: {
+        setAddLoading: (state, action: PayloadAction<boolean>) => {
+            state.addLoading = action.payload;
+        },
+        setUserName: (state, action: PayloadAction<string>) => {
+            state.userName = action.payload;
+        },
+        setSelectedGroups: (state, action: PayloadAction<string[]>) => {
+            state.selectedGroups = action.payload;
+        },
+        setSecretKey: (state, action: PayloadAction<string>) => {
+            state.secretKey = action.payload;
+        },
+        setSelectedPolicies: (state, action: PayloadAction<string[]>) => {
+            state.selectedPolicies = action.payload;
+        },
+        setShowPassword: (state, action: PayloadAction<boolean>) => {
+            state.showPassword = action.payload;
+        },
+        setSendEnabled: (state) => {
+            state.sendEnabled = state.userName.trim() !== "";
+        },
+        setApinoerror: (state, action: PayloadAction<boolean>) => {
+            state.apinoerror = action.payload;
+        },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(resetFormAsync.fulfilled, (state, action) => {
+                state.userName = "";
+                state.selectedGroups = [];
+                state.secretKey = "";
+                state.selectedPolicies = [];
+                state.showPassword = false;
+            })
+            .addCase(createUserAsync.pending, (state, action) => {
+                state.addLoading = true;
+            })
+            .addCase(createUserAsync.rejected, (state, action) => {
+                state.addLoading = false;
+            })
+            .addCase(createUserAsync.fulfilled, (state, action) => {
+                state.apinoerror = true;
+            });
+    },
+});
+
+export const {
+    setUserName,
+    setSelectedGroups,
+    setSecretKey,
+    setSelectedPolicies,
+    setShowPassword,
+    setAddLoading,
+    setSendEnabled,
+    setApinoerror,
+} = createUserSlice.actions;
+
+export default createUserSlice.reducer;

--- a/portal-ui/src/screens/Console/Users/SetUserPolicies.tsx
+++ b/portal-ui/src/screens/Console/Users/SetUserPolicies.tsx
@@ -110,7 +110,6 @@ const SetUserPolicies = ({
         <Grid item xs={12}>
           <PolicySelectors
             selectedPolicy={selectedPolicy}
-            setSelectedPolicy={setSelectedPolicy}
           />
         </Grid>
       </Grid>

--- a/portal-ui/src/screens/Console/Users/UserSelector.tsx
+++ b/portal-ui/src/screens/Console/Users/UserSelector.tsx
@@ -1,0 +1,51 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Fragment } from "react";
+import InputBoxWrapper from "../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
+import { setUserName } from "./AddUsersSlice";
+import { useDispatch, useSelector } from "react-redux";
+import {AppState} from "../../../store";
+
+interface IAddUserProps2 {
+    classes: any;
+}
+
+const UserSelector = ({ classes }: IAddUserProps2 ) => {
+    const dispatch = useDispatch();
+    const userName = useSelector(
+        (state: AppState) => state.createUser.userName
+    )
+    return (
+        <Fragment>
+            <InputBoxWrapper
+                className={classes.spacerBottom}
+                classes={{
+                    inputLabel: classes.sizedLabel,
+                }}
+                id="accesskey-input"
+                name="accesskey-input"
+                label="User Name"
+                value={userName}
+                autoFocus={true}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    dispatch(setUserName(e.target.value));
+                }}
+            />
+        </Fragment>
+    );
+};
+export default UserSelector;

--- a/portal-ui/src/screens/Console/Users/thunk/AddUsersThunk.tsx
+++ b/portal-ui/src/screens/Console/Users/thunk/AddUsersThunk.tsx
@@ -1,0 +1,68 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import {
+    setSelectedGroups,
+    setUserName,
+    setSecretKey,
+    setSelectedPolicies,
+    setShowPassword,
+    setAddLoading,
+} from "../AddUsersSlice";
+import {AppState} from "../../../../store";
+import api from "../../../../common/api";
+import {ErrorResponseHandler} from "../../../../common/types";
+import {setErrorSnackMessage} from "../../../../systemSlice";
+import history from "../../../../history";
+import {IAM_PAGES} from "../../../../common/SecureComponent/permissions";
+
+export const resetFormAsync = createAsyncThunk(
+    "resetForm/resetFormAsync",
+    async (_, { dispatch }) => {
+        dispatch(setSelectedGroups([]));
+        dispatch(setUserName(""));
+        dispatch(setSecretKey(""));
+        dispatch(setSelectedPolicies([]));
+        dispatch(setShowPassword(false));
+    }
+);
+
+export const createUserAsync = createAsyncThunk(
+    "createTenant/createNamespaceAsync",
+    async (_, { getState, rejectWithValue, dispatch }) => {
+        const state = getState() as AppState;
+        const accessKey = state.createUser.userName
+        const secretKey = state.createUser.secretKey
+        const selectedGroups = state.createUser.selectedGroups
+        const selectedPolicies = state.createUser.selectedPolicies
+        return api
+            .invoke("POST", "/api/v1/users", {
+                accessKey,
+                secretKey,
+                groups: selectedGroups,
+                policies: selectedPolicies,
+            })
+            .then((res) => {
+                dispatch(setAddLoading(false));
+                history.push(`${IAM_PAGES.USERS}`);
+            })
+            .catch((err: ErrorResponseHandler) => {
+                dispatch(setAddLoading(false));
+                dispatch(setErrorSnackMessage(err));
+            });
+    }
+);

--- a/portal-ui/src/store.ts
+++ b/portal-ui/src/store.ts
@@ -28,6 +28,7 @@ import objectBrowserReducer from "./screens/Console/ObjectBrowser/objectBrowserS
 import tenantsReducer from "./screens/Console/Tenants/tenantsSlice";
 import dashboardReducer from "./screens/Console/Dashboard/dashboardSlice";
 import createTenantReducer from "./screens/Console/Tenants/AddTenant/createTenantSlice";
+import createUserReducer from "./screens/Console/Users/AddUsersSlice";
 import addPoolReducer from "./screens/Console/Tenants/TenantDetails/Pools/AddPool/addPoolSlice";
 import editPoolReducer from "./screens/Console/Tenants/TenantDetails/Pools/EditPool/editPoolSlice";
 
@@ -45,6 +46,7 @@ const rootReducer = combineReducers({
   // Operator Reducers
   tenants: tenantsReducer,
   createTenant: createTenantReducer,
+  createUser: createUserReducer,
   addPool: addPoolReducer,
   editPool: editPoolReducer,
 });


### PR DESCRIPTION
## What does this do?

Reduce renders in User Name when adding a user (Notice only that field is being rendered, not the entire screen):

![reduce-renders](https://user-images.githubusercontent.com/6667358/172949951-5417412f-4a0e-4ac2-94ff-2b0bcefd6084.gif)

