### PR TITLE
Improving our Operator Test in console

### DIFF
--- a/portal-ui/tests/scripts/operator.sh
+++ b/portal-ui/tests/scripts/operator.sh
@@ -63,12 +63,17 @@ function install_operator() {
 	echo "Waiting for k8s api"
 	sleep 10
 
-	echo "Waiting for Operator Pods to come online (2m timeout)"
+	echo "wait for the app=console to be present -> One Pod"
+	wait_for_resource minio-operator console app
+
+	echo "wait for the name=minio-operator to be present -> Two Pods"
 	wait_for_resource minio-operator $value $key
+
+	echo "Waiting for Operator Pods to come online (3m timeout)"
 	try kubectl wait --namespace minio-operator \
 	--for=condition=ready pod \
 	--selector $key=$value \
-	--timeout=120s
+	--timeout=180s
 
 	echo "start - get data to verify proper image is being used"
 	kubectl get pods --namespace minio-operator


### PR DESCRIPTION
I still observe the same failure as before, and I am trying to fix this problem.
I think `kubectl wait` command is not yet ready at this point and maybe we should wait for the 3 pods from Operator to be present and then increment the timeout from 2 min to 3 min, let me try this approach to make the test more reliable.

# Console issue
# Operator UI Tests (1.17.x, ubuntu-latest)
https://github.com/minio/console/runs/6994192544?check_suite_focus=true
```
deployment.apps/minio-operator created
key, value for pod selector in kustomize test
Waiting for k8s api
Waiting for Operator Pods to come online (2m timeout)
command to wait on:
kubectl -n minio-operator get pods -l name=minio-operator --no-headers
Found 2 pods
timed out waiting for the condition on pods/minio-operator-f8f874647-4j6z9
timed out waiting for the condition on pods/minio-operator-f8f874647-752df
/home/runner/work/console/console/portal-ui/tests/scripts/operator.sh: cannot kubectl wait --namespace minio-operator --for=condition=ready pod --selector name=minio-operator --timeout=120s
Deleting cluster "kind" ...
Error: Process completed with exit code 111.
```

### Affected PR:

* https://github.com/minio/console/pull/2130