### PR TITLE
Object Browser only mode

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -276,7 +276,7 @@ jobs:
           semgrep --config semgrep.yaml $(pwd)/portal-ui --error
 
   no-warnings-and-make-assets:
-    name: "React Code Has No Warning & Prettified and then Make Assets"
+    name: "React Code Has No Warnings & is Prettified, then Make Assets"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/models/login_request.go
+++ b/models/login_request.go
@@ -28,7 +28,6 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/go-openapi/validate"
 )
 
 // LoginRequest login request
@@ -37,45 +36,29 @@ import (
 type LoginRequest struct {
 
 	// access key
-	// Required: true
-	AccessKey *string `json:"accessKey"`
+	AccessKey string `json:"accessKey,omitempty"`
 
 	// features
 	Features *LoginRequestFeatures `json:"features,omitempty"`
 
 	// secret key
-	// Required: true
-	SecretKey *string `json:"secretKey"`
+	SecretKey string `json:"secretKey,omitempty"`
+
+	// sts
+	Sts string `json:"sts,omitempty"`
 }
 
 // Validate validates this login request
 func (m *LoginRequest) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateAccessKey(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateFeatures(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSecretKey(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *LoginRequest) validateAccessKey(formats strfmt.Registry) error {
-
-	if err := validate.Required("accessKey", "body", m.AccessKey); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -93,15 +76,6 @@ func (m *LoginRequest) validateFeatures(formats strfmt.Registry) error {
 			}
 			return err
 		}
-	}
-
-	return nil
-}
-
-func (m *LoginRequest) validateSecretKey(formats strfmt.Registry) error {
-
-	if err := validate.Required("secretKey", "body", m.SecretKey); err != nil {
-		return err
 	}
 
 	return nil

--- a/models/principal.go
+++ b/models/principal.go
@@ -48,6 +48,9 @@ type Principal struct {
 
 	// hm
 	Hm bool `json:"hm,omitempty"`
+
+	// ob
+	Ob bool `json:"ob,omitempty"`
 }
 
 // Validate validates this principal

--- a/operatorapi/embedded_spec.go
+++ b/operatorapi/embedded_spec.go
@@ -3283,10 +3283,6 @@ func init() {
     },
     "loginRequest": {
       "type": "object",
-      "required": [
-        "accessKey",
-        "secretKey"
-      ],
       "properties": {
         "accessKey": {
           "type": "string"
@@ -3300,6 +3296,9 @@ func init() {
           }
         },
         "secretKey": {
+          "type": "string"
+        },
+        "sts": {
           "type": "string"
         }
       }
@@ -8788,10 +8787,6 @@ func init() {
     },
     "loginRequest": {
       "type": "object",
-      "required": [
-        "accessKey",
-        "secretKey"
-      ],
       "properties": {
         "accessKey": {
           "type": "string"
@@ -8805,6 +8800,9 @@ func init() {
           }
         },
         "secretKey": {
+          "type": "string"
+        },
+        "sts": {
           "type": "string"
         }
       }

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -67,11 +67,18 @@ type TokenClaims struct {
 	STSSessionToken    string `json:"stsSessionToken,omitempty"`
 	AccountAccessKey   string `json:"accountAccessKey,omitempty"`
 	HideMenu           bool   `json:"hm,omitempty"`
+	ObjectBrowser      bool   `json:"ob,omitempty"`
+}
+
+// STSClaims claims struct for STS Token
+type STSClaims struct {
+	AccessKey string `json:"accessKey,omitempty"`
 }
 
 // SessionFeatures represents features stored in the session
 type SessionFeatures struct {
-	HideMenu bool
+	HideMenu      bool
+	ObjectBrowser bool
 }
 
 // SessionTokenAuthenticate takes a session token, decode it, extract claims and validate the signature
@@ -115,6 +122,7 @@ func NewEncryptedTokenForClient(credentials *credentials.Value, accountAccessKey
 		}
 		if features != nil {
 			tokenClaims.HideMenu = features.HideMenu
+			tokenClaims.ObjectBrowser = features.ObjectBrowser
 		}
 		encryptedClaims, err := encryptClaims(tokenClaims)
 		if err != nil {

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/BucketListItem.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/BucketListItem.tsx
@@ -163,6 +163,7 @@ interface IBucketListItem {
   onSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
   selected: boolean;
   bulkSelect: boolean;
+  noManage?: boolean;
 }
 
 const BucketListItem = ({
@@ -171,6 +172,7 @@ const BucketListItem = ({
   onSelect,
   selected,
   bulkSelect,
+  noManage = false,
 }: IBucketListItem) => {
   const usage = niceBytes(`${bucket.size}` || "0");
   const usageScalar = usage.split(" ")[0];
@@ -236,24 +238,26 @@ const BucketListItem = ({
             </Grid>
           </Grid>
           <Grid item xs={12} sm={5} className={classes.bucketActionButtons}>
-            <SecureComponent
-              scopes={IAM_PERMISSIONS[IAM_ROLES.BUCKET_ADMIN]}
-              resource={bucket.name}
-            >
-              <Link
-                to={`/buckets/${bucket.name}/admin`}
-                style={{ textDecoration: "none" }}
+            {!noManage && (
+              <SecureComponent
+                scopes={IAM_PERMISSIONS[IAM_ROLES.BUCKET_ADMIN]}
+                resource={bucket.name}
               >
-                <RBIconButton
-                  tooltip={"Manage"}
-                  onClick={() => {}}
-                  text={"Manage"}
-                  icon={<SettingsIcon />}
-                  color={"primary"}
-                  variant={"outlined"}
-                />
-              </Link>
-            </SecureComponent>
+                <Link
+                  to={`/buckets/${bucket.name}/admin`}
+                  style={{ textDecoration: "none" }}
+                >
+                  <RBIconButton
+                    tooltip={"Manage"}
+                    onClick={() => {}}
+                    text={"Manage"}
+                    icon={<SettingsIcon />}
+                    color={"primary"}
+                    variant={"outlined"}
+                  />
+                </Link>
+              </SecureComponent>
+            )}
             <Link
               to={`/buckets/${bucket.name}/browse`}
               style={{ textDecoration: "none" }}

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/ListBuckets.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/ListBuckets.tsx
@@ -27,6 +27,7 @@ import {
   AddIcon,
   BucketsIcon,
   LifecycleConfigIcon,
+  LoginMinIOLogo,
   SelectAllIcon,
 } from "../../../../icons";
 import {
@@ -57,6 +58,8 @@ import BulkLifecycleModal from "./BulkLifecycleModal";
 import hasPermission from "../../../../common/SecureComponent/accessControl";
 import { setErrorSnackMessage } from "../../../../systemSlice";
 import { useAppDispatch } from "../../../../store";
+import { useSelector } from "react-redux";
+import { selFeatures } from "../../consoleSlice";
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -98,8 +101,10 @@ const ListBuckets = ({ classes }: IListBucketsProps) => {
   const [replicationModalOpen, setReplicationModalOpen] =
     useState<boolean>(false);
   const [lifecycleModalOpen, setLifecycleModalOpen] = useState<boolean>(false);
-
   const [bulkSelect, setBulkSelect] = useState<boolean>(false);
+
+  const features = useSelector(selFeatures);
+  const obOnly = !!features?.includes("object-browser-only");
 
   useEffect(() => {
     if (loading) {
@@ -172,6 +177,7 @@ const ListBuckets = ({ classes }: IListBucketsProps) => {
           onSelect={selectListBuckets}
           selected={selectedBuckets.includes(bucket.name)}
           bulkSelect={bulkSelect}
+          noManage={obOnly}
         />
       );
     }
@@ -209,9 +215,16 @@ const ListBuckets = ({ classes }: IListBucketsProps) => {
           open={lifecycleModalOpen}
         />
       )}
-      <PageHeader label={"Buckets"} />
+      {!obOnly && <PageHeader label={"Buckets"} />}
       <PageLayout>
         <Grid item xs={12} className={classes.actionsTray} display="flex">
+          {obOnly && (
+            <Grid item xs>
+              <LoginMinIOLogo
+                style={{ width: 105, marginRight: 15, marginTop: 10 }}
+              />
+            </Grid>
+          )}
           <SearchBox
             onChange={setFilterBuckets}
             placeholder="Search Buckets"
@@ -226,58 +239,62 @@ const ListBuckets = ({ classes }: IListBucketsProps) => {
             alignItems={"center"}
             justifyContent={"flex-end"}
           >
-            <RBIconButton
-              tooltip={
-                bulkSelect ? "Unselect Buckets" : "Select Multiple Buckets"
-              }
-              onClick={() => {
-                setBulkSelect(!bulkSelect);
-                setSelectedBuckets([]);
-              }}
-              text={""}
-              icon={<SelectMultipleIcon />}
-              color={"primary"}
-              variant={bulkSelect ? "contained" : "outlined"}
-            />
+            {!obOnly && (
+              <Fragment>
+                <RBIconButton
+                  tooltip={
+                    bulkSelect ? "Unselect Buckets" : "Select Multiple Buckets"
+                  }
+                  onClick={() => {
+                    setBulkSelect(!bulkSelect);
+                    setSelectedBuckets([]);
+                  }}
+                  text={""}
+                  icon={<SelectMultipleIcon />}
+                  color={"primary"}
+                  variant={bulkSelect ? "contained" : "outlined"}
+                />
 
-            {bulkSelect && (
-              <RBIconButton
-                tooltip={
-                  selectedBuckets.length === filteredRecords.length
-                    ? "Unselect All Buckets"
-                    : "Select All Buckets"
-                }
-                onClick={selectAllBuckets}
-                text={""}
-                icon={<SelectAllIcon />}
-                color={"primary"}
-                variant={"outlined"}
-              />
+                {bulkSelect && (
+                  <RBIconButton
+                    tooltip={
+                      selectedBuckets.length === filteredRecords.length
+                        ? "Unselect All Buckets"
+                        : "Select All Buckets"
+                    }
+                    onClick={selectAllBuckets}
+                    text={""}
+                    icon={<SelectAllIcon />}
+                    color={"primary"}
+                    variant={"outlined"}
+                  />
+                )}
+
+                <RBIconButton
+                  tooltip={"Set Lifecycle"}
+                  onClick={() => {
+                    setLifecycleModalOpen(true);
+                  }}
+                  text={""}
+                  icon={<LifecycleConfigIcon />}
+                  disabled={selectedBuckets.length === 0}
+                  color={"primary"}
+                  variant={"outlined"}
+                />
+
+                <RBIconButton
+                  tooltip={"Set Replication"}
+                  onClick={() => {
+                    setReplicationModalOpen(true);
+                  }}
+                  text={""}
+                  icon={<MultipleBucketsIcon />}
+                  disabled={selectedBuckets.length === 0}
+                  color={"primary"}
+                  variant={"outlined"}
+                />
+              </Fragment>
             )}
-
-            <RBIconButton
-              tooltip={"Set Lifecycle"}
-              onClick={() => {
-                setLifecycleModalOpen(true);
-              }}
-              text={""}
-              icon={<LifecycleConfigIcon />}
-              disabled={selectedBuckets.length === 0}
-              color={"primary"}
-              variant={"outlined"}
-            />
-
-            <RBIconButton
-              tooltip={"Set Replication"}
-              onClick={() => {
-                setReplicationModalOpen(true);
-              }}
-              text={""}
-              icon={<MultipleBucketsIcon />}
-              disabled={selectedBuckets.length === 0}
-              color={"primary"}
-              variant={"outlined"}
-            />
 
             <RBIconButton
               tooltip={"Refresh"}
@@ -290,17 +307,19 @@ const ListBuckets = ({ classes }: IListBucketsProps) => {
               variant={"outlined"}
             />
 
-            <RBIconButton
-              tooltip={"Create Bucket"}
-              onClick={() => {
-                navigate(IAM_PAGES.ADD_BUCKETS);
-              }}
-              text={"Create Bucket"}
-              icon={<AddIcon />}
-              color={"primary"}
-              variant={"contained"}
-              disabled={!canCreateBucket}
-            />
+            {!obOnly && (
+              <RBIconButton
+                tooltip={"Create Bucket"}
+                onClick={() => {
+                  navigate(IAM_PAGES.ADD_BUCKETS);
+                }}
+                text={"Create Bucket"}
+                icon={<AddIcon />}
+                color={"primary"}
+                variant={"contained"}
+                disabled={!canCreateBucket}
+              />
+            )}
           </Grid>
         </Grid>
 

--- a/portal-ui/src/screens/Console/Console.tsx
+++ b/portal-ui/src/screens/Console/Console.tsx
@@ -203,6 +203,8 @@ const Console = ({ classes }: IConsoleProps) => {
   const [openSnackbar, setOpenSnackbar] = useState<boolean>(false);
 
   const ldapIsEnabled = (features && features.includes("ldap-idp")) || false;
+  const obOnly = !!features?.includes("object-browser-only");
+
   const restartServer = () => {
     dispatch(serverIsLoading(true));
     api
@@ -461,16 +463,17 @@ const Console = ({ classes }: IConsoleProps) => {
 
   const allowedRoutes = (
     operatorMode ? operatorConsoleRoutes : consoleAdminRoutes
-  ).filter(
-    (route: any) =>
-      (route.forceDisplay ||
-        (route.customPermissionFnc
-          ? route.customPermissionFnc()
-          : hasPermission(
-              CONSOLE_UI_RESOURCE,
-              IAM_PAGES_PERMISSIONS[route.path]
-            ))) &&
-      !route.fsHidden
+  ).filter((route: any) =>
+    obOnly
+      ? route.path.includes("buckets")
+      : (route.forceDisplay ||
+          (route.customPermissionFnc
+            ? route.customPermissionFnc()
+            : hasPermission(
+                CONSOLE_UI_RESOURCE,
+                IAM_PAGES_PERMISSIONS[route.path]
+              ))) &&
+        !route.fsHidden
   );
 
   const closeSnackBar = () => {
@@ -493,6 +496,8 @@ const Console = ({ classes }: IConsoleProps) => {
   if (features?.includes("hide-menu")) {
     hideMenu = true;
   } else if (pathname.endsWith("/hop")) {
+    hideMenu = true;
+  } else if (obOnly) {
     hideMenu = true;
   }
 

--- a/portal-ui/src/screens/LoginPage/LoginField.tsx
+++ b/portal-ui/src/screens/LoginPage/LoginField.tsx
@@ -1,0 +1,68 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import makeStyles from "@mui/styles/makeStyles";
+import { Theme } from "@mui/material/styles";
+import createStyles from "@mui/styles/createStyles";
+import { TextFieldProps } from "@mui/material";
+import TextField from "@mui/material/TextField";
+import React from "react";
+
+const inputStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      "& .MuiOutlinedInput-root": {
+        paddingLeft: 0,
+        "& svg": {
+          marginLeft: 4,
+          height: 14,
+          color: theme.palette.primary.main,
+        },
+        "& input": {
+          padding: 10,
+          fontSize: 14,
+          paddingLeft: 0,
+          "&::placeholder": {
+            fontSize: 12,
+          },
+          "@media (max-width: 900px)": {
+            padding: 10,
+          },
+        },
+        "& fieldset": {},
+
+        "& fieldset:hover": {
+          borderBottom: "2px solid #000000",
+          borderRadius: 0,
+        },
+      },
+    },
+  })
+);
+
+export const LoginField = (props: TextFieldProps) => {
+  const classes = inputStyles();
+
+  return (
+    <TextField
+      classes={{
+        root: classes.root,
+      }}
+      variant="standard"
+      {...props}
+    />
+  );
+};

--- a/portal-ui/src/screens/LoginPage/StrategyForm.tsx
+++ b/portal-ui/src/screens/LoginPage/StrategyForm.tsx
@@ -1,0 +1,231 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import Grid from "@mui/material/Grid";
+import React, { Fragment } from "react";
+import { setAccessKey, setSecretKey, setSTS, setUseSTS } from "./loginSlice";
+import { Box, InputAdornment, LinearProgress } from "@mui/material";
+import UserFilledIcon from "../../icons/UsersFilledIcon";
+import LockFilledIcon from "../../icons/LockFilledIcon";
+import Button from "@mui/material/Button";
+import { AppState, useAppDispatch } from "../../store";
+import { useSelector } from "react-redux";
+import { LoginField } from "./LoginField";
+import makeStyles from "@mui/styles/makeStyles";
+import { Theme, useTheme } from "@mui/material/styles";
+import createStyles from "@mui/styles/createStyles";
+import { spacingUtils } from "../Console/Common/FormComponents/common/styleLibrary";
+import { doLoginAsync } from "./loginThunks";
+import { PasswordKeyIcon } from "../../icons";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+      overflow: "auto",
+    },
+    form: {
+      width: "100%", // Fix IE 11 issue.
+    },
+    submit: {
+      margin: "30px 0px 8px",
+      height: 40,
+      width: "100%",
+      boxShadow: "none",
+      padding: "16px 30px",
+    },
+    submitContainer: {
+      textAlign: "right",
+    },
+    linearPredef: {
+      height: 10,
+    },
+    ...spacingUtils,
+  })
+);
+
+const StrategyForm = () => {
+  const dispatch = useAppDispatch();
+  const classes = useStyles();
+  const theme = useTheme();
+
+  const accessKey = useSelector((state: AppState) => state.login.accessKey);
+  const secretKey = useSelector((state: AppState) => state.login.secretKey);
+  const sts = useSelector((state: AppState) => state.login.sts);
+  const useSTS = useSelector((state: AppState) => state.login.useSTS);
+
+  const loginSending = useSelector(
+    (state: AppState) => state.login.loginSending
+  );
+
+  const formSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    dispatch(doLoginAsync());
+  };
+
+  return (
+    <React.Fragment>
+      <form className={classes.form} noValidate onSubmit={formSubmit}>
+        <Grid container spacing={2}>
+          <Grid item xs={12} className={classes.spacerBottom}>
+            <LoginField
+              fullWidth
+              id="accessKey"
+              className={classes.inputField}
+              value={accessKey}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                dispatch(setAccessKey(e.target.value))
+              }
+              placeholder={useSTS ? "STS Username" : "Username"}
+              name="accessKey"
+              autoComplete="username"
+              disabled={loginSending}
+              variant={"outlined"}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment
+                    position="start"
+                    className={classes.iconColor}
+                  >
+                    <UserFilledIcon />
+                  </InputAdornment>
+                ),
+              }}
+            />
+          </Grid>
+          <Grid item xs={12} className={useSTS ? classes.spacerBottom : ""}>
+            <LoginField
+              fullWidth
+              className={classes.inputField}
+              value={secretKey}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                dispatch(setSecretKey(e.target.value))
+              }
+              name="secretKey"
+              type="password"
+              id="secretKey"
+              autoComplete="current-password"
+              disabled={loginSending}
+              placeholder={useSTS ? "STS Secret" : "Password"}
+              variant={"outlined"}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment
+                    position="start"
+                    className={classes.iconColor}
+                  >
+                    <LockFilledIcon />
+                  </InputAdornment>
+                ),
+              }}
+            />
+          </Grid>
+          {useSTS && (
+            <Grid item xs={12} className={classes.spacerBottom}>
+              <LoginField
+                fullWidth
+                id="sts"
+                className={classes.inputField}
+                value={sts}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  dispatch(setSTS(e.target.value))
+                }
+                placeholder={"STS Token"}
+                name="STS"
+                autoComplete="sts"
+                disabled={loginSending}
+                variant={"outlined"}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment
+                      position="start"
+                      className={classes.iconColor}
+                    >
+                      <PasswordKeyIcon />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+            </Grid>
+          )}
+        </Grid>
+
+        <Grid item xs={12} className={classes.submitContainer}>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            id="do-login"
+            className={classes.submit}
+            disabled={
+              (!useSTS && (accessKey === "" || secretKey === "")) ||
+              (useSTS && sts === "") ||
+              loginSending
+            }
+          >
+            Login
+          </Button>
+        </Grid>
+        <Grid item xs={12} className={classes.linearPredef}>
+          {loginSending && <LinearProgress />}
+        </Grid>
+        <Grid item xs={12} className={classes.linearPredef}>
+          <Box
+            style={{
+              textAlign: "center",
+              marginTop: 20,
+            }}
+          >
+            <span
+              onClick={() => {
+                dispatch(setUseSTS(!useSTS));
+              }}
+              style={{
+                color: theme.colors.link,
+                font: "normal normal normal 12px/15px Lato",
+                textDecoration: "underline",
+                cursor: "pointer",
+              }}
+            >
+              {!useSTS && <Fragment>Use STS</Fragment>}
+              {useSTS && <Fragment>Use Credentials</Fragment>}
+            </span>
+            <span
+              onClick={() => {
+                dispatch(setUseSTS(!useSTS));
+              }}
+              style={{
+                color: theme.colors.link,
+                font: "normal normal normal 12px/15px Lato",
+                textDecoration: "none",
+                fontWeight: "bold",
+                paddingLeft: 4,
+              }}
+            >
+              ➔
+            </span>
+          </Box>
+        </Grid>
+      </form>
+    </React.Fragment>
+  );
+};
+
+export default StrategyForm;

--- a/portal-ui/src/screens/LoginPage/loginSlice.ts
+++ b/portal-ui/src/screens/LoginPage/loginSlice.ts
@@ -1,0 +1,135 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { ILoginDetails, loginStrategyType } from "./types";
+import {
+  doLoginAsync,
+  getFetchConfigurationAsync,
+  getVersionAsync,
+} from "./loginThunks";
+
+export interface LoginState {
+  accessKey: string;
+  secretKey: string;
+  sts: string;
+  useSTS: boolean;
+
+  jwt: string;
+
+  loginStrategy: ILoginDetails;
+
+  loginSending: boolean;
+  loadingFetchConfiguration: boolean;
+
+  latestMinIOVersion: string;
+  loadingVersion: boolean;
+
+  navigateTo: string;
+}
+
+const initialState: LoginState = {
+  accessKey: "",
+  secretKey: "",
+  sts: "",
+  useSTS: false,
+  jwt: "",
+  loginStrategy: {
+    loginStrategy: loginStrategyType.unknown,
+    redirect: "",
+  },
+  loginSending: false,
+  loadingFetchConfiguration: true,
+  latestMinIOVersion: "",
+  loadingVersion: true,
+
+  navigateTo: "",
+};
+
+export const loginSlice = createSlice({
+  name: "login",
+  initialState,
+  reducers: {
+    setAccessKey: (state, action: PayloadAction<string>) => {
+      state.accessKey = action.payload;
+    },
+    setSecretKey: (state, action: PayloadAction<string>) => {
+      state.secretKey = action.payload;
+    },
+    setUseSTS: (state, action: PayloadAction<boolean>) => {
+      state.useSTS = action.payload;
+    },
+    setSTS: (state, action: PayloadAction<string>) => {
+      state.sts = action.payload;
+    },
+    setJwt: (state, action: PayloadAction<string>) => {
+      state.jwt = action.payload;
+    },
+    setNavigateTo: (state, action: PayloadAction<string>) => {
+      state.navigateTo = action.payload;
+    },
+    resetForm: (state) => initialState,
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(getVersionAsync.pending, (state, action) => {
+        state.loadingVersion = true;
+      })
+      .addCase(getVersionAsync.rejected, (state, action) => {
+        state.loadingVersion = false;
+      })
+      .addCase(getVersionAsync.fulfilled, (state, action) => {
+        state.loadingVersion = false;
+        if (action.payload) {
+          state.latestMinIOVersion = action.payload;
+        }
+      })
+      .addCase(getFetchConfigurationAsync.pending, (state, action) => {
+        state.loadingFetchConfiguration = true;
+      })
+      .addCase(getFetchConfigurationAsync.rejected, (state, action) => {
+        state.loadingFetchConfiguration = false;
+      })
+      .addCase(getFetchConfigurationAsync.fulfilled, (state, action) => {
+        state.loadingFetchConfiguration = false;
+        if (action.payload) {
+          state.loginStrategy = action.payload;
+        }
+      })
+      .addCase(doLoginAsync.pending, (state, action) => {
+        state.loginSending = true;
+      })
+      .addCase(doLoginAsync.rejected, (state, action) => {
+        state.loginSending = false;
+      })
+      .addCase(doLoginAsync.fulfilled, (state, action) => {
+        state.loginSending = false;
+      });
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const {
+  setAccessKey,
+  setSecretKey,
+  setUseSTS,
+  setSTS,
+  setJwt,
+  setNavigateTo,
+  resetForm,
+} = loginSlice.actions;
+
+export default loginSlice.reducer;

--- a/portal-ui/src/screens/LoginPage/loginThunks.ts
+++ b/portal-ui/src/screens/LoginPage/loginThunks.ts
@@ -1,0 +1,145 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { AppState } from "../../store";
+import api from "../../common/api";
+import { ErrorResponseHandler } from "../../common/types";
+import {
+  setErrorSnackMessage,
+  showMarketplace,
+  userLogged,
+} from "../../systemSlice";
+import { ILoginDetails, loginStrategyType } from "./types";
+import { setNavigateTo } from "./loginSlice";
+import {
+  getTargetPath,
+  loginStrategyEndpoints,
+  LoginStrategyPayload,
+} from "./LoginPage";
+
+export const doLoginAsync = createAsyncThunk(
+  "login/doLoginAsync",
+  async (_, { getState, rejectWithValue, dispatch }) => {
+    const state = getState() as AppState;
+    const loginStrategy = state.login.loginStrategy;
+    const accessKey = state.login.accessKey;
+    const secretKey = state.login.secretKey;
+    const jwt = state.login.jwt;
+    const sts = state.login.sts;
+    const useSTS = state.login.useSTS;
+
+    const isOperator =
+      loginStrategy.loginStrategy === loginStrategyType.serviceAccount ||
+      loginStrategy.loginStrategy === loginStrategyType.redirectServiceAccount;
+
+    let loginStrategyPayload: LoginStrategyPayload = {
+      form: { accessKey, secretKey },
+      "service-account": { jwt },
+    };
+    if (useSTS) {
+      loginStrategyPayload = {
+        form: { accessKey, secretKey, sts },
+      };
+    }
+
+    return api
+      .invoke(
+        "POST",
+        loginStrategyEndpoints[loginStrategy.loginStrategy] || "/api/v1/login",
+        loginStrategyPayload[loginStrategy.loginStrategy]
+      )
+      .then(() => {
+        // We set the state in redux
+        dispatch(userLogged(true));
+        if (loginStrategy.loginStrategy === loginStrategyType.form) {
+          localStorage.setItem("userLoggedIn", accessKey);
+        }
+        if (isOperator) {
+          api
+            .invoke("GET", "/api/v1/mp-integration/")
+            .then((res: any) => {
+              dispatch(setNavigateTo(getTargetPath())); // Email already set, continue with normal flow
+            })
+            .catch((err: ErrorResponseHandler) => {
+              if (err.statusCode === 404) {
+                dispatch(showMarketplace(true));
+                dispatch(setNavigateTo("/marketplace"));
+              } else {
+                // Unexpected error, continue with normal flow
+                dispatch(setNavigateTo(getTargetPath()));
+              }
+            });
+        } else {
+          dispatch(setNavigateTo(getTargetPath()));
+        }
+      })
+      .catch((err) => {
+        dispatch(setErrorSnackMessage(err));
+      });
+  }
+);
+export const getFetchConfigurationAsync = createAsyncThunk(
+  "login/getFetchConfigurationAsync",
+  async (_, { getState, rejectWithValue, dispatch }) => {
+    return api
+      .invoke("GET", "/api/v1/login")
+      .then((loginDetails: ILoginDetails) => {
+        return loginDetails;
+      })
+      .catch((err: ErrorResponseHandler) => {
+        dispatch(setErrorSnackMessage(err));
+      });
+  }
+);
+
+export const getVersionAsync = createAsyncThunk(
+  "login/getVersionAsync",
+  async (_, { getState, rejectWithValue, dispatch }) => {
+    return api
+      .invoke("GET", "/api/v1/check-version")
+      .then(
+        ({
+          current_version,
+          latest_version,
+        }: {
+          current_version: string;
+          latest_version: string;
+        }) => {
+          return latest_version;
+        }
+      )
+      .catch((err: ErrorResponseHandler) => {
+        // try the operator version
+        api
+          .invoke("GET", "/api/v1/check-operator-version")
+          .then(
+            ({
+              current_version,
+              latest_version,
+            }: {
+              current_version: string;
+              latest_version: string;
+            }) => {
+              return latest_version;
+            }
+          )
+          .catch((err: ErrorResponseHandler) => {
+            return err;
+          });
+      });
+  }
+);

--- a/portal-ui/src/store.ts
+++ b/portal-ui/src/store.ts
@@ -17,6 +17,7 @@ import { useDispatch } from "react-redux";
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 
 import systemReducer from "./systemSlice";
+import loginReducer from "./screens/LoginPage/loginSlice";
 import traceReducer from "./screens/Console/Trace/traceSlice";
 import logReducer from "./screens/Console/Logs/logsSlice";
 import healthInfoReducer from "./screens/Console/HealthInfo/healthInfoSlice";
@@ -36,6 +37,7 @@ import editTenantAuditLoggingReducer from "./screens/Console/Tenants/TenantDetai
 
 const rootReducer = combineReducers({
   system: systemReducer,
+  login: loginReducer,
   trace: traceReducer,
   logs: logReducer,
   watch: watchReducer,

--- a/restapi/config.go
+++ b/restapi/config.go
@@ -235,6 +235,10 @@ func getPrometheusExtraLabels() string {
 	return env.Get(PrometheusExtraLabels, "")
 }
 
+func getObjectBrowserOnly() string {
+	return env.Get(ConsoleObjectBrowserOnly, "off")
+}
+
 var (
 	// GlobalRootCAs is CA root certificates, a nil value means system certs pool will be used
 	GlobalRootCAs *x509.CertPool

--- a/restapi/config.go
+++ b/restapi/config.go
@@ -235,10 +235,6 @@ func getPrometheusExtraLabels() string {
 	return env.Get(PrometheusExtraLabels, "")
 }
 
-func getObjectBrowserOnly() string {
-	return env.Get(ConsoleObjectBrowserOnly, "off")
-}
-
 var (
 	// GlobalRootCAs is CA root certificates, a nil value means system certs pool will be used
 	GlobalRootCAs *x509.CertPool

--- a/restapi/consts.go
+++ b/restapi/consts.go
@@ -51,6 +51,7 @@ const (
 	PrometheusExtraLabels                        = "CONSOLE_PROMETHEUS_EXTRA_LABELS"
 	ConsoleLogQueryURL                           = "CONSOLE_LOG_QUERY_URL"
 	ConsoleLogQueryAuthToken                     = "CONSOLE_LOG_QUERY_AUTH_TOKEN"
+	ConsoleObjectBrowserOnly                     = "CONSOLE_OBJECT_BROWSER_ONLY"
 	LogSearchQueryAuthToken                      = "LOGSEARCH_QUERY_AUTH_TOKEN"
 	SlashSeparator                               = "/"
 )

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5412,10 +5412,6 @@ func init() {
     },
     "loginRequest": {
       "type": "object",
-      "required": [
-        "accessKey",
-        "secretKey"
-      ],
       "properties": {
         "accessKey": {
           "type": "string"
@@ -5429,6 +5425,9 @@ func init() {
           }
         },
         "secretKey": {
+          "type": "string"
+        },
+        "sts": {
           "type": "string"
         }
       }
@@ -5969,6 +5968,9 @@ func init() {
           "type": "string"
         },
         "hm": {
+          "type": "boolean"
+        },
+        "ob": {
           "type": "boolean"
         }
       }
@@ -12631,10 +12633,6 @@ func init() {
     },
     "loginRequest": {
       "type": "object",
-      "required": [
-        "accessKey",
-        "secretKey"
-      ],
       "properties": {
         "accessKey": {
           "type": "string"
@@ -12648,6 +12646,9 @@ func init() {
           }
         },
         "secretKey": {
+          "type": "string"
+        },
+        "sts": {
           "type": "string"
         }
       }
@@ -13188,6 +13189,9 @@ func init() {
           "type": "string"
         },
         "hm": {
+          "type": "boolean"
+        },
+        "ob": {
           "type": "boolean"
         }
       }

--- a/restapi/user_session.go
+++ b/restapi/user_session.go
@@ -254,6 +254,7 @@ func getListOfEnabledFeatures(session *models.Principal) []string {
 	logSearchURL := getLogSearchURL()
 	oidcEnabled := oauth2.IsIDPEnabled()
 	ldapEnabled := ldap.GetLDAPEnabled()
+	browserOnly := getObjectBrowserOnly()
 
 	if logSearchURL != "" {
 		features = append(features, "log-search")
@@ -267,6 +268,10 @@ func getListOfEnabledFeatures(session *models.Principal) []string {
 
 	if session.Hm {
 		features = append(features, "hide-menu")
+	}
+
+	if browserOnly == "on" {
+		features = append(features, "object-browser-only")
 	}
 
 	return features

--- a/restapi/user_session.go
+++ b/restapi/user_session.go
@@ -254,7 +254,6 @@ func getListOfEnabledFeatures(session *models.Principal) []string {
 	logSearchURL := getLogSearchURL()
 	oidcEnabled := oauth2.IsIDPEnabled()
 	ldapEnabled := ldap.GetLDAPEnabled()
-	browserOnly := getObjectBrowserOnly()
 
 	if logSearchURL != "" {
 		features = append(features, "log-search")
@@ -269,8 +268,7 @@ func getListOfEnabledFeatures(session *models.Principal) []string {
 	if session.Hm {
 		features = append(features, "hide-menu")
 	}
-
-	if browserOnly == "on" {
+	if session.Ob {
 		features = append(features, "object-browser-only")
 	}
 

--- a/swagger-console.yml
+++ b/swagger-console.yml
@@ -1,4 +1,3 @@
-
 swagger: "2.0"
 info:
   title: MinIO Console Server
@@ -3677,13 +3676,12 @@ definitions:
         type: string
   loginRequest:
     type: object
-    required:
-      - accessKey
-      - secretKey
     properties:
       accessKey:
         type: string
       secretKey:
+        type: string
+      sts:
         type: string
       features:
         type: object
@@ -3708,6 +3706,8 @@ definitions:
       accountAccessKey:
         type: string
       hm:
+        type: boolean
+      ob:
         type: boolean
   startProfilingItem:
     type: object

--- a/swagger-operator.yml
+++ b/swagger-operator.yml
@@ -1391,13 +1391,12 @@ definitions:
         type: string
   loginRequest:
     type: object
-    required:
-      - accessKey
-      - secretKey
     properties:
       accessKey:
         type: string
       secretKey:
+        type: string
+      sts:
         type: string
       features:
         type: object


### PR DESCRIPTION
## What does this do?

- Added Support for STS Token login
- Hidden not necessary buttons for object browser
- Added Support to Object browser only mode. To enable this, you need to:
  - Make assets
  - Generate an STS Token in your preferred mode
  - Open localhost:9090 & add the following query params: `http://localhost:9090/buckets?sts=<<STS_TOKEN>>&sts_a=<<STS_ACCESS_KEY_ID>>&sts_s=<<STS_SECRET>>`
  - Start navigating through Object Browser (Only Object browser Routes are available)

## How does it look?

<img width="1324" alt="Screen Shot 2022-06-29 at 22 27 23" src="https://user-images.githubusercontent.com/33497058/176587039-549b6e5b-11f7-4f87-9dd8-bd1f7aa0d835.png">
<img width="2069" alt="Screen Shot 2022-06-29 at 22 27 18" src="https://user-images.githubusercontent.com/33497058/176587049-1ea0b08e-c3f7-44ce-aac5-871e8e120cdc.png">
<img width="589" alt="Screen Shot 2022-07-06 at 23 33 32" src="https://user-images.githubusercontent.com/33497058/177691865-372afda9-d71f-47a8-aa91-58aded174640.png">
<img width="837" alt="Screen Shot 2022-07-06 at 23 33 28" src="https://user-images.githubusercontent.com/33497058/177691870-6cbb2bd6-532e-4ddc-8ce0-b7156925b852.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>