### PR TITLE
Fixed storage class selectors for add & edit pool wizards

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/Pools/AddPool/PoolResources.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/Pools/AddPool/PoolResources.tsx
@@ -274,7 +274,7 @@ const PoolResources = ({ classes }: IPoolResourcesProps) => {
           id="storage_class"
           name="storage_class"
           onChange={(e: SelectChangeEvent<string>) => {
-            setFieldInfo("storageClasses", e.target.value as string);
+            setFieldInfo("storageClass", e.target.value as string);
           }}
           label="Storage Class"
           value={storageClass}

--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/Pools/EditPool/EditPoolResources.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/Pools/EditPool/EditPoolResources.tsx
@@ -256,7 +256,7 @@ const PoolResources = ({ classes }: IPoolResourcesProps) => {
           id="storage_class"
           name="storage_class"
           onChange={(e: SelectChangeEvent<string>) => {
-            setFieldInfo("storageClasses", e.target.value as string);
+            setFieldInfo("storageClass", e.target.value as string);
           }}
           label="Storage Class"
           value={storageClass}

--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/Pools/EditPool/thunks/editPoolAsync.ts
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/Pools/EditPool/thunks/editPoolAsync.ts
@@ -23,7 +23,7 @@ import { generatePoolName } from "../../../../../../../common/utils";
 import { getDefaultAffinity, getNodeSelector } from "../../../utils";
 import { IEditPoolItem, IEditPoolRequest } from "../../../../ListTenants/types";
 import { resetEditPoolForm } from "../editPoolSlice";
-import { setTenantDetailsLoad } from "../../../../tenantsSlice";
+import { getTenantAsync } from "../../../../thunks/tenantDetailsAsync";
 
 export const editPoolAsync = createAsyncThunk(
   "editPool/editPoolAsync",
@@ -128,7 +128,7 @@ export const editPoolAsync = createAsyncThunk(
       )
       .then(() => {
         dispatch(resetEditPoolForm());
-        dispatch(setTenantDetailsLoad(true));
+        dispatch(getTenantAsync());
         return poolsURL;
       })
       .catch((err: ErrorResponseHandler) => {


### PR DESCRIPTION
## What does this do?

Fixes an issue wit storage class selectors in add & edit pool wizards

## How does it look?
<img width="1429" alt="Screen Shot 2022-07-19 at 22 56 53" src="https://user-images.githubusercontent.com/33497058/179893774-716a5880-4617-4ccb-a799-361e1741c72d.png">
<img width="1375" alt="Screen Shot 2022-07-19 at 22 56 48" src="https://user-images.githubusercontent.com/33497058/179893776-ae667fdb-dd51-45a6-85fe-c729a730a02c.png">
<img width="1386" alt="Screen Shot 2022-07-19 at 22 56 38" src="https://user-images.githubusercontent.com/33497058/179893780-f07d86da-e1a8-41ce-af3b-d52fc92c23dc.png">
<img width="1343" alt="Screen Shot 2022-07-19 at 22 56 33" src="https://user-images.githubusercontent.com/33497058/179893784-9eb7b7ff-6db9-45ba-8cb6-4747c732f516.png">



Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>