### PR TITLE
Add object-level error message display in Downloads/Uploads panel

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -783,8 +783,8 @@ const ListObjects = () => {
       () => {
         dispatch(completeObject(identityDownload));
       },
-      () => {
-        dispatch(failObject(identityDownload));
+      (msg: string) => {
+        dispatch(failObject({ instanceID: identityDownload, msg }));
       },
       () => {
         dispatch(cancelObjectInList(identityDownload));
@@ -804,6 +804,7 @@ const ListObjects = () => {
         waitingForFile: true,
         failed: false,
         cancelled: false,
+        errorMessage: "",
       })
     );
 
@@ -924,14 +925,24 @@ const ListObjects = () => {
                     errorMessage = "something went wrong";
                   }
                 }
-                dispatch(failObject(identity));
+                dispatch(
+                  failObject({
+                    instanceID: identity,
+                    msg: errorMessage,
+                  })
+                );
                 reject({ status: xhr.status, message: errorMessage });
               }
             };
 
             xhr.upload.addEventListener("error", (event) => {
               reject(errorMessage);
-              dispatch(failObject(identity));
+              dispatch(
+                failObject({
+                  instanceID: identity,
+                  msg: "A network error occurred.",
+                })
+              );
               return;
             });
 
@@ -948,7 +959,12 @@ const ListObjects = () => {
 
             xhr.onerror = () => {
               reject(errorMessage);
-              dispatch(failObject(identity));
+              dispatch(
+                failObject({
+                  instanceID: identity,
+                  msg: "A network error occurred.",
+                })
+              );
               return;
             };
             xhr.onloadend = () => {
@@ -977,6 +993,7 @@ const ListObjects = () => {
                   waitingForFile: false,
                   failed: false,
                   cancelled: false,
+                  errorMessage: "",
                 })
               );
 

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ObjectDetailPanel.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ObjectDetailPanel.tsx
@@ -318,8 +318,8 @@ const ObjectDetailPanel = ({
       () => {
         dispatch(completeObject(identityDownload));
       },
-      () => {
-        dispatch(failObject(identityDownload));
+      (msg: string) => {
+        dispatch(failObject({ instanceID: identityDownload, msg }));
       },
       () => {
         dispatch(cancelObjectInList(identityDownload));
@@ -339,6 +339,7 @@ const ObjectDetailPanel = ({
         waitingForFile: true,
         failed: false,
         cancelled: false,
+        errorMessage: "",
       })
     );
 

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/VersionsNavigator.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/VersionsNavigator.tsx
@@ -263,8 +263,8 @@ const VersionsNavigator = ({
       () => {
         dispatch(completeObject(identityDownload));
       },
-      () => {
-        dispatch(failObject(identityDownload));
+      (msg: string) => {
+        dispatch(failObject({ instanceID: identityDownload, msg }));
       },
       () => {
         dispatch(cancelObjectInList(identityDownload));
@@ -284,6 +284,7 @@ const VersionsNavigator = ({
         waitingForFile: true,
         failed: false,
         cancelled: false,
+        errorMessage: "",
       })
     );
 

--- a/portal-ui/src/screens/Console/Common/ObjectManager/ObjectHandled.tsx
+++ b/portal-ui/src/screens/Console/Common/ObjectManager/ObjectHandled.tsx
@@ -144,6 +144,13 @@ const styles = (theme: Theme) =>
       color: "#696969",
       fontWeight: "normal",
     },
+    errorMessage: {
+      fontSize: 12,
+      color: "#C83B51",
+      fontWeight: "normal",
+      marginTop: 6,
+      overflowWrap: "break-word",
+    },
   });
 
 const ObjectHandled = ({
@@ -247,6 +254,12 @@ const ObjectHandled = ({
             />
           )}
         </div>
+        {objectToDisplay.errorMessage !== "" && (
+          <div className={classes.errorMessage}>
+            <strong>Error: </strong>
+            {objectToDisplay.errorMessage}
+          </div>
+        )}
       </div>
     </Fragment>
   );

--- a/portal-ui/src/screens/Console/ObjectBrowser/RenameLongFilename.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/RenameLongFilename.tsx
@@ -101,8 +101,8 @@ const RenameLongFileName = ({
       () => {
         dispatch(completeObject(identityDownload));
       },
-      () => {
-        dispatch(failObject(identityDownload));
+      (msg: string) => {
+        dispatch(failObject({ instanceID: identityDownload, msg }));
       },
       () => {
         dispatch(cancelObjectInList(identityDownload));
@@ -122,6 +122,7 @@ const RenameLongFileName = ({
         waitingForFile: true,
         failed: false,
         cancelled: false,
+        errorMessage: "",
       })
     );
 

--- a/portal-ui/src/screens/Console/ObjectBrowser/objectBrowserSlice.ts
+++ b/portal-ui/src/screens/Console/ObjectBrowser/objectBrowserSlice.ts
@@ -120,12 +120,15 @@ export const objectBrowserSlice = createSlice({
         false;
       state.objectManager.objectsToManage[objectToComplete].done = true;
     },
-    failObject: (state, action: PayloadAction<string>) => {
+    failObject: (state, action: PayloadAction<{instanceID: string; msg: string}>) => {
       const objectToFail = state.objectManager.objectsToManage.findIndex(
-        (item) => item.instanceID === action.payload
+        (item) => item.instanceID === action.payload.instanceID
       );
 
       state.objectManager.objectsToManage[objectToFail].failed = true;
+      state.objectManager.objectsToManage[objectToFail].waitingForFile = false;
+      state.objectManager.objectsToManage[objectToFail].done = true;
+      state.objectManager.objectsToManage[objectToFail].errorMessage = action.payload.msg;
     },
     cancelObjectInList: (state, action: PayloadAction<string>) => {
       const objectToCancel = state.objectManager.objectsToManage.findIndex(

--- a/portal-ui/src/screens/Console/ObjectBrowser/types.ts
+++ b/portal-ui/src/screens/Console/ObjectBrowser/types.ts
@@ -99,6 +99,7 @@ export interface IFileItem {
   waitingForFile: boolean;
   failed: boolean;
   cancelled: boolean;
+  errorMessage: string;
 }
 
 interface RewindSetEnabled {


### PR DESCRIPTION
Resolves #2111

This PR adds support for displaying object-level error messages in the Downloads/Uploads panel. It works for both uploads and downloads (including downloads initiated via the object version list).

While working on this feature, I have noticed that the `/buckets/{bucket_name}/objects/download` endpoint produces empty body (content-type of which is declared as `application/octet-stream`) and a 403 code when the user isn't allowed to perform `GetObject` action instead of returning an object conforming to `#/definitions/error`. Is that behavior expected or is it a potential issue? For the purpose of this PR, I've worked around that by composing an error message that includes only the status code if the response body is not available.

<details>
  <summary>Screenshots</summary> 

Download error (missing GetObject permission):

![download-error](https://user-images.githubusercontent.com/34161459/175951584-7857226c-e413-4fe9-8d1e-69d3d1cc8e7c.png)
Upload error (missing PutObject permission):

![upload-error-message](https://user-images.githubusercontent.com/34161459/175951620-86af3ded-cd36-468b-8b97-5f1918eab477.png)
</details>

