### PR TITLE
Various fixes for Tenant details page

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Configure.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Configure.tsx
@@ -181,8 +181,7 @@ const Configure = ({ classes }: IConfigureProps) => {
           fieldKey: `minio-domain-${index.toString()}`,
           required: false,
           value: validation,
-          pattern:
-            /((http|https):\/\/)+[a-zA-Z0-9\-.]{3,}\.[a-zA-Z]{2,}(\.[a-zA-Z]{2,})?$/,
+          pattern: /^(https?):\/\/([a-zA-Z0-9\-.]+)(:[0-9]+)?$/,
           customPatternMessage:
             "MinIO domain is not in the form of http|https://subdomain.domain",
         };
@@ -196,7 +195,7 @@ const Configure = ({ classes }: IConfigureProps) => {
           required: false,
           value: consoleDomain,
           pattern:
-            /((http|https):\/\/)+[a-zA-Z0-9\-.]{3,}\.[a-zA-Z]{2,}(\.[a-zA-Z]{2,})?(:[1-9]{1}([0-9]{1,4})?)?(\/[a-zA-Z0-9]{1,})*?$/,
+            /^(https?):\/\/([a-zA-Z0-9\-.]+)(:[0-9]+)?(\/[a-zA-Z0-9\-./]*)?$/,
           customPatternMessage:
             "Console domain is not in the form of http|https://subdomain.domain:port/subpath1/subpath2",
         },

--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/EditDomains.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/EditDomains.tsx
@@ -33,7 +33,10 @@ import ModalWrapper from "../../Common/ModalWrapper/ModalWrapper";
 import InputBoxWrapper from "../../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
 import api from "../../../../common/api";
 import RemoveIcon from "../../../../icons/RemoveIcon";
