### PR TITLE
Added improvements to Rename modal in windows

### DIFF
--- a/portal-ui/src/screens/Console/ObjectBrowser/RenameLongFilename.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/RenameLongFilename.tsx
@@ -41,6 +41,7 @@ import { makeid, storeCallForObjectWithID } from "./transferManager";
 import { useAppDispatch } from "../../../store";
 import ModalWrapper from "../Common/ModalWrapper/ModalWrapper";
 import InputBoxWrapper from "../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
+import FormSwitchWrapper from "../Common/FormComponents/FormSwitchWrapper/FormSwitchWrapper";
 
 interface IRenameLongFilename {
   open: boolean;
@@ -71,7 +72,8 @@ const RenameLongFileName = ({
   const classes = useStyles();
   const dispatch = useAppDispatch();
 
-  const [newFileName, setNewFileName] = useState(currentItem);
+  const [newFileName, setNewFileName] = useState<string>(currentItem);
+  const [acceptLongName, setAcceptLongName] = useState<boolean>(false);
 
   const doDownload = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -140,7 +142,7 @@ const RenameLongFileName = ({
         This can cause issues on Windows Systems by trimming the file name after
         download.
         <br />
-        <br /> Would you like to rename the file for this download?
+        <br /> We recommend to rename the file download
       </div>
       <form
         noValidate
@@ -158,21 +160,39 @@ const RenameLongFileName = ({
                 onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                   setNewFileName(event.target.value);
                 }}
-                label="Filename for download"
+                label=""
                 type={"text"}
                 value={newFileName}
+                error={
+                  newFileName.length > 200 && !acceptLongName
+                    ? "Filename should be less than 200 characters long."
+                    : ""
+                }
+              />
+            </Grid>
+            <Grid item xs={12} className={classes.formFieldRow}>
+              <FormSwitchWrapper
+                value="acceptLongName"
+                id="acceptLongName"
+                name="acceptLongName"
+                checked={acceptLongName}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setAcceptLongName(event.target.checked);
+                  if (event.target.checked) {
+                    setNewFileName(currentItem);
+                  }
+                }}
+                label={"Use Original Name"}
               />
             </Grid>
           </Grid>
-          {newFileName.length > 200 && (
-            <Grid item xs={12}>
-              We suggest filename to be less than 200 characters long. <br />
-              Are you sure you want to continue?
-            </Grid>
-          )}
-
           <Grid item xs={12} className={classes.modalButtonBar}>
-            <Button type="submit" variant="contained" color="primary">
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              disabled={newFileName.length > 200 && !acceptLongName}
+            >
               Download File
             </Button>
           </Grid>


### PR DESCRIPTION
## What does this do?

- Disabled button when filename is less than 200 characters long
- Selector to override & accept long name
- Added this behavior when one file is checked in objects list

## How does it look?
<img width="949" alt="Screen Shot 2022-06-22 at 20 14 16" src="https://user-images.githubusercontent.com/33497058/175187046-9b75b725-48cf-4ea9-9939-364e0c80f2ae.png">
<img width="1016" alt="Screen Shot 2022-06-22 at 20 14 06" src="https://user-images.githubusercontent.com/33497058/175187051-0ff8c8b6-445a-418d-86a3-accd483a77df.png">
<img width="1904" alt="Screen Shot 2022-06-22 at 20 14 02" src="https://user-images.githubusercontent.com/33497058/175187054-a7d33f75-659e-45d6-857b-55458b2185a6.png">

