### PR TITLE
Fixed issues in Replication rules screens

### DIFF
--- a/integration/user_api_bucket_test.go
+++ b/integration/user_api_bucket_test.go
@@ -2787,10 +2787,7 @@ func TestReplication(t *testing.T) {
 	}
 	finalResponse := inspectHTTPResponse(response)
 	if response != nil {
-		// https://github.com/minio/minio/pull/14972
-		// Disallow deletion of arn when active replication config
-		// no longer 204 is expected due to above change
-		assert.Equal(500, response.StatusCode, finalResponse)
+		assert.Equal(204, response.StatusCode, finalResponse)
 	}
 
 	// 6. Delete 2nd rule only with dedicated end point for single rules:
@@ -2825,10 +2822,7 @@ func TestReplication(t *testing.T) {
 	}
 	finalResponse = inspectHTTPResponse(response)
 	if response != nil {
-		// https://github.com/minio/minio/pull/14972
-		// Disallow deletion of arn when active replication config
-		// 204 is no longer expected but 500
-		assert.Equal(500, response.StatusCode, finalResponse)
+		assert.Equal(204, response.StatusCode, finalResponse)
 	}
 
 	// 8. Get replication, at this point zero rules are expected
@@ -2850,7 +2844,7 @@ func TestReplication(t *testing.T) {
 		log.Println(err)
 		assert.Nil(err)
 	}
-	expected := 3 // none got deleted due to https://github.com/minio/minio/pull/14972
+	expected := 0
 	actual := len(structBucketRepl.Rules)
 	assert.Equal(expected, actual, "Delete failed")
 }

--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/AddReplicationModal.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/AddReplicationModal.tsx
@@ -170,10 +170,10 @@ const AddReplicationModal = ({
           setAddLoading(false);
 
           if (itemVal.errorString && itemVal.errorString !== "") {
-            setModalErrorSnackMessage({
+            dispatch(setModalErrorSnackMessage({
               errorMessage: itemVal.errorString,
               detailedError: "",
-            });
+            }));
             return;
           }
 
@@ -181,10 +181,10 @@ const AddReplicationModal = ({
 
           return;
         }
-        setModalErrorSnackMessage({
+        dispatch(setModalErrorSnackMessage({
           errorMessage: "No changes applied",
           detailedError: "",
-        });
+        }));
       })
       .catch((err: ErrorResponseHandler) => {
         setAddLoading(false);


### PR DESCRIPTION
fixes #2132 

## What does this do?

- Reconnected error messages in Add replication modals
- Fixed issue with  remote bucket deletion

## How does it look?

<img width="1475" alt="Screen Shot 2022-06-23 at 19 35 31" src="https://user-images.githubusercontent.com/33497058/175437568-be2446a9-7eb6-44e7-af6a-ada90e913a64.png">
<img width="1425" alt="Screen Shot 2022-06-23 at 19 35 27" src="https://user-images.githubusercontent.com/33497058/175437569-50f4fc28-a944-48cf-9bd4-2fa0cefb8f0c.png">
<img width="1477" alt="Screen Shot 2022-06-23 at 19 35 19" src="https://user-images.githubusercontent.com/33497058/175437574-76f2e1d4-568f-47ea-ac8a-26a287097db6.png">
<img width="1448" alt="Screen Shot 2022-06-23 at 19 34 27" src="https://user-images.githubusercontent.com/33497058/175437575-821af435-6c22-48ac-951f-37afdb6d526a.png">
<img width="1320" alt="Screen Shot 2022-06-23 at 19 34 23" src="https://user-images.githubusercontent.com/33497058/175437576-6666a43a-f3f9-4d42-ba70-8a50d92a56a9.png">
<img width="1095" alt="Screen Shot 2022-06-23 at 19 34 16" src="https://user-images.githubusercontent.com/33497058/175437577-1dac0311-f8a8-40dc-8b5a-957c9dc2e52f.png">
<img width="1684" alt="Screen Shot 2022-06-23 at 19 34 02" src="https://user-images.githubusercontent.com/33497058/175437578-28d2ea63-92a1-4f2b-937c-cbb9fd0b2d64.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>