### PR TITLE
Catch error in gofmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,7 @@ verifiers: getdeps fmt lint
 
 fmt:
 	@echo "Running $@ check"
-	@GO111MODULE=on gofmt -d restapi/
-	@GO111MODULE=on gofmt -d pkg/
-	@GO111MODULE=on gofmt -d cmd/
-	@GO111MODULE=on gofmt -d cluster/
+	@(env bash $(PWD)/verify-gofmt.sh)
 
 crosscompile:
 	@(env bash $(PWD)/cross-compile.sh $(arg1))

--- a/verify-gofmt.sh
+++ b/verify-gofmt.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Expanding gofmt to cover more areas.
+# This will include auto generated files created by Swagger.
+# Catching the difference due to https://github.com/golang/go/issues/46289
+DIFF=$(GO111MODULE=on gofmt -d .)
+if [[ -n $DIFF ]];
+then
+	echo "$DIFF";
+	echo "please run gofmt";
+	exit 1;
+fi


### PR DESCRIPTION
Our test is not catching error in `gofmt` in version of go 1.19, look -d is not exiting with status of 1 hence we just print the difference but we don't notice this is actually failing:

https://github.com/golang/go/issues/46289

What I am doing in this PR is to actually catch the issue and fail the test if gofmt is having any difference.

### Dependencies:

* https://github.com/minio/console/pull/2278

### Related: 

* https://github.com/minio/console/pull/2283