### PR TITLE
Avoid the crash in the test

### DIFF
--- a/operator-integration/tenant_test.go
+++ b/operator-integration/tenant_test.go
@@ -635,7 +635,10 @@ func TestListTenantsByNameSpace(t *testing.T) {
 		log.Println(err)
 		assert.Nil(err)
 	}
-	TenantName := &result.Tenants[0].Name // The array has to be empty, no index accessible
+	if len(result.Tenants) == 0 {
+		assert.Fail("FAIL: There are no tenants in the array")
+	}
+	TenantName := &result.Tenants[0].Name
 	fmt.Println(*TenantName)
 	assert.Equal("new-tenant", *TenantName, *TenantName)
 }


### PR DESCRIPTION
There is a failure in `Operator API Tests (1.17.x)`, I am not sure why we can't connect to `9090` server. Maybe `kubectl proxy` failed or stopped working and hence there is no way to create the tenant. But at least we have to handle the crash for now.

```sh
Done.
Starting to serve on 127.0.0.1:8001
secret/console-sa-secret configured
start ---> make test-operator-integration
Start cd operator-integration && go test:
/home/runner/work/console/console
.......................TestMain(): started
sleeping
start server
Server has been started at this point
Start serving with Serve() function
after 2 seconds sleep
creating the client
Where we have the secret already: 
Prior executing second command to get the token
after executing second command to get the token
requestData:  map[jwt:]
=== RUN   TestListTenants
.......................TestListTenants(): started
storage-kms-encrypted
.......................TestListTenants(): completed
--- PASS: TestListTenants (0.01s)
=== RUN   TestCreateTenant
.......................TestCreateTenant(): started
    tenant_test.go:432: 
        	Error Trace:	tenant_test.go:432
        	Error:      	Expected nil, but got: &url.Error{Op:"Post", URL:"http://localhost:9090/api/v1/tenants", Err:(*http.httpError)(0xc0013e5fb0)}
        	Test:       	TestCreateTenant
2022/06/24 09:17:21 Post "http://localhost:9090/api/v1/tenants": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
--- FAIL: TestCreateTenant (2.00s)
=== RUN   TestDeleteTenant
E0624 09:17:21.154419   15009 proxy_server.go:147] Error while proxying request: context canceled
.......................TestCreateTenant(): started
E: 2022/06/24 09:17:21 Post "http://localhost:8001/api/v1/namespaces/default/secrets": context canceled
%!(EXTRA *url.Error=Post "http://localhost:8001/api/v1/namespaces/default/secrets": context canceled)
E: 2022/06/24 09:17:21 deleting secrets created for failed tenant: new-tenant if any: &{500 0xc0014d4130 0xc0014d4120}
E: 2022/06/24 09:17:21 error deleting tenant's secrets: context canceled
E: 2022/06/24 09:17:22 deleting secret name new-tenant-3-env-configuration failed: secrets "new-tenant-3-env-configuration" not found, continuing..
.......................TestCreateTenant(): completed
--- PASS: TestDeleteTenant (1.13s)
=== RUN   TestListTenantsByNameSpace
--- FAIL: TestListTenantsByNameSpace (0.02s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0
goroutine 94 [running]:
testing.tRunner.func1.2({0x1fc4620, 0xc0010ff200})
	/opt/hostedtoolcache/go/1.17.11/x64/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.17.11/x64/src/testing/testing.go:1212 +0x218
panic({0x1fc4620, 0xc0010ff200})
	/opt/hostedtoolcache/go/1.17.11/x64/src/runtime/panic.go:1038 +0x215
github.com/minio/console/operator-integration.TestListTenantsByNameSpace(0x4550588)
	/home/runner/work/console/console/operator-integration/tenant_test.go:638 +0x33c
testing.tRunner(0xc000a9f6c0, 0x4317798)
	/opt/hostedtoolcache/go/1.17.11/x64/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/opt/hostedtoolcache/go/1.17.11/x64/src/testing/testing.go:1306 +0x35a
make: *** [Makefile:185: test-operator-integration] Error 2
Error: Process completed with exit code 2.
```