### PR TITLE
Use intended console code in compiled MinIO

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -135,6 +135,7 @@ jobs:
         run: |
           echo "The idea is to build minio image from downloaded repository";
           cd $GITHUB_WORKSPACE/minio_repository;
+          echo "replace github.com/minio/console => ../" >> go.mod
           echo "Get git version to build MinIO Image";
           VERSION=`git rev-parse HEAD`;
           echo $VERSION;


### PR DESCRIPTION
We compile MinIO to usen the latest code available.
But we were missing to use proper Console version along with that MinIO version that we are compiling.
In this PR, we are replacing console version for the console that we are actually testing on the PR.
This way we can catch dependencies issues like the one observed with IDP changes:

Failure is expected at `Workflow / SSO Integration Test` until MinIO IDP is properly updated with missing or new added argument, a struct for multiple IDPs:

```
Cesars-MacBook-Pro:minio-1 cniackz$ make build
Checking dependencies
Building minio binary to './minio'
# github.com/minio/minio/cmd
cmd/common-main.go:265:33: not enough arguments in call to operations.NewConsoleAPI
	have (*loads.Document)
	want (*loads.Document, "github.com/minio/console/pkg/auth/idp/oauth2".OpenIDPCfg)
make: *** [build] Error 2
```
