### PR TITLE
Execute Lint Job with Self Hosted Runner

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -207,7 +207,7 @@ jobs:
 
   lint-job:
     name: Checking Lint
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted]
     strategy:
       matrix:
         go-version: [ 1.18.x, 1.19.x ]


### PR DESCRIPTION
To start using self hosted runner in Datacenter for lint job:

<img width="597" alt="Screen Shot 2022-08-24 at 3 47 27 PM" src="https://user-images.githubusercontent.com/6667358/186509665-54ab3f20-6710-4b16-937f-b821a41d9ebc.png">

