### PR TITLE
Migrate vulnerable-dependencies-checks to datacenter

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -231,7 +231,7 @@ jobs:
 
   vulnerable-dependencies-checks:
     name: "Check for vulnerable dependencies"
-    runs-on: ${{ matrix.os }}
+    runs-on: self-hosted
     strategy:
       matrix:
         go-version: [ 1.18.x, 1.19.x ]
@@ -253,9 +253,9 @@ jobs:
           CGO_ENABLED: 0
           GO111MODULE: on
         run: |
-          sudo apt install jq -y
-          sudo sysctl net.ipv6.conf.all.disable_ipv6=0
-          sudo sysctl net.ipv6.conf.default.disable_ipv6=0
+          sudo apt install jq -y || apt install jq -y
+          sudo sysctl net.ipv6.conf.all.disable_ipv6=0 || sysctl net.ipv6.conf.all.disable_ipv6=0
+          sudo sysctl net.ipv6.conf.default.disable_ipv6=0 || sysctl net.ipv6.conf.default.disable_ipv6=0
           nancy_version=$(curl --retry 10 -Ls -o /dev/null -w "%{url_effective}" https://github.com/sonatype-nexus-community/nancy/releases/latest | sed "s/https:\/\/github.com\/sonatype-nexus-community\/nancy\/releases\/tag\///")
           curl -L -o nancy https://github.com/sonatype-nexus-community/nancy/releases/download/${nancy_version}/nancy-${nancy_version}-linux-amd64 && chmod +x nancy
           go list -deps -json ./... | jq -s 'unique_by(.Module.Path)|.[]|select(has("Module"))|.Module' | ./nancy sleuth


### PR DESCRIPTION
### Objective: 

Migrate `vulnerable-dependencies-checks` to datacenter

### Executed in Datacenter already:

* https://github.com/minio/console/runs/8005455223?check_suite_focus=true
* https://github.com/minio/console/runs/8005455308?check_suite_focus=true

```sh
Current runner version: '2.295.0'
Runner name: 'console-runner-1'
Runner group name: 'Default'
Machine name: 'console-runner-1'
```

```sh
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Summary                       ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━┫
┃ Audited Dependencies    ┃ 167 ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━┫
┃ Vulnerable Dependencies ┃ 0   ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━┛
```