-import { setModalErrorSnackMessage } from "../../../../systemSlice";
+import {
+  setModalErrorSnackMessage,
+  setSnackBarMessage,
+} from "../../../../systemSlice";
 import { useAppDispatch } from "../../../../store";
 
 interface IEditDomains {
@@ -90,7 +93,7 @@ const EditDomains = ({
       if (consoleDomainSet !== "") {
         // We Validate console domain
         const consoleRegExp = new RegExp(
-          /((http|https):\/\/)+[a-zA-Z0-9\-.]{3,}\.[a-zA-Z]{2,}(\.[a-zA-Z]{2,})?(:[1-9]{1}([0-9]{1,4})?)?(\/[a-zA-Z0-9]{1,})*?$/
+          /^(https?):\/\/([a-zA-Z0-9\-.]+)(:[0-9]+)?(\/[a-zA-Z0-9\-./]*)?$/
         );
 
         setConsoleDomainValid(consoleRegExp.test(consoleDomainSet));
@@ -102,7 +105,7 @@ const EditDomains = ({
         setMinioDomains(domains.minio);
 
         const minioRegExp = new RegExp(
-          /((http|https):\/\/)+[a-zA-Z0-9\-.]{3,}\.[a-zA-Z]{2,}(\.[a-zA-Z]{2,})?$/
+          /^(https?):\/\/([a-zA-Z0-9\-.]+)(:[0-9]+)?$/
         );
 
         const initialValidations = domains.minio.map((domain) => {
@@ -146,11 +149,12 @@ const EditDomains = ({
       )
       .then(() => {
         setIsSending(false);
+        dispatch(setSnackBarMessage(`Domains updated successfully`));
         closeModalAndRefresh(true);
       })
       .catch((error: ErrorResponseHandler) => {
-        dispatch(setModalErrorSnackMessage(error));
         setIsSending(false);
+        dispatch(setModalErrorSnackMessage(error));
       });
   };
 
@@ -191,7 +195,6 @@ const EditDomains = ({
 
     setMinioDomainValid(cloneValidation);
   };
-
   return (
     <ModalWrapper
       title={`Edit Tenant Domains - ${idTenant}`}
@@ -216,7 +219,7 @@ const EditDomains = ({
                   "Eg. http://subdomain.domain:port/subpath1/subpath2"
                 }
                 pattern={
-                  "((http|https):\\/\\/)+[a-zA-Z0-9\\-.]{3,}\\.[a-zA-Z]{2,}(\\.[a-zA-Z]{2,})?(:[1-9]{1}([0-9]{1,4})?)?(\\/[a-zA-Z0-9]{1,})*?$"
+                  "^(https?):\\/\\/([a-zA-Z0-9\\-.]+)(:[0-9]+)?(\\/[a-zA-Z0-9\\-.\\/]*)?$"
                 }
                 error={
                   !consoleDomainValid
@@ -248,7 +251,7 @@ const EditDomains = ({
                         value={domain}
                         placeholder={"Eg. http://subdomain.domain"}
                         pattern={
-                          "((http|https):\\/\\/)+[a-zA-Z0-9\\-.]{3,}\\.[a-zA-Z]{2,}(\\.[a-zA-Z]{2,})?$"
+                          "^(https?):\\/\\/([a-zA-Z0-9\\-.]+)(:[0-9]+)?$"
                         }
                         error={
                           !minioDomainValid[index]

--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantSummary.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantSummary.tsx
@@ -35,9 +35,9 @@ import SectionTitle from "../../Common/SectionTitle";
 import RBIconButton from "../../Buckets/BucketDetails/SummaryItems/RBIconButton";
 import { EditIcon } from "../../../../icons";
 import EditDomains from "./EditDomains";
-import { setTenantDetailsLoad } from "../tenantsSlice";
 import { ITenant } from "../ListTenants/types";
 import { useParams } from "react-router-dom";
+import { getTenantAsync } from "../thunks/tenantDetailsAsync";
 
 interface ITenantsSummary {
   classes: any;
@@ -221,9 +221,8 @@ const TenantSummary = ({ classes }: ITenantsSummary) => {
 
   const closeEditDomainsModal = (refresh: boolean) => {
     setEditDomainsOpen(false);
-
     if (refresh) {
-      dispatch(setTenantDetailsLoad(true));
+      dispatch(getTenantAsync());
     }
   };
 
@@ -232,8 +231,11 @@ const TenantSummary = ({ classes }: ITenantsSummary) => {
       {updateMinioVersion && (
         <UpdateTenantModal
           open={updateMinioVersion}
-          closeModalAndRefresh={() => {
+          closeModalAndRefresh={(refresh: boolean) => {
             setUpdateMinioVersion(false);
+            if (refresh) {
+              dispatch(getTenantAsync());
+            }
           }}
           idTenant={tenantName || ""}
           namespace={tenantNamespace || ""}

--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/UpdateTenantModal.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/UpdateTenantModal.tsx
@@ -29,7 +29,10 @@ import ModalWrapper from "../../Common/ModalWrapper/ModalWrapper";
 import InputBoxWrapper from "../../Common/FormComponents/InputBoxWrapper/InputBoxWrapper";
 import FormSwitchWrapper from "../../Common/FormComponents/FormSwitchWrapper/FormSwitchWrapper";
 import api from "../../../../common/api";
-import { setModalErrorSnackMessage } from "../../../../systemSlice";
+import {
+  setModalErrorSnackMessage,
+  setSnackBarMessage,
+} from "../../../../systemSlice";
 import { useAppDispatch } from "../../../../store";
 
 interface IUpdateTenantModal {
@@ -127,6 +130,7 @@ const UpdateTenantModal = ({
       )
       .then(() => {
         setIsSending(false);
+        dispatch(setSnackBarMessage(`Image updated successfully`));
         closeModalAndRefresh(true);
       })
       .catch((error: ErrorResponseHandler) => {


### PR DESCRIPTION
- fixed refresh tenant details page after changing Domains and updating
  image
- Relax tenant domains to allow including port number

![Screenshot from 2022-07-19 17-00-21](https://user-images.githubusercontent.com/1795553/179870137-568b9d90-e283-4beb-b186-1f273ec8a81f.png)

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>