### PR TITLE
read license from envt variable

### DIFF
--- a/pkg/subnet/utils.go
+++ b/pkg/subnet/utils.go
@@ -26,10 +26,10 @@ import (
 	"net/http"
 
 	xhttp "github.com/minio/console/pkg/http"
+	"github.com/minio/pkg/env"
 
 	"github.com/minio/madmin-go"
 	mc "github.com/minio/mc/cmd"
-	"github.com/minio/pkg/env"
 )
 
 const (
@@ -37,7 +37,7 @@ const (
 )
 
 func subnetBaseURL() string {
-	return env.Get(ConsoleSubnetURL, "https://subnet.min.io")
+	return env.Get(ConsoleSubnetURL, "http://localhost:9000")
 }
 
 func subnetRegisterURL() string {

--- a/pkg/subnet/utils.go
+++ b/pkg/subnet/utils.go
@@ -26,10 +26,10 @@ import (
 	"net/http"
 
 	xhttp "github.com/minio/console/pkg/http"
-	"github.com/minio/pkg/env"
 
 	"github.com/minio/madmin-go"
 	mc "github.com/minio/mc/cmd"
+	"github.com/minio/pkg/env"
 )
 
 const (
@@ -37,7 +37,7 @@ const (
 )
 
 func subnetBaseURL() string {
-	return env.Get(ConsoleSubnetURL, "http://localhost:9000")
+	return env.Get(ConsoleSubnetURL, "https://subnet.min.io")
 }
 
 func subnetRegisterURL() string {

--- a/portal-ui/src/screens/Console/License/License.tsx
+++ b/portal-ui/src/screens/Console/License/License.tsx
@@ -25,12 +25,7 @@ import { containerForHeader } from "../Common/FormComponents/common/styleLibrary
 import PageHeader from "../Common/PageHeader/PageHeader";
 import api from "../../../common/api";
 import { ArrowRightLink, HelpIconFilled, LoginMinIOLogo } from "../../../icons";
-import { hasPermission } from "../../../common/SecureComponent";
-import {
-  CONSOLE_UI_RESOURCE,
-  IAM_PAGES,
-  IAM_PAGES_PERMISSIONS,
-} from "../../../common/SecureComponent/permissions";
+import { IAM_PAGES } from "../../../common/SecureComponent/permissions";
 import LicensePlans from "./LicensePlans";
 import { Link } from "react-router-dom";
 import PageLayout from "../Common/Layout/PageLayout";
@@ -131,12 +126,6 @@ const License = () => {
   const [isLicenseConsentOpen, setIsLicenseConsentOpen] =
     useState<boolean>(false);
 
-  const getSubnetInfo = hasPermission(
-    CONSOLE_UI_RESOURCE,
-    IAM_PAGES_PERMISSIONS[IAM_PAGES.LICENSE],
-    true
-  );
-
   const closeModalAndFetchLicenseInfo = () => {
     setActivateProductModal(false);
     fetchLicenseInfo();
@@ -164,32 +153,28 @@ const License = () => {
     if (loadingLicenseInfo) {
       return;
     }
-    if (getSubnetInfo) {
-      setLoadingLicenseInfo(true);
-      api
-        .invoke("GET", `/api/v1/subnet/info`)
-        .then((res: SubnetInfo) => {
-          if (res) {
-            if (res.plan === "STANDARD") {
-              setCurrentPlanID(1);
-            } else if (res.plan === "ENTERPRISE") {
-              setCurrentPlanID(2);
-            } else {
-              setCurrentPlanID(1);
-            }
-            setLicenseInfo(res);
+    setLoadingLicenseInfo(true);
+    api
+      .invoke("GET", `/api/v1/subnet/info`)
+      .then((res: SubnetInfo) => {
+        if (res) {
+          if (res.plan === "STANDARD") {
+            setCurrentPlanID(1);
+          } else if (res.plan === "ENTERPRISE") {
+            setCurrentPlanID(2);
+          } else {
+            setCurrentPlanID(1);
           }
-          setClusterRegistered(true);
-          setLoadingLicenseInfo(false);
-        })
-        .catch(() => {
-          setClusterRegistered(false);
-          setLoadingLicenseInfo(false);
-        });
-    } else {
-      setLoadingLicenseInfo(false);
-    }
-  }, [loadingLicenseInfo, getSubnetInfo]);
+          setLicenseInfo(res);
+        }
+        setClusterRegistered(true);
+        setLoadingLicenseInfo(false);
+      })
+      .catch(() => {
+        setClusterRegistered(false);
+        setLoadingLicenseInfo(false);
+      });
+  }, [loadingLicenseInfo]);
 
   useEffect(() => {
     if (initialLicenseLoading) {

--- a/portal-ui/src/screens/Console/Support/Register.tsx
+++ b/portal-ui/src/screens/Console/Support/Register.tsx
@@ -190,7 +190,10 @@ const Register = ({ classes }: IRegister) => {
           setLoadingLicenseInfo(false);
         })
         .catch((err: ErrorResponseHandler) => {
-          if (err.errorMessage !== "License not found") {
+          if (
+            err.detailedError.toLowerCase() !==
+            "License is not present".toLowerCase()
+          ) {
             dispatch(setErrorSnackMessage(err));
           }
           setClusterRegistered(false);

--- a/restapi/admin_subnet.go
+++ b/restapi/admin_subnet.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 
 	xhttp "github.com/minio/console/pkg/http"
 
@@ -307,22 +308,11 @@ func GetSubnetRegisterResponse(session *models.Principal, params subnetApi.Subne
 func GetSubnetInfoResponse(session *models.Principal, params subnetApi.SubnetInfoParams) (*models.License, *models.Error) {
 	ctx, cancel := context.WithCancel(params.HTTPRequest.Context())
 	defer cancel()
-	mAdmin, err := NewMinioAdminClient(session)
-	if err != nil {
-		return nil, ErrorWithContext(ctx, err)
-	}
-	adminClient := AdminClient{Client: mAdmin}
-	subnetTokens, err := GetSubnetKeyFromMinIOConfig(ctx, adminClient)
-	if err != nil {
-		return nil, ErrorWithContext(ctx, err)
-	}
-	if subnetTokens.APIKey == "" {
-		return nil, ErrorWithContext(ctx, ErrLicenseNotFound)
-	}
 	client := &xhttp.Client{
 		Client: GetConsoleHTTPClient(),
 	}
-	licenseInfo, err := subnet.ParseLicense(client, subnetTokens.License)
+
+	licenseInfo, err := subnet.ParseLicense(client, os.Getenv("CONSOLE_SUBNET_LICENSE"))
 	if err != nil {
 		return nil, ErrorWithContext(ctx, err)
 	}


### PR DESCRIPTION
Earlier the license were read from config , and only admin had the privilige to read those the config , so any normal user with read write permission were seeing AGPL license even when they had the license .

With this PR the license is being read from envt variable which is set in MinIO at initialization.


