### PR TITLE
Wait until resource exist to wait on it

### DIFF
--- a/portal-ui/tests/scripts/operator.sh
+++ b/portal-ui/tests/scripts/operator.sh
@@ -64,6 +64,7 @@ function install_operator() {
 	sleep 10
 
 	echo "Waiting for Operator Pods to come online (2m timeout)"
+	wait_for_resource minio-operator $value $key
 	try kubectl wait --namespace minio-operator \
 	--for=condition=ready pod \
 	--selector $key=$value \


### PR DESCRIPTION
There is a failure that I want to correct in this PR:

[Operator UI Tests (1.17.x, ubuntu-latest)](https://github.com/minio/console/runs/6973690098?check_suite_focus=true#logs)

https://github.com/minio/console/runs/6973690098?check_suite_focus=true

```sh
Waiting for Operator Pods to come online (2m timeout)
timed out waiting for the condition on pods/minio-operator-6b59dbc778-6cnn4
timed out waiting for the condition on pods/minio-operator-6b59dbc778-jpmzx
/home/runner/work/console/console/portal-ui/tests/scripts/operator.sh: cannot kubectl wait --namespace minio-operator --for=condition=ready pod --selector name=minio-operator --timeout=120s
Deleting cluster "kind" ...
Error: Process completed with exit code 111.
```

The reason is that we are failing on the wait because I suspect the resource is still not present.
So If we add a function to wait until resource is present and then we launch the kubectl command, this should work!