### PR TITLE
Migrate Lint Test to Datacenter

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -229,6 +229,21 @@ jobs:
         run: |
           make verifiers
 
+  lint-job-for-containers:
+    name: Checking Lint
+    runs-on: self-hosted
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Run Lint Job Test
+        env:
+          GO111MODULE: on
+          GOOS: linux
+        run: |
+          make lint-for-containers
+
   vulnerable-dependencies-checks:
     name: "Check for vulnerable dependencies"
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ lint:
 	@GO111MODULE=on ${GOPATH}/bin/golangci-lint cache clean
 	@GO111MODULE=on ${GOPATH}/bin/golangci-lint run --timeout=5m --config ./.golangci.yml
 
+lint-for-containers:
+	@echo "Running $@ check in container:"
+	@GO111MODULE=on /usr/bin/golangci-lint cache clean
+	@GO111MODULE=on /usr/bin/golangci-lint run --timeout=5m --config ./.golangci.yml
+
 install: console
 	@echo "Installing console binary to '$(GOPATH)/bin/console'"
 	@mkdir -p $(GOPATH)/bin && cp -f $(PWD)/console $(GOPATH)/bin/console


### PR DESCRIPTION
### Objective: To start migrating our tests to containers in our Datacenter.

- This was tested in my fork: https://github.com/cniackz/console/runs/7776531245?check_suite_focus=true

- The container image will already have `go` and `golangci-lint`, saving a lot of time in execution time.

  * `Successful in 23s` <--- Lint Test in container on Datacenter.
  * `Successful in 3m` <--- Lint Test in GitHub Action.

### Additional information:

https://github.com/golangci/golangci-lint/discussions/2215