### PR TITLE
Correcting response on invalid login attempt

### DIFF
--- a/restapi/errors.go
+++ b/restapi/errors.go
@@ -19,6 +19,7 @@ package restapi
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/go-openapi/swag"
 	"github.com/minio/console/models"
@@ -69,6 +70,7 @@ var (
 	ErrDeletingEncryptionConfig         = errors.New("error disabling tenant encryption")
 	ErrEncryptionConfigNotFound         = errors.New("encryption configuration not found")
 	ErrPolicyNotFound                   = errors.New("policy does not exist")
+	ErrLoginNotAllowed                  = errors.New("login not allowed")
 )
 
 // ErrorWithContext :
@@ -92,6 +94,10 @@ func ErrorWithContext(ctx context.Context, err ...interface{}) *models.Error {
 			if errors.Is(err1, ErrInvalidLogin) {
 				errorCode = 401
 				errorMessage = ErrInvalidLogin.Error()
+			}
+			if strings.Contains(err1.Error(), ErrLoginNotAllowed.Error()) {
+				errorCode = 400
+				errorMessage = ErrLoginNotAllowed.Error()
 			}
 			// console invalid erasure coding value
 			if errors.Is(err1, ErrInvalidErasureCodingValue) {

--- a/sso-integration/sso_test.go
+++ b/sso-integration/sso_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -28,6 +29,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/minio/console/models"
 
 	"github.com/go-openapi/loads"
 	consoleoauth2 "github.com/minio/console/pkg/auth/idp/oauth2"
@@ -254,5 +257,15 @@ func TestBadLogin(t *testing.T) {
 	fmt.Println(response)
 	fmt.Println(err)
 	expectedError := response.Status
-	assert.Equal("500 Internal Server Error", expectedError)
+	assert.Equal("400 Bad Request", expectedError)
+	bodyBytes, _ := ioutil.ReadAll(response.Body)
+	result2 := models.Error{}
+	err = json.Unmarshal(bodyBytes, &result2)
+	if err != nil {
+		log.Println(err)
+		assert.Nil(err)
+	}
+	detailedMessage := *result2.DetailedMessage
+	fmt.Println(detailedMessage)
+	assert.Equal("expected 'code' response type - got [], login not allowed", detailedMessage)
 }


### PR DESCRIPTION
Correcting reposnse on invalid login attempt.
If `expected 'code' response type - got [], login not allowed` then returning 400 HTTP Status.