### PR TITLE
Correct gofmt version 1.19

### DIFF
--- a/pkg/clientgen/clientset/versioned/fake/register.go
+++ b/pkg/clientgen/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/clientgen/clientset/versioned/scheme/register.go
+++ b/pkg/clientgen/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/restapi/doc.go
+++ b/restapi/doc.go
@@ -18,21 +18,21 @@
 
 // Package restapi MinIO Console Server
 //
-//  Schemes:
-//    http
-//    ws
-//  Host: localhost
-//  BasePath: /api/v1
-//  Version: 0.1.0
+//	Schemes:
+//	  http
+//	  ws
+//	Host: localhost
+//	BasePath: /api/v1
+//	Version: 0.1.0
 //
-//  Consumes:
-//    - application/json
-//    - multipart/form-data
+//	Consumes:
+//	  - application/json
+//	  - multipart/form-data
 //
-//  Produces:
-//    - application/zip
-//    - application/octet-stream
-//    - application/json
+//	Produces:
+//	  - application/zip
+//	  - application/octet-stream
+//	  - application/json
 //
 // swagger:meta
 package restapi

--- a/restapi/operations/account/account_change_password.go
+++ b/restapi/operations/account/account_change_password.go
@@ -48,10 +48,10 @@ func NewAccountChangePassword(ctx *middleware.Context, handler AccountChangePass
 	return &AccountChangePassword{Context: ctx, Handler: handler}
 }
 
-/* AccountChangePassword swagger:route POST /account/change-password Account accountChangePassword
+/*
+	AccountChangePassword swagger:route POST /account/change-password Account accountChangePassword
 
 Change password of currently logged in user.
-
 */
 type AccountChangePassword struct {
 	Context *middleware.Context

--- a/restapi/operations/account/account_change_password_responses.go
+++ b/restapi/operations/account/account_change_password_responses.go
@@ -33,7 +33,8 @@ import (
 // AccountChangePasswordNoContentCode is the HTTP code returned for type AccountChangePasswordNoContent
 const AccountChangePasswordNoContentCode int = 204
 
-/*AccountChangePasswordNoContent A successful login.
+/*
+AccountChangePasswordNoContent A successful login.
 
 swagger:response accountChangePasswordNoContent
 */
@@ -54,7 +55,8 @@ func (o *AccountChangePasswordNoContent) WriteResponse(rw http.ResponseWriter, p
 	rw.WriteHeader(204)
 }
 
-/*AccountChangePasswordDefault Generic error response.
+/*
+AccountChangePasswordDefault Generic error response.
 
 swagger:response accountChangePasswordDefault
 */

--- a/restapi/operations/account/change_user_password.go
+++ b/restapi/operations/account/change_user_password.go
@@ -48,10 +48,10 @@ func NewChangeUserPassword(ctx *middleware.Context, handler ChangeUserPasswordHa
 	return &ChangeUserPassword{Context: ctx, Handler: handler}
 }
 
-/* ChangeUserPassword swagger:route POST /account/change-user-password Account changeUserPassword
+/*
+	ChangeUserPassword swagger:route POST /account/change-user-password Account changeUserPassword
 
 Change password of currently logged in user.
-
 */
 type ChangeUserPassword struct {
 	Context *middleware.Context

--- a/restapi/operations/account/change_user_password_responses.go
+++ b/restapi/operations/account/change_user_password_responses.go
@@ -33,7 +33,8 @@ import (
 // ChangeUserPasswordCreatedCode is the HTTP code returned for type ChangeUserPasswordCreated
 const ChangeUserPasswordCreatedCode int = 201
 
-/*ChangeUserPasswordCreated Password successfully changed.
+/*
+ChangeUserPasswordCreated Password successfully changed.
 
 swagger:response changeUserPasswordCreated
 */
@@ -54,7 +55,8 @@ func (o *ChangeUserPasswordCreated) WriteResponse(rw http.ResponseWriter, produc
 	rw.WriteHeader(201)
 }
 
-/*ChangeUserPasswordDefault Generic error response.
+/*
+ChangeUserPasswordDefault Generic error response.
 
 swagger:response changeUserPasswordDefault
 */

--- a/restapi/operations/auth/login.go
+++ b/restapi/operations/auth/login.go
@@ -46,10 +46,10 @@ func NewLogin(ctx *middleware.Context, handler LoginHandler) *Login {
 	return &Login{Context: ctx, Handler: handler}
 }
 
-/* Login swagger:route POST /login Auth login
+/*
+	Login swagger:route POST /login Auth login
 
 Login to Console
-
 */
 type Login struct {
 	Context *middleware.Context

--- a/restapi/operations/auth/login_detail.go
+++ b/restapi/operations/auth/login_detail.go
@@ -46,10 +46,10 @@ func NewLoginDetail(ctx *middleware.Context, handler LoginDetailHandler) *LoginD
 	return &LoginDetail{Context: ctx, Handler: handler}
 }
 
-/* LoginDetail swagger:route GET /login Auth loginDetail
+/*
+	LoginDetail swagger:route GET /login Auth loginDetail
 
 Returns login strategy, form or sso.
-
 */
 type LoginDetail struct {
 	Context *middleware.Context

--- a/restapi/operations/auth/login_detail_responses.go
+++ b/restapi/operations/auth/login_detail_responses.go
@@ -33,7 +33,8 @@ import (
 // LoginDetailOKCode is the HTTP code returned for type LoginDetailOK
 const LoginDetailOKCode int = 200
 
-/*LoginDetailOK A successful response.
+/*
+LoginDetailOK A successful response.
 
 swagger:response loginDetailOK
 */
@@ -74,7 +75,8 @@ func (o *LoginDetailOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 }
 
-/*LoginDetailDefault Generic error response.
+/*
+LoginDetailDefault Generic error response.
 
 swagger:response loginDetailDefault
 */

--- a/restapi/operations/auth/login_oauth2_auth.go
+++ b/restapi/operations/auth/login_oauth2_auth.go
@@ -46,10 +46,10 @@ func NewLoginOauth2Auth(ctx *middleware.Context, handler LoginOauth2AuthHandler)
 	return &LoginOauth2Auth{Context: ctx, Handler: handler}
 }
 
-/* LoginOauth2Auth swagger:route POST /login/oauth2/auth Auth loginOauth2Auth
+/*
+	LoginOauth2Auth swagger:route POST /login/oauth2/auth Auth loginOauth2Auth
 
 Identity Provider oauth2 callback endpoint.
-
 */
 type LoginOauth2Auth struct {
 	Context *middleware.Context

--- a/restapi/operations/auth/login_oauth2_auth_responses.go
+++ b/restapi/operations/auth/login_oauth2_auth_responses.go
@@ -33,7 +33,8 @@ import (
 // LoginOauth2AuthNoContentCode is the HTTP code returned for type LoginOauth2AuthNoContent
 const LoginOauth2AuthNoContentCode int = 204
 
-/*LoginOauth2AuthNoContent A successful login.
+/*
+LoginOauth2AuthNoContent A successful login.
 
 swagger:response loginOauth2AuthNoContent
 */
@@ -54,7 +55,8 @@ func (o *LoginOauth2AuthNoContent) WriteResponse(rw http.ResponseWriter, produce
 	rw.WriteHeader(204)
 }
 
-/*LoginOauth2AuthDefault Generic error response.
+/*
+LoginOauth2AuthDefault Generic error response.
 
 swagger:response loginOauth2AuthDefault
 */

--- a/restapi/operations/auth/login_responses.go
+++ b/restapi/operations/auth/login_responses.go
@@ -33,7 +33,8 @@ import (
 // LoginNoContentCode is the HTTP code returned for type LoginNoContent
 const LoginNoContentCode int = 204
 
-/*LoginNoContent A successful login.
+/*
+LoginNoContent A successful login.
 
 swagger:response loginNoContent
 */
@@ -54,7 +55,8 @@ func (o *LoginNoContent) WriteResponse(rw http.ResponseWriter, producer runtime.
 	rw.WriteHeader(204)
 }
 
-/*LoginDefault Generic error response.
+/*
+LoginDefault Generic error response.
 
 swagger:response loginDefault
 */

--- a/restapi/operations/auth/logout.go
+++ b/restapi/operations/auth/logout.go
@@ -48,10 +48,10 @@ func NewLogout(ctx *middleware.Context, handler LogoutHandler) *Logout {
 	return &Logout{Context: ctx, Handler: handler}
 }
 
-/* Logout swagger:route POST /logout Auth logout
+/*
+	Logout swagger:route POST /logout Auth logout
 
 Logout from Console.
-
 */
 type Logout struct {
 	Context *middleware.Context

--- a/restapi/operations/auth/logout_responses.go
+++ b/restapi/operations/auth/logout_responses.go
@@ -33,7 +33,8 @@ import (
 // LogoutOKCode is the HTTP code returned for type LogoutOK
 const LogoutOKCode int = 200
 
-/*LogoutOK A successful response.
+/*
+LogoutOK A successful response.
 
 swagger:response logoutOK
 */
@@ -54,7 +55,8 @@ func (o *LogoutOK) WriteResponse(rw http.ResponseWriter, producer runtime.Produc
 	rw.WriteHeader(200)
 }
 
-/*LogoutDefault Generic error response.
+/*
+LogoutDefault Generic error response.
 
 swagger:response logoutDefault
 */

--- a/restapi/operations/auth/session_check.go
+++ b/restapi/operations/auth/session_check.go
@@ -48,10 +48,10 @@ func NewSessionCheck(ctx *middleware.Context, handler SessionCheckHandler) *Sess
 	return &SessionCheck{Context: ctx, Handler: handler}
 }
 
-/* SessionCheck swagger:route GET /session Auth sessionCheck
+/*
+	SessionCheck swagger:route GET /session Auth sessionCheck
 
 Endpoint to check if your session is still valid
-
 */
 type SessionCheck struct {
 	Context *middleware.Context

--- a/restapi/operations/auth/session_check_responses.go
+++ b/restapi/operations/auth/session_check_responses.go
@@ -33,7 +33,8 @@ import (
 // SessionCheckOKCode is the HTTP code returned for type SessionCheckOK
 const SessionCheckOKCode int = 200
 
-/*SessionCheckOK A successful response.
+/*
+SessionCheckOK A successful response.
 
 swagger:response sessionCheckOK
 */
@@ -74,7 +75,8 @@ func (o *SessionCheckOK) WriteResponse(rw http.ResponseWriter, producer runtime.
 	}
 }
 
-/*SessionCheckDefault Generic error response.
+/*
+SessionCheckDefault Generic error response.
 
 swagger:response sessionCheckDefault
 */

--- a/restapi/operations/bucket/add_bucket_lifecycle.go
+++ b/restapi/operations/bucket/add_bucket_lifecycle.go
@@ -48,10 +48,10 @@ func NewAddBucketLifecycle(ctx *middleware.Context, handler AddBucketLifecycleHa
 	return &AddBucketLifecycle{Context: ctx, Handler: handler}
 }
 
-/* AddBucketLifecycle swagger:route POST /buckets/{bucket_name}/lifecycle Bucket addBucketLifecycle
+/*
+	AddBucketLifecycle swagger:route POST /buckets/{bucket_name}/lifecycle Bucket addBucketLifecycle
 
 Add Bucket Lifecycle
-
 */
 type AddBucketLifecycle struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/add_bucket_lifecycle_responses.go
+++ b/restapi/operations/bucket/add_bucket_lifecycle_responses.go
@@ -33,7 +33,8 @@ import (
 // AddBucketLifecycleCreatedCode is the HTTP code returned for type AddBucketLifecycleCreated
 const AddBucketLifecycleCreatedCode int = 201
 
-/*AddBucketLifecycleCreated A successful response.
+/*
+AddBucketLifecycleCreated A successful response.
 
 swagger:response addBucketLifecycleCreated
 */
@@ -54,7 +55,8 @@ func (o *AddBucketLifecycleCreated) WriteResponse(rw http.ResponseWriter, produc
 	rw.WriteHeader(201)
 }
 
-/*AddBucketLifecycleDefault Generic error response.
+/*
+AddBucketLifecycleDefault Generic error response.
 
 swagger:response addBucketLifecycleDefault
 */

--- a/restapi/operations/bucket/add_multi_bucket_lifecycle.go
+++ b/restapi/operations/bucket/add_multi_bucket_lifecycle.go
@@ -48,10 +48,10 @@ func NewAddMultiBucketLifecycle(ctx *middleware.Context, handler AddMultiBucketL
 	return &AddMultiBucketLifecycle{Context: ctx, Handler: handler}
 }
 
-/* AddMultiBucketLifecycle swagger:route POST /buckets/multi-lifecycle Bucket addMultiBucketLifecycle
+/*
+	AddMultiBucketLifecycle swagger:route POST /buckets/multi-lifecycle Bucket addMultiBucketLifecycle
 
 Add Multi Bucket Lifecycle
-
 */
 type AddMultiBucketLifecycle struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/add_multi_bucket_lifecycle_responses.go
+++ b/restapi/operations/bucket/add_multi_bucket_lifecycle_responses.go
@@ -33,7 +33,8 @@ import (
 // AddMultiBucketLifecycleOKCode is the HTTP code returned for type AddMultiBucketLifecycleOK
 const AddMultiBucketLifecycleOKCode int = 200
 
-/*AddMultiBucketLifecycleOK A successful response.
+/*
+AddMultiBucketLifecycleOK A successful response.
 
 swagger:response addMultiBucketLifecycleOK
 */
@@ -74,7 +75,8 @@ func (o *AddMultiBucketLifecycleOK) WriteResponse(rw http.ResponseWriter, produc
 	}
 }
 
-/*AddMultiBucketLifecycleDefault Generic error response.
+/*
+AddMultiBucketLifecycleDefault Generic error response.
 
 swagger:response addMultiBucketLifecycleDefault
 */

--- a/restapi/operations/bucket/add_remote_bucket.go
+++ b/restapi/operations/bucket/add_remote_bucket.go
@@ -48,10 +48,10 @@ func NewAddRemoteBucket(ctx *middleware.Context, handler AddRemoteBucketHandler)
 	return &AddRemoteBucket{Context: ctx, Handler: handler}
 }
 
-/* AddRemoteBucket swagger:route POST /remote-buckets Bucket addRemoteBucket
+/*
+	AddRemoteBucket swagger:route POST /remote-buckets Bucket addRemoteBucket
 
 Add Remote Bucket
-
 */
 type AddRemoteBucket struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/add_remote_bucket_responses.go
+++ b/restapi/operations/bucket/add_remote_bucket_responses.go
@@ -33,7 +33,8 @@ import (
 // AddRemoteBucketCreatedCode is the HTTP code returned for type AddRemoteBucketCreated
 const AddRemoteBucketCreatedCode int = 201
 
-/*AddRemoteBucketCreated A successful response.
+/*
+AddRemoteBucketCreated A successful response.
 
 swagger:response addRemoteBucketCreated
 */
@@ -54,7 +55,8 @@ func (o *AddRemoteBucketCreated) WriteResponse(rw http.ResponseWriter, producer 
 	rw.WriteHeader(201)
 }
 
-/*AddRemoteBucketDefault Generic error response.
+/*
+AddRemoteBucketDefault Generic error response.
 
 swagger:response addRemoteBucketDefault
 */

--- a/restapi/operations/bucket/bucket_info.go
+++ b/restapi/operations/bucket/bucket_info.go
@@ -48,10 +48,10 @@ func NewBucketInfo(ctx *middleware.Context, handler BucketInfoHandler) *BucketIn
 	return &BucketInfo{Context: ctx, Handler: handler}
 }
 
-/* BucketInfo swagger:route GET /buckets/{name} Bucket bucketInfo
+/*
+	BucketInfo swagger:route GET /buckets/{name} Bucket bucketInfo
 
 Bucket Info
-
 */
 type BucketInfo struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/bucket_info_responses.go
+++ b/restapi/operations/bucket/bucket_info_responses.go
@@ -33,7 +33,8 @@ import (
 // BucketInfoOKCode is the HTTP code returned for type BucketInfoOK
 const BucketInfoOKCode int = 200
 
-/*BucketInfoOK A successful response.
+/*
+BucketInfoOK A successful response.
 
 swagger:response bucketInfoOK
 */
@@ -74,7 +75,8 @@ func (o *BucketInfoOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 	}
 }
 
-/*BucketInfoDefault Generic error response.
+/*
+BucketInfoDefault Generic error response.
 
 swagger:response bucketInfoDefault
 */

--- a/restapi/operations/bucket/bucket_set_policy.go
+++ b/restapi/operations/bucket/bucket_set_policy.go
@@ -48,10 +48,10 @@ func NewBucketSetPolicy(ctx *middleware.Context, handler BucketSetPolicyHandler)
 	return &BucketSetPolicy{Context: ctx, Handler: handler}
 }
 
-/* BucketSetPolicy swagger:route PUT /buckets/{name}/set-policy Bucket bucketSetPolicy
+/*
+	BucketSetPolicy swagger:route PUT /buckets/{name}/set-policy Bucket bucketSetPolicy
 
 Bucket Set Policy
-
 */
 type BucketSetPolicy struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/bucket_set_policy_responses.go
+++ b/restapi/operations/bucket/bucket_set_policy_responses.go
@@ -33,7 +33,8 @@ import (
 // BucketSetPolicyOKCode is the HTTP code returned for type BucketSetPolicyOK
 const BucketSetPolicyOKCode int = 200
 
-/*BucketSetPolicyOK A successful response.
+/*
+BucketSetPolicyOK A successful response.
 
 swagger:response bucketSetPolicyOK
 */
@@ -74,7 +75,8 @@ func (o *BucketSetPolicyOK) WriteResponse(rw http.ResponseWriter, producer runti
 	}
 }
 
-/*BucketSetPolicyDefault Generic error response.
+/*
+BucketSetPolicyDefault Generic error response.
 
 swagger:response bucketSetPolicyDefault
 */

--- a/restapi/operations/bucket/create_bucket_event.go
+++ b/restapi/operations/bucket/create_bucket_event.go
@@ -48,10 +48,10 @@ func NewCreateBucketEvent(ctx *middleware.Context, handler CreateBucketEventHand
 	return &CreateBucketEvent{Context: ctx, Handler: handler}
 }
 
-/* CreateBucketEvent swagger:route POST /buckets/{bucket_name}/events Bucket createBucketEvent
+/*
+	CreateBucketEvent swagger:route POST /buckets/{bucket_name}/events Bucket createBucketEvent
 
 Create Bucket Event
-
 */
 type CreateBucketEvent struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/create_bucket_event_responses.go
+++ b/restapi/operations/bucket/create_bucket_event_responses.go
@@ -33,7 +33,8 @@ import (
 // CreateBucketEventCreatedCode is the HTTP code returned for type CreateBucketEventCreated
 const CreateBucketEventCreatedCode int = 201
 
-/*CreateBucketEventCreated A successful response.
+/*
+CreateBucketEventCreated A successful response.
 
 swagger:response createBucketEventCreated
 */
@@ -54,7 +55,8 @@ func (o *CreateBucketEventCreated) WriteResponse(rw http.ResponseWriter, produce
 	rw.WriteHeader(201)
 }
 
-/*CreateBucketEventDefault Generic error response.
+/*
+CreateBucketEventDefault Generic error response.
 
 swagger:response createBucketEventDefault
 */

--- a/restapi/operations/bucket/delete_access_rule_with_bucket.go
+++ b/restapi/operations/bucket/delete_access_rule_with_bucket.go
@@ -48,10 +48,10 @@ func NewDeleteAccessRuleWithBucket(ctx *middleware.Context, handler DeleteAccess
 	return &DeleteAccessRuleWithBucket{Context: ctx, Handler: handler}
 }
 
-/* DeleteAccessRuleWithBucket swagger:route DELETE /bucket/{bucket}/access-rules Bucket deleteAccessRuleWithBucket
+/*
+	DeleteAccessRuleWithBucket swagger:route DELETE /bucket/{bucket}/access-rules Bucket deleteAccessRuleWithBucket
 
 Delete Access Rule From Given Bucket
-
 */
 type DeleteAccessRuleWithBucket struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/delete_access_rule_with_bucket_responses.go
+++ b/restapi/operations/bucket/delete_access_rule_with_bucket_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteAccessRuleWithBucketOKCode is the HTTP code returned for type DeleteAccessRuleWithBucketOK
 const DeleteAccessRuleWithBucketOKCode int = 200
 
-/*DeleteAccessRuleWithBucketOK A successful response.
+/*
+DeleteAccessRuleWithBucketOK A successful response.
 
 swagger:response deleteAccessRuleWithBucketOK
 */
@@ -72,7 +73,8 @@ func (o *DeleteAccessRuleWithBucketOK) WriteResponse(rw http.ResponseWriter, pro
 	}
 }
 
-/*DeleteAccessRuleWithBucketDefault Generic error response.
+/*
+DeleteAccessRuleWithBucketDefault Generic error response.
 
 swagger:response deleteAccessRuleWithBucketDefault
 */

--- a/restapi/operations/bucket/delete_all_replication_rules.go
+++ b/restapi/operations/bucket/delete_all_replication_rules.go
@@ -48,10 +48,10 @@ func NewDeleteAllReplicationRules(ctx *middleware.Context, handler DeleteAllRepl
 	return &DeleteAllReplicationRules{Context: ctx, Handler: handler}
 }
 
-/* DeleteAllReplicationRules swagger:route DELETE /buckets/{bucket_name}/delete-all-replication-rules Bucket deleteAllReplicationRules
+/*
+	DeleteAllReplicationRules swagger:route DELETE /buckets/{bucket_name}/delete-all-replication-rules Bucket deleteAllReplicationRules
 
 Deletes all replication rules from a bucket
-
 */
 type DeleteAllReplicationRules struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/delete_all_replication_rules_responses.go
+++ b/restapi/operations/bucket/delete_all_replication_rules_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteAllReplicationRulesNoContentCode is the HTTP code returned for type DeleteAllReplicationRulesNoContent
 const DeleteAllReplicationRulesNoContentCode int = 204
 
-/*DeleteAllReplicationRulesNoContent A successful response.
+/*
+DeleteAllReplicationRulesNoContent A successful response.
 
 swagger:response deleteAllReplicationRulesNoContent
 */
@@ -54,7 +55,8 @@ func (o *DeleteAllReplicationRulesNoContent) WriteResponse(rw http.ResponseWrite
 	rw.WriteHeader(204)
 }
 
-/*DeleteAllReplicationRulesDefault Generic error response.
+/*
+DeleteAllReplicationRulesDefault Generic error response.
 
 swagger:response deleteAllReplicationRulesDefault
 */

--- a/restapi/operations/bucket/delete_bucket.go
+++ b/restapi/operations/bucket/delete_bucket.go
@@ -48,10 +48,10 @@ func NewDeleteBucket(ctx *middleware.Context, handler DeleteBucketHandler) *Dele
 	return &DeleteBucket{Context: ctx, Handler: handler}
 }
 
-/* DeleteBucket swagger:route DELETE /buckets/{name} Bucket deleteBucket
+/*
+	DeleteBucket swagger:route DELETE /buckets/{name} Bucket deleteBucket
 
 Delete Bucket
-
 */
 type DeleteBucket struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/delete_bucket_event.go
+++ b/restapi/operations/bucket/delete_bucket_event.go
@@ -48,10 +48,10 @@ func NewDeleteBucketEvent(ctx *middleware.Context, handler DeleteBucketEventHand
 	return &DeleteBucketEvent{Context: ctx, Handler: handler}
 }
 
-/* DeleteBucketEvent swagger:route DELETE /buckets/{bucket_name}/events/{arn} Bucket deleteBucketEvent
+/*
+	DeleteBucketEvent swagger:route DELETE /buckets/{bucket_name}/events/{arn} Bucket deleteBucketEvent
 
 Delete Bucket Event
-
 */
 type DeleteBucketEvent struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/delete_bucket_event_responses.go
+++ b/restapi/operations/bucket/delete_bucket_event_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteBucketEventNoContentCode is the HTTP code returned for type DeleteBucketEventNoContent
 const DeleteBucketEventNoContentCode int = 204
 
-/*DeleteBucketEventNoContent A successful response.
+/*
+DeleteBucketEventNoContent A successful response.
 
 swagger:response deleteBucketEventNoContent
 */
@@ -54,7 +55,8 @@ func (o *DeleteBucketEventNoContent) WriteResponse(rw http.ResponseWriter, produ
 	rw.WriteHeader(204)
 }
 
-/*DeleteBucketEventDefault Generic error response.
+/*
+DeleteBucketEventDefault Generic error response.
 
 swagger:response deleteBucketEventDefault
 */

--- a/restapi/operations/bucket/delete_bucket_lifecycle_rule.go
+++ b/restapi/operations/bucket/delete_bucket_lifecycle_rule.go
@@ -48,10 +48,10 @@ func NewDeleteBucketLifecycleRule(ctx *middleware.Context, handler DeleteBucketL
 	return &DeleteBucketLifecycleRule{Context: ctx, Handler: handler}
 }
 
-/* DeleteBucketLifecycleRule swagger:route DELETE /buckets/{bucket_name}/lifecycle/{lifecycle_id} Bucket deleteBucketLifecycleRule
+/*
+	DeleteBucketLifecycleRule swagger:route DELETE /buckets/{bucket_name}/lifecycle/{lifecycle_id} Bucket deleteBucketLifecycleRule
 
 Delete Lifecycle rule
-
 */
 type DeleteBucketLifecycleRule struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/delete_bucket_lifecycle_rule_responses.go
+++ b/restapi/operations/bucket/delete_bucket_lifecycle_rule_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteBucketLifecycleRuleNoContentCode is the HTTP code returned for type DeleteBucketLifecycleRuleNoContent
 const DeleteBucketLifecycleRuleNoContentCode int = 204
 
-/*DeleteBucketLifecycleRuleNoContent A successful response.
+/*
+DeleteBucketLifecycleRuleNoContent A successful response.
 
 swagger:response deleteBucketLifecycleRuleNoContent
 */
@@ -54,7 +55,8 @@ func (o *DeleteBucketLifecycleRuleNoContent) WriteResponse(rw http.ResponseWrite
 	rw.WriteHeader(204)
 }
 
-/*DeleteBucketLifecycleRuleDefault Generic error response.
+/*
+DeleteBucketLifecycleRuleDefault Generic error response.
 
 swagger:response deleteBucketLifecycleRuleDefault
 */

--- a/restapi/operations/bucket/delete_bucket_replication_rule.go
+++ b/restapi/operations/bucket/delete_bucket_replication_rule.go
@@ -48,10 +48,10 @@ func NewDeleteBucketReplicationRule(ctx *middleware.Context, handler DeleteBucke
 	return &DeleteBucketReplicationRule{Context: ctx, Handler: handler}
 }
 
-/* DeleteBucketReplicationRule swagger:route DELETE /buckets/{bucket_name}/replication/{rule_id} Bucket deleteBucketReplicationRule
+/*
+	DeleteBucketReplicationRule swagger:route DELETE /buckets/{bucket_name}/replication/{rule_id} Bucket deleteBucketReplicationRule
 
 Bucket Replication Rule Delete
-
 */
 type DeleteBucketReplicationRule struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/delete_bucket_replication_rule_responses.go
+++ b/restapi/operations/bucket/delete_bucket_replication_rule_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteBucketReplicationRuleNoContentCode is the HTTP code returned for type DeleteBucketReplicationRuleNoContent
 const DeleteBucketReplicationRuleNoContentCode int = 204
 
-/*DeleteBucketReplicationRuleNoContent A successful response.
+/*
+DeleteBucketReplicationRuleNoContent A successful response.
 
 swagger:response deleteBucketReplicationRuleNoContent
 */
@@ -54,7 +55,8 @@ func (o *DeleteBucketReplicationRuleNoContent) WriteResponse(rw http.ResponseWri
 	rw.WriteHeader(204)
 }
 
-/*DeleteBucketReplicationRuleDefault Generic error response.
+/*
+DeleteBucketReplicationRuleDefault Generic error response.
 
 swagger:response deleteBucketReplicationRuleDefault
 */

--- a/restapi/operations/bucket/delete_bucket_responses.go
+++ b/restapi/operations/bucket/delete_bucket_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteBucketNoContentCode is the HTTP code returned for type DeleteBucketNoContent
 const DeleteBucketNoContentCode int = 204
 
-/*DeleteBucketNoContent A successful response.
+/*
+DeleteBucketNoContent A successful response.
 
 swagger:response deleteBucketNoContent
 */
@@ -54,7 +55,8 @@ func (o *DeleteBucketNoContent) WriteResponse(rw http.ResponseWriter, producer r
 	rw.WriteHeader(204)
 }
 
-/*DeleteBucketDefault Generic error response.
+/*
+DeleteBucketDefault Generic error response.
 
 swagger:response deleteBucketDefault
 */

--- a/restapi/operations/bucket/delete_remote_bucket.go
+++ b/restapi/operations/bucket/delete_remote_bucket.go
@@ -48,10 +48,10 @@ func NewDeleteRemoteBucket(ctx *middleware.Context, handler DeleteRemoteBucketHa
 	return &DeleteRemoteBucket{Context: ctx, Handler: handler}
 }
 
-/* DeleteRemoteBucket swagger:route DELETE /remote-buckets/{source-bucket-name}/{arn} Bucket deleteRemoteBucket
+/*
+	DeleteRemoteBucket swagger:route DELETE /remote-buckets/{source-bucket-name}/{arn} Bucket deleteRemoteBucket
 
 Delete Remote Bucket
-
 */
 type DeleteRemoteBucket struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/delete_remote_bucket_responses.go
+++ b/restapi/operations/bucket/delete_remote_bucket_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteRemoteBucketNoContentCode is the HTTP code returned for type DeleteRemoteBucketNoContent
 const DeleteRemoteBucketNoContentCode int = 204
 
-/*DeleteRemoteBucketNoContent A successful response.
+/*
+DeleteRemoteBucketNoContent A successful response.
 
 swagger:response deleteRemoteBucketNoContent
 */
@@ -54,7 +55,8 @@ func (o *DeleteRemoteBucketNoContent) WriteResponse(rw http.ResponseWriter, prod
 	rw.WriteHeader(204)
 }
 
-/*DeleteRemoteBucketDefault Generic error response.
+/*
+DeleteRemoteBucketDefault Generic error response.
 
 swagger:response deleteRemoteBucketDefault
 */

--- a/restapi/operations/bucket/delete_selected_replication_rules.go
+++ b/restapi/operations/bucket/delete_selected_replication_rules.go
@@ -48,10 +48,10 @@ func NewDeleteSelectedReplicationRules(ctx *middleware.Context, handler DeleteSe
 	return &DeleteSelectedReplicationRules{Context: ctx, Handler: handler}
 }
 
-/* DeleteSelectedReplicationRules swagger:route DELETE /buckets/{bucket_name}/delete-selected-replication-rules Bucket deleteSelectedReplicationRules
+/*
+	DeleteSelectedReplicationRules swagger:route DELETE /buckets/{bucket_name}/delete-selected-replication-rules Bucket deleteSelectedReplicationRules
 
 Deletes selected replication rules from a bucket
-
 */
 type DeleteSelectedReplicationRules struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/delete_selected_replication_rules_responses.go
+++ b/restapi/operations/bucket/delete_selected_replication_rules_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteSelectedReplicationRulesNoContentCode is the HTTP code returned for type DeleteSelectedReplicationRulesNoContent
 const DeleteSelectedReplicationRulesNoContentCode int = 204
 
-/*DeleteSelectedReplicationRulesNoContent A successful response.
+/*
+DeleteSelectedReplicationRulesNoContent A successful response.
 
 swagger:response deleteSelectedReplicationRulesNoContent
 */
@@ -54,7 +55,8 @@ func (o *DeleteSelectedReplicationRulesNoContent) WriteResponse(rw http.Response
 	rw.WriteHeader(204)
 }
 
-/*DeleteSelectedReplicationRulesDefault Generic error response.
+/*
+DeleteSelectedReplicationRulesDefault Generic error response.
 
 swagger:response deleteSelectedReplicationRulesDefault
 */

--- a/restapi/operations/bucket/disable_bucket_encryption.go
+++ b/restapi/operations/bucket/disable_bucket_encryption.go
@@ -48,10 +48,10 @@ func NewDisableBucketEncryption(ctx *middleware.Context, handler DisableBucketEn
 	return &DisableBucketEncryption{Context: ctx, Handler: handler}
 }
 
-/* DisableBucketEncryption swagger:route POST /buckets/{bucket_name}/encryption/disable Bucket disableBucketEncryption
+/*
+	DisableBucketEncryption swagger:route POST /buckets/{bucket_name}/encryption/disable Bucket disableBucketEncryption
 
 Disable bucket encryption.
-
 */
 type DisableBucketEncryption struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/disable_bucket_encryption_responses.go
+++ b/restapi/operations/bucket/disable_bucket_encryption_responses.go
@@ -33,7 +33,8 @@ import (
 // DisableBucketEncryptionOKCode is the HTTP code returned for type DisableBucketEncryptionOK
 const DisableBucketEncryptionOKCode int = 200
 
-/*DisableBucketEncryptionOK A successful response.
+/*
+DisableBucketEncryptionOK A successful response.
 
 swagger:response disableBucketEncryptionOK
 */
@@ -54,7 +55,8 @@ func (o *DisableBucketEncryptionOK) WriteResponse(rw http.ResponseWriter, produc
 	rw.WriteHeader(200)
 }
 
-/*DisableBucketEncryptionDefault Generic error response.
+/*
+DisableBucketEncryptionDefault Generic error response.
 
 swagger:response disableBucketEncryptionDefault
 */

--- a/restapi/operations/bucket/enable_bucket_encryption.go
+++ b/restapi/operations/bucket/enable_bucket_encryption.go
@@ -48,10 +48,10 @@ func NewEnableBucketEncryption(ctx *middleware.Context, handler EnableBucketEncr
 	return &EnableBucketEncryption{Context: ctx, Handler: handler}
 }
 
-/* EnableBucketEncryption swagger:route POST /buckets/{bucket_name}/encryption/enable Bucket enableBucketEncryption
+/*
+	EnableBucketEncryption swagger:route POST /buckets/{bucket_name}/encryption/enable Bucket enableBucketEncryption
 
 Enable bucket encryption.
-
 */
 type EnableBucketEncryption struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/enable_bucket_encryption_responses.go
+++ b/restapi/operations/bucket/enable_bucket_encryption_responses.go
@@ -33,7 +33,8 @@ import (
 // EnableBucketEncryptionOKCode is the HTTP code returned for type EnableBucketEncryptionOK
 const EnableBucketEncryptionOKCode int = 200
 
-/*EnableBucketEncryptionOK A successful response.
+/*
+EnableBucketEncryptionOK A successful response.
 
 swagger:response enableBucketEncryptionOK
 */
@@ -54,7 +55,8 @@ func (o *EnableBucketEncryptionOK) WriteResponse(rw http.ResponseWriter, produce
 	rw.WriteHeader(200)
 }
 
-/*EnableBucketEncryptionDefault Generic error response.
+/*
+EnableBucketEncryptionDefault Generic error response.
 
 swagger:response enableBucketEncryptionDefault
 */

--- a/restapi/operations/bucket/get_bucket_encryption_info.go
+++ b/restapi/operations/bucket/get_bucket_encryption_info.go
@@ -48,10 +48,10 @@ func NewGetBucketEncryptionInfo(ctx *middleware.Context, handler GetBucketEncryp
 	return &GetBucketEncryptionInfo{Context: ctx, Handler: handler}
 }
 
-/* GetBucketEncryptionInfo swagger:route GET /buckets/{bucket_name}/encryption/info Bucket getBucketEncryptionInfo
+/*
+	GetBucketEncryptionInfo swagger:route GET /buckets/{bucket_name}/encryption/info Bucket getBucketEncryptionInfo
 
 Get bucket encryption information.
-
 */
 type GetBucketEncryptionInfo struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/get_bucket_encryption_info_responses.go
+++ b/restapi/operations/bucket/get_bucket_encryption_info_responses.go
@@ -33,7 +33,8 @@ import (
 // GetBucketEncryptionInfoOKCode is the HTTP code returned for type GetBucketEncryptionInfoOK
 const GetBucketEncryptionInfoOKCode int = 200
 
-/*GetBucketEncryptionInfoOK A successful response.
+/*
+GetBucketEncryptionInfoOK A successful response.
 
 swagger:response getBucketEncryptionInfoOK
 */
@@ -74,7 +75,8 @@ func (o *GetBucketEncryptionInfoOK) WriteResponse(rw http.ResponseWriter, produc
 	}
 }
 
-/*GetBucketEncryptionInfoDefault Generic error response.
+/*
+GetBucketEncryptionInfoDefault Generic error response.
 
 swagger:response getBucketEncryptionInfoDefault
 */

--- a/restapi/operations/bucket/get_bucket_lifecycle.go
+++ b/restapi/operations/bucket/get_bucket_lifecycle.go
@@ -48,10 +48,10 @@ func NewGetBucketLifecycle(ctx *middleware.Context, handler GetBucketLifecycleHa
 	return &GetBucketLifecycle{Context: ctx, Handler: handler}
 }
 
-/* GetBucketLifecycle swagger:route GET /buckets/{bucket_name}/lifecycle Bucket getBucketLifecycle
+/*
+	GetBucketLifecycle swagger:route GET /buckets/{bucket_name}/lifecycle Bucket getBucketLifecycle
 
 Bucket Lifecycle
-
 */
 type GetBucketLifecycle struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/get_bucket_lifecycle_responses.go
+++ b/restapi/operations/bucket/get_bucket_lifecycle_responses.go
@@ -33,7 +33,8 @@ import (
 // GetBucketLifecycleOKCode is the HTTP code returned for type GetBucketLifecycleOK
 const GetBucketLifecycleOKCode int = 200
 
-/*GetBucketLifecycleOK A successful response.
+/*
+GetBucketLifecycleOK A successful response.
 
 swagger:response getBucketLifecycleOK
 */
@@ -74,7 +75,8 @@ func (o *GetBucketLifecycleOK) WriteResponse(rw http.ResponseWriter, producer ru
 	}
 }
 
-/*GetBucketLifecycleDefault Generic error response.
+/*
+GetBucketLifecycleDefault Generic error response.
 
 swagger:response getBucketLifecycleDefault
 */

--- a/restapi/operations/bucket/get_bucket_object_locking_status.go
+++ b/restapi/operations/bucket/get_bucket_object_locking_status.go
@@ -48,10 +48,10 @@ func NewGetBucketObjectLockingStatus(ctx *middleware.Context, handler GetBucketO
 	return &GetBucketObjectLockingStatus{Context: ctx, Handler: handler}
 }
 
-/* GetBucketObjectLockingStatus swagger:route GET /buckets/{bucket_name}/object-locking Bucket getBucketObjectLockingStatus
+/*
+	GetBucketObjectLockingStatus swagger:route GET /buckets/{bucket_name}/object-locking Bucket getBucketObjectLockingStatus
 
 Returns the status of object locking support on the bucket
-
 */
 type GetBucketObjectLockingStatus struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/get_bucket_object_locking_status_responses.go
+++ b/restapi/operations/bucket/get_bucket_object_locking_status_responses.go
@@ -33,7 +33,8 @@ import (
 // GetBucketObjectLockingStatusOKCode is the HTTP code returned for type GetBucketObjectLockingStatusOK
 const GetBucketObjectLockingStatusOKCode int = 200
 
-/*GetBucketObjectLockingStatusOK A successful response.
+/*
+GetBucketObjectLockingStatusOK A successful response.
 
 swagger:response getBucketObjectLockingStatusOK
 */
@@ -74,7 +75,8 @@ func (o *GetBucketObjectLockingStatusOK) WriteResponse(rw http.ResponseWriter, p
 	}
 }
 
-/*GetBucketObjectLockingStatusDefault Generic error response.
+/*
+GetBucketObjectLockingStatusDefault Generic error response.
 
 swagger:response getBucketObjectLockingStatusDefault
 */

--- a/restapi/operations/bucket/get_bucket_quota.go
+++ b/restapi/operations/bucket/get_bucket_quota.go
@@ -48,10 +48,10 @@ func NewGetBucketQuota(ctx *middleware.Context, handler GetBucketQuotaHandler) *
 	return &GetBucketQuota{Context: ctx, Handler: handler}
 }
 
-/* GetBucketQuota swagger:route GET /buckets/{name}/quota Bucket getBucketQuota
+/*
+	GetBucketQuota swagger:route GET /buckets/{name}/quota Bucket getBucketQuota
 
 Get Bucket Quota
-
 */
 type GetBucketQuota struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/get_bucket_quota_responses.go
+++ b/restapi/operations/bucket/get_bucket_quota_responses.go
@@ -33,7 +33,8 @@ import (
 // GetBucketQuotaOKCode is the HTTP code returned for type GetBucketQuotaOK
 const GetBucketQuotaOKCode int = 200
 
-/*GetBucketQuotaOK A successful response.
+/*
+GetBucketQuotaOK A successful response.
 
 swagger:response getBucketQuotaOK
 */
@@ -74,7 +75,8 @@ func (o *GetBucketQuotaOK) WriteResponse(rw http.ResponseWriter, producer runtim
 	}
 }
 
-/*GetBucketQuotaDefault Generic error response.
+/*
+GetBucketQuotaDefault Generic error response.
 
 swagger:response getBucketQuotaDefault
 */

--- a/restapi/operations/bucket/get_bucket_replication.go
+++ b/restapi/operations/bucket/get_bucket_replication.go
@@ -48,10 +48,10 @@ func NewGetBucketReplication(ctx *middleware.Context, handler GetBucketReplicati
 	return &GetBucketReplication{Context: ctx, Handler: handler}
 }
 
-/* GetBucketReplication swagger:route GET /buckets/{bucket_name}/replication Bucket getBucketReplication
+/*
+	GetBucketReplication swagger:route GET /buckets/{bucket_name}/replication Bucket getBucketReplication
 
 Bucket Replication
-
 */
 type GetBucketReplication struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/get_bucket_replication_responses.go
+++ b/restapi/operations/bucket/get_bucket_replication_responses.go
@@ -33,7 +33,8 @@ import (
 // GetBucketReplicationOKCode is the HTTP code returned for type GetBucketReplicationOK
 const GetBucketReplicationOKCode int = 200
 
-/*GetBucketReplicationOK A successful response.
+/*
+GetBucketReplicationOK A successful response.
 
 swagger:response getBucketReplicationOK
 */
@@ -74,7 +75,8 @@ func (o *GetBucketReplicationOK) WriteResponse(rw http.ResponseWriter, producer 
 	}
 }
 
-/*GetBucketReplicationDefault Generic error response.
+/*
+GetBucketReplicationDefault Generic error response.
 
 swagger:response getBucketReplicationDefault
 */

--- a/restapi/operations/bucket/get_bucket_replication_rule.go
+++ b/restapi/operations/bucket/get_bucket_replication_rule.go
@@ -48,10 +48,10 @@ func NewGetBucketReplicationRule(ctx *middleware.Context, handler GetBucketRepli
 	return &GetBucketReplicationRule{Context: ctx, Handler: handler}
 }
 
-/* GetBucketReplicationRule swagger:route GET /buckets/{bucket_name}/replication/{rule_id} Bucket getBucketReplicationRule
+/*
+	GetBucketReplicationRule swagger:route GET /buckets/{bucket_name}/replication/{rule_id} Bucket getBucketReplicationRule
 
 Bucket Replication
-
 */
 type GetBucketReplicationRule struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/get_bucket_replication_rule_responses.go
+++ b/restapi/operations/bucket/get_bucket_replication_rule_responses.go
@@ -33,7 +33,8 @@ import (
 // GetBucketReplicationRuleOKCode is the HTTP code returned for type GetBucketReplicationRuleOK
 const GetBucketReplicationRuleOKCode int = 200
 
-/*GetBucketReplicationRuleOK A successful response.
+/*
+GetBucketReplicationRuleOK A successful response.
 
 swagger:response getBucketReplicationRuleOK
 */
@@ -74,7 +75,8 @@ func (o *GetBucketReplicationRuleOK) WriteResponse(rw http.ResponseWriter, produ
 	}
 }
 
-/*GetBucketReplicationRuleDefault Generic error response.
+/*
+GetBucketReplicationRuleDefault Generic error response.
 
 swagger:response getBucketReplicationRuleDefault
 */

--- a/restapi/operations/bucket/get_bucket_retention_config.go
+++ b/restapi/operations/bucket/get_bucket_retention_config.go
@@ -48,10 +48,10 @@ func NewGetBucketRetentionConfig(ctx *middleware.Context, handler GetBucketReten
 	return &GetBucketRetentionConfig{Context: ctx, Handler: handler}
 }
 
-/* GetBucketRetentionConfig swagger:route GET /buckets/{bucket_name}/retention Bucket getBucketRetentionConfig
+/*
+	GetBucketRetentionConfig swagger:route GET /buckets/{bucket_name}/retention Bucket getBucketRetentionConfig
 
 Get Bucket's retention config
-
 */
 type GetBucketRetentionConfig struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/get_bucket_retention_config_responses.go
+++ b/restapi/operations/bucket/get_bucket_retention_config_responses.go
@@ -33,7 +33,8 @@ import (
 // GetBucketRetentionConfigOKCode is the HTTP code returned for type GetBucketRetentionConfigOK
 const GetBucketRetentionConfigOKCode int = 200
 
-/*GetBucketRetentionConfigOK A successful response.
+/*
+GetBucketRetentionConfigOK A successful response.
 
 swagger:response getBucketRetentionConfigOK
 */
@@ -74,7 +75,8 @@ func (o *GetBucketRetentionConfigOK) WriteResponse(rw http.ResponseWriter, produ
 	}
 }
 
-/*GetBucketRetentionConfigDefault Generic error response.
+/*
+GetBucketRetentionConfigDefault Generic error response.
 
 swagger:response getBucketRetentionConfigDefault
 */

--- a/restapi/operations/bucket/get_bucket_rewind.go
+++ b/restapi/operations/bucket/get_bucket_rewind.go
@@ -48,10 +48,10 @@ func NewGetBucketRewind(ctx *middleware.Context, handler GetBucketRewindHandler)
 	return &GetBucketRewind{Context: ctx, Handler: handler}
 }
 
-/* GetBucketRewind swagger:route GET /buckets/{bucket_name}/rewind/{date} Bucket getBucketRewind
+/*
+	GetBucketRewind swagger:route GET /buckets/{bucket_name}/rewind/{date} Bucket getBucketRewind
 
 Get objects in a bucket for a rewind date
-
 */
 type GetBucketRewind struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/get_bucket_rewind_responses.go
+++ b/restapi/operations/bucket/get_bucket_rewind_responses.go
@@ -33,7 +33,8 @@ import (
 // GetBucketRewindOKCode is the HTTP code returned for type GetBucketRewindOK
 const GetBucketRewindOKCode int = 200
 
-/*GetBucketRewindOK A successful response.
+/*
+GetBucketRewindOK A successful response.
 
 swagger:response getBucketRewindOK
 */
@@ -74,7 +75,8 @@ func (o *GetBucketRewindOK) WriteResponse(rw http.ResponseWriter, producer runti
 	}
 }
 
-/*GetBucketRewindDefault Generic error response.
+/*
+GetBucketRewindDefault Generic error response.
 
 swagger:response getBucketRewindDefault
 */

--- a/restapi/operations/bucket/get_bucket_versioning.go
+++ b/restapi/operations/bucket/get_bucket_versioning.go
@@ -48,10 +48,10 @@ func NewGetBucketVersioning(ctx *middleware.Context, handler GetBucketVersioning
 	return &GetBucketVersioning{Context: ctx, Handler: handler}
 }
 
-/* GetBucketVersioning swagger:route GET /buckets/{bucket_name}/versioning Bucket getBucketVersioning
+/*
+	GetBucketVersioning swagger:route GET /buckets/{bucket_name}/versioning Bucket getBucketVersioning
 
 Bucket Versioning
-
 */
 type GetBucketVersioning struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/get_bucket_versioning_responses.go
+++ b/restapi/operations/bucket/get_bucket_versioning_responses.go
@@ -33,7 +33,8 @@ import (
 // GetBucketVersioningOKCode is the HTTP code returned for type GetBucketVersioningOK
 const GetBucketVersioningOKCode int = 200
 
-/*GetBucketVersioningOK A successful response.
+/*
+GetBucketVersioningOK A successful response.
 
 swagger:response getBucketVersioningOK
 */
@@ -74,7 +75,8 @@ func (o *GetBucketVersioningOK) WriteResponse(rw http.ResponseWriter, producer r
 	}
 }
 
-/*GetBucketVersioningDefault Generic error response.
+/*
+GetBucketVersioningDefault Generic error response.
 
 swagger:response getBucketVersioningDefault
 */

--- a/restapi/operations/bucket/list_access_rules_with_bucket.go
+++ b/restapi/operations/bucket/list_access_rules_with_bucket.go
@@ -48,10 +48,10 @@ func NewListAccessRulesWithBucket(ctx *middleware.Context, handler ListAccessRul
 	return &ListAccessRulesWithBucket{Context: ctx, Handler: handler}
 }
 
-/* ListAccessRulesWithBucket swagger:route GET /bucket/{bucket}/access-rules Bucket listAccessRulesWithBucket
+/*
+	ListAccessRulesWithBucket swagger:route GET /bucket/{bucket}/access-rules Bucket listAccessRulesWithBucket
 
 List Access Rules With Given Bucket
-
 */
 type ListAccessRulesWithBucket struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/list_access_rules_with_bucket_responses.go
+++ b/restapi/operations/bucket/list_access_rules_with_bucket_responses.go
@@ -33,7 +33,8 @@ import (
 // ListAccessRulesWithBucketOKCode is the HTTP code returned for type ListAccessRulesWithBucketOK
 const ListAccessRulesWithBucketOKCode int = 200
 
-/*ListAccessRulesWithBucketOK A successful response.
+/*
+ListAccessRulesWithBucketOK A successful response.
 
 swagger:response listAccessRulesWithBucketOK
 */
@@ -74,7 +75,8 @@ func (o *ListAccessRulesWithBucketOK) WriteResponse(rw http.ResponseWriter, prod
 	}
 }
 
-/*ListAccessRulesWithBucketDefault Generic error response.
+/*
+ListAccessRulesWithBucketDefault Generic error response.
 
 swagger:response listAccessRulesWithBucketDefault
 */

--- a/restapi/operations/bucket/list_bucket_events.go
+++ b/restapi/operations/bucket/list_bucket_events.go
@@ -48,10 +48,10 @@ func NewListBucketEvents(ctx *middleware.Context, handler ListBucketEventsHandle
 	return &ListBucketEvents{Context: ctx, Handler: handler}
 }
 
-/* ListBucketEvents swagger:route GET /buckets/{bucket_name}/events Bucket listBucketEvents
+/*
+	ListBucketEvents swagger:route GET /buckets/{bucket_name}/events Bucket listBucketEvents
 
 List Bucket Events
-
 */
 type ListBucketEvents struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/list_bucket_events_responses.go
+++ b/restapi/operations/bucket/list_bucket_events_responses.go
@@ -33,7 +33,8 @@ import (
 // ListBucketEventsOKCode is the HTTP code returned for type ListBucketEventsOK
 const ListBucketEventsOKCode int = 200
 
-/*ListBucketEventsOK A successful response.
+/*
+ListBucketEventsOK A successful response.
 
 swagger:response listBucketEventsOK
 */
@@ -74,7 +75,8 @@ func (o *ListBucketEventsOK) WriteResponse(rw http.ResponseWriter, producer runt
 	}
 }
 
-/*ListBucketEventsDefault Generic error response.
+/*
+ListBucketEventsDefault Generic error response.
 
 swagger:response listBucketEventsDefault
 */

--- a/restapi/operations/bucket/list_buckets.go
+++ b/restapi/operations/bucket/list_buckets.go
@@ -48,10 +48,10 @@ func NewListBuckets(ctx *middleware.Context, handler ListBucketsHandler) *ListBu
 	return &ListBuckets{Context: ctx, Handler: handler}
 }
 
-/* ListBuckets swagger:route GET /buckets Bucket listBuckets
+/*
+	ListBuckets swagger:route GET /buckets Bucket listBuckets
 
 List Buckets
-
 */
 type ListBuckets struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/list_buckets_responses.go
+++ b/restapi/operations/bucket/list_buckets_responses.go
@@ -33,7 +33,8 @@ import (
 // ListBucketsOKCode is the HTTP code returned for type ListBucketsOK
 const ListBucketsOKCode int = 200
 
-/*ListBucketsOK A successful response.
+/*
+ListBucketsOK A successful response.
 
 swagger:response listBucketsOK
 */
@@ -74,7 +75,8 @@ func (o *ListBucketsOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 }
 
-/*ListBucketsDefault Generic error response.
+/*
+ListBucketsDefault Generic error response.
 
 swagger:response listBucketsDefault
 */

--- a/restapi/operations/bucket/list_external_buckets.go
+++ b/restapi/operations/bucket/list_external_buckets.go
@@ -48,10 +48,10 @@ func NewListExternalBuckets(ctx *middleware.Context, handler ListExternalBuckets
 	return &ListExternalBuckets{Context: ctx, Handler: handler}
 }
 
-/* ListExternalBuckets swagger:route POST /list-external-buckets Bucket listExternalBuckets
+/*
+	ListExternalBuckets swagger:route POST /list-external-buckets Bucket listExternalBuckets
 
 Lists an External list of buckets using custom credentials
-
 */
 type ListExternalBuckets struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/list_external_buckets_responses.go
+++ b/restapi/operations/bucket/list_external_buckets_responses.go
@@ -33,7 +33,8 @@ import (
 // ListExternalBucketsOKCode is the HTTP code returned for type ListExternalBucketsOK
 const ListExternalBucketsOKCode int = 200
 
-/*ListExternalBucketsOK A successful response.
+/*
+ListExternalBucketsOK A successful response.
 
 swagger:response listExternalBucketsOK
 */
@@ -74,7 +75,8 @@ func (o *ListExternalBucketsOK) WriteResponse(rw http.ResponseWriter, producer r
 	}
 }
 
-/*ListExternalBucketsDefault Generic error response.
+/*
+ListExternalBucketsDefault Generic error response.
 
 swagger:response listExternalBucketsDefault
 */

--- a/restapi/operations/bucket/list_policies_with_bucket.go
+++ b/restapi/operations/bucket/list_policies_with_bucket.go
@@ -48,10 +48,10 @@ func NewListPoliciesWithBucket(ctx *middleware.Context, handler ListPoliciesWith
 	return &ListPoliciesWithBucket{Context: ctx, Handler: handler}
 }
 
-/* ListPoliciesWithBucket swagger:route GET /bucket-policy/{bucket} Bucket listPoliciesWithBucket
+/*
+	ListPoliciesWithBucket swagger:route GET /bucket-policy/{bucket} Bucket listPoliciesWithBucket
 
 List Policies With Given Bucket
-
 */
 type ListPoliciesWithBucket struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/list_policies_with_bucket_responses.go
+++ b/restapi/operations/bucket/list_policies_with_bucket_responses.go
@@ -33,7 +33,8 @@ import (
 // ListPoliciesWithBucketOKCode is the HTTP code returned for type ListPoliciesWithBucketOK
 const ListPoliciesWithBucketOKCode int = 200
 
-/*ListPoliciesWithBucketOK A successful response.
+/*
+ListPoliciesWithBucketOK A successful response.
 
 swagger:response listPoliciesWithBucketOK
 */
@@ -74,7 +75,8 @@ func (o *ListPoliciesWithBucketOK) WriteResponse(rw http.ResponseWriter, produce
 	}
 }
 
-/*ListPoliciesWithBucketDefault Generic error response.
+/*
+ListPoliciesWithBucketDefault Generic error response.
 
 swagger:response listPoliciesWithBucketDefault
 */

--- a/restapi/operations/bucket/list_remote_buckets.go
+++ b/restapi/operations/bucket/list_remote_buckets.go
@@ -48,10 +48,10 @@ func NewListRemoteBuckets(ctx *middleware.Context, handler ListRemoteBucketsHand
 	return &ListRemoteBuckets{Context: ctx, Handler: handler}
 }
 
-/* ListRemoteBuckets swagger:route GET /remote-buckets Bucket listRemoteBuckets
+/*
+	ListRemoteBuckets swagger:route GET /remote-buckets Bucket listRemoteBuckets
 
 List Remote Buckets
-
 */
 type ListRemoteBuckets struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/list_remote_buckets_responses.go
+++ b/restapi/operations/bucket/list_remote_buckets_responses.go
@@ -33,7 +33,8 @@ import (
 // ListRemoteBucketsOKCode is the HTTP code returned for type ListRemoteBucketsOK
 const ListRemoteBucketsOKCode int = 200
 
-/*ListRemoteBucketsOK A successful response.
+/*
+ListRemoteBucketsOK A successful response.
 
 swagger:response listRemoteBucketsOK
 */
@@ -74,7 +75,8 @@ func (o *ListRemoteBucketsOK) WriteResponse(rw http.ResponseWriter, producer run
 	}
 }
 
-/*ListRemoteBucketsDefault Generic error response.
+/*
+ListRemoteBucketsDefault Generic error response.
 
 swagger:response listRemoteBucketsDefault
 */

--- a/restapi/operations/bucket/list_users_with_access_to_bucket.go
+++ b/restapi/operations/bucket/list_users_with_access_to_bucket.go
@@ -48,10 +48,10 @@ func NewListUsersWithAccessToBucket(ctx *middleware.Context, handler ListUsersWi
 	return &ListUsersWithAccessToBucket{Context: ctx, Handler: handler}
 }
 
-/* ListUsersWithAccessToBucket swagger:route GET /bucket-users/{bucket} Bucket listUsersWithAccessToBucket
+/*
+	ListUsersWithAccessToBucket swagger:route GET /bucket-users/{bucket} Bucket listUsersWithAccessToBucket
 
 List Users With Access to a Given Bucket
-
 */
 type ListUsersWithAccessToBucket struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/list_users_with_access_to_bucket_responses.go
+++ b/restapi/operations/bucket/list_users_with_access_to_bucket_responses.go
@@ -33,7 +33,8 @@ import (
 // ListUsersWithAccessToBucketOKCode is the HTTP code returned for type ListUsersWithAccessToBucketOK
 const ListUsersWithAccessToBucketOKCode int = 200
 
-/*ListUsersWithAccessToBucketOK A successful response.
+/*
+ListUsersWithAccessToBucketOK A successful response.
 
 swagger:response listUsersWithAccessToBucketOK
 */
@@ -77,7 +78,8 @@ func (o *ListUsersWithAccessToBucketOK) WriteResponse(rw http.ResponseWriter, pr
 	}
 }
 
-/*ListUsersWithAccessToBucketDefault Generic error response.
+/*
+ListUsersWithAccessToBucketDefault Generic error response.
 
 swagger:response listUsersWithAccessToBucketDefault
 */

--- a/restapi/operations/bucket/make_bucket.go
+++ b/restapi/operations/bucket/make_bucket.go
@@ -48,10 +48,10 @@ func NewMakeBucket(ctx *middleware.Context, handler MakeBucketHandler) *MakeBuck
 	return &MakeBucket{Context: ctx, Handler: handler}
 }
 
-/* MakeBucket swagger:route POST /buckets Bucket makeBucket
+/*
+	MakeBucket swagger:route POST /buckets Bucket makeBucket
 
 Make bucket
-
 */
 type MakeBucket struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/make_bucket_responses.go
+++ b/restapi/operations/bucket/make_bucket_responses.go
@@ -33,7 +33,8 @@ import (
 // MakeBucketCreatedCode is the HTTP code returned for type MakeBucketCreated
 const MakeBucketCreatedCode int = 201
 
-/*MakeBucketCreated A successful response.
+/*
+MakeBucketCreated A successful response.
 
 swagger:response makeBucketCreated
 */
@@ -54,7 +55,8 @@ func (o *MakeBucketCreated) WriteResponse(rw http.ResponseWriter, producer runti
 	rw.WriteHeader(201)
 }
 
-/*MakeBucketDefault Generic error response.
+/*
+MakeBucketDefault Generic error response.
 
 swagger:response makeBucketDefault
 */

--- a/restapi/operations/bucket/put_bucket_tags.go
+++ b/restapi/operations/bucket/put_bucket_tags.go
@@ -48,10 +48,10 @@ func NewPutBucketTags(ctx *middleware.Context, handler PutBucketTagsHandler) *Pu
 	return &PutBucketTags{Context: ctx, Handler: handler}
 }
 
-/* PutBucketTags swagger:route PUT /buckets/{bucket_name}/tags Bucket putBucketTags
+/*
+	PutBucketTags swagger:route PUT /buckets/{bucket_name}/tags Bucket putBucketTags
 
 Put Bucket's tags
-
 */
 type PutBucketTags struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/put_bucket_tags_responses.go
+++ b/restapi/operations/bucket/put_bucket_tags_responses.go
@@ -33,7 +33,8 @@ import (
 // PutBucketTagsOKCode is the HTTP code returned for type PutBucketTagsOK
 const PutBucketTagsOKCode int = 200
 
-/*PutBucketTagsOK A successful response.
+/*
+PutBucketTagsOK A successful response.
 
 swagger:response putBucketTagsOK
 */
@@ -54,7 +55,8 @@ func (o *PutBucketTagsOK) WriteResponse(rw http.ResponseWriter, producer runtime
 	rw.WriteHeader(200)
 }
 
-/*PutBucketTagsDefault Generic error response.
+/*
+PutBucketTagsDefault Generic error response.
 
 swagger:response putBucketTagsDefault
 */

--- a/restapi/operations/bucket/remote_bucket_details.go
+++ b/restapi/operations/bucket/remote_bucket_details.go
@@ -48,10 +48,10 @@ func NewRemoteBucketDetails(ctx *middleware.Context, handler RemoteBucketDetails
 	return &RemoteBucketDetails{Context: ctx, Handler: handler}
 }
 
-/* RemoteBucketDetails swagger:route GET /remote-buckets/{name} Bucket remoteBucketDetails
+/*
+	RemoteBucketDetails swagger:route GET /remote-buckets/{name} Bucket remoteBucketDetails
 
 Remote Bucket Details
-
 */
 type RemoteBucketDetails struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/remote_bucket_details_responses.go
+++ b/restapi/operations/bucket/remote_bucket_details_responses.go
@@ -33,7 +33,8 @@ import (
 // RemoteBucketDetailsOKCode is the HTTP code returned for type RemoteBucketDetailsOK
 const RemoteBucketDetailsOKCode int = 200
 
-/*RemoteBucketDetailsOK A successful response.
+/*
+RemoteBucketDetailsOK A successful response.
 
 swagger:response remoteBucketDetailsOK
 */
@@ -74,7 +75,8 @@ func (o *RemoteBucketDetailsOK) WriteResponse(rw http.ResponseWriter, producer r
 	}
 }
 
-/*RemoteBucketDetailsDefault Generic error response.
+/*
+RemoteBucketDetailsDefault Generic error response.
 
 swagger:response remoteBucketDetailsDefault
 */

--- a/restapi/operations/bucket/set_access_rule_with_bucket.go
+++ b/restapi/operations/bucket/set_access_rule_with_bucket.go
@@ -48,10 +48,10 @@ func NewSetAccessRuleWithBucket(ctx *middleware.Context, handler SetAccessRuleWi
 	return &SetAccessRuleWithBucket{Context: ctx, Handler: handler}
 }
 
-/* SetAccessRuleWithBucket swagger:route PUT /bucket/{bucket}/access-rules Bucket setAccessRuleWithBucket
+/*
+	SetAccessRuleWithBucket swagger:route PUT /bucket/{bucket}/access-rules Bucket setAccessRuleWithBucket
 
 Add Access Rule To Given Bucket
-
 */
 type SetAccessRuleWithBucket struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/set_access_rule_with_bucket_responses.go
+++ b/restapi/operations/bucket/set_access_rule_with_bucket_responses.go
@@ -33,7 +33,8 @@ import (
 // SetAccessRuleWithBucketOKCode is the HTTP code returned for type SetAccessRuleWithBucketOK
 const SetAccessRuleWithBucketOKCode int = 200
 
-/*SetAccessRuleWithBucketOK A successful response.
+/*
+SetAccessRuleWithBucketOK A successful response.
 
 swagger:response setAccessRuleWithBucketOK
 */
@@ -72,7 +73,8 @@ func (o *SetAccessRuleWithBucketOK) WriteResponse(rw http.ResponseWriter, produc
 	}
 }
 
-/*SetAccessRuleWithBucketDefault Generic error response.
+/*
+SetAccessRuleWithBucketDefault Generic error response.
 
 swagger:response setAccessRuleWithBucketDefault
 */

--- a/restapi/operations/bucket/set_bucket_quota.go
+++ b/restapi/operations/bucket/set_bucket_quota.go
@@ -48,10 +48,10 @@ func NewSetBucketQuota(ctx *middleware.Context, handler SetBucketQuotaHandler) *
 	return &SetBucketQuota{Context: ctx, Handler: handler}
 }
 
-/* SetBucketQuota swagger:route PUT /buckets/{name}/quota Bucket setBucketQuota
+/*
+	SetBucketQuota swagger:route PUT /buckets/{name}/quota Bucket setBucketQuota
 
 Bucket Quota
-
 */
 type SetBucketQuota struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/set_bucket_quota_responses.go
+++ b/restapi/operations/bucket/set_bucket_quota_responses.go
@@ -33,7 +33,8 @@ import (
 // SetBucketQuotaOKCode is the HTTP code returned for type SetBucketQuotaOK
 const SetBucketQuotaOKCode int = 200
 
-/*SetBucketQuotaOK A successful response.
+/*
+SetBucketQuotaOK A successful response.
 
 swagger:response setBucketQuotaOK
 */
@@ -74,7 +75,8 @@ func (o *SetBucketQuotaOK) WriteResponse(rw http.ResponseWriter, producer runtim
 	}
 }
 
-/*SetBucketQuotaDefault Generic error response.
+/*
+SetBucketQuotaDefault Generic error response.
 
 swagger:response setBucketQuotaDefault
 */

--- a/restapi/operations/bucket/set_bucket_retention_config.go
+++ b/restapi/operations/bucket/set_bucket_retention_config.go
@@ -48,10 +48,10 @@ func NewSetBucketRetentionConfig(ctx *middleware.Context, handler SetBucketReten
 	return &SetBucketRetentionConfig{Context: ctx, Handler: handler}
 }
 
-/* SetBucketRetentionConfig swagger:route PUT /buckets/{bucket_name}/retention Bucket setBucketRetentionConfig
+/*
+	SetBucketRetentionConfig swagger:route PUT /buckets/{bucket_name}/retention Bucket setBucketRetentionConfig
 
 Set Bucket's retention config
-
 */
 type SetBucketRetentionConfig struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/set_bucket_retention_config_responses.go
+++ b/restapi/operations/bucket/set_bucket_retention_config_responses.go
@@ -33,7 +33,8 @@ import (
 // SetBucketRetentionConfigOKCode is the HTTP code returned for type SetBucketRetentionConfigOK
 const SetBucketRetentionConfigOKCode int = 200
 
-/*SetBucketRetentionConfigOK A successful response.
+/*
+SetBucketRetentionConfigOK A successful response.
 
 swagger:response setBucketRetentionConfigOK
 */
@@ -54,7 +55,8 @@ func (o *SetBucketRetentionConfigOK) WriteResponse(rw http.ResponseWriter, produ
 	rw.WriteHeader(200)
 }
 
-/*SetBucketRetentionConfigDefault Generic error response.
+/*
+SetBucketRetentionConfigDefault Generic error response.
 
 swagger:response setBucketRetentionConfigDefault
 */

--- a/restapi/operations/bucket/set_bucket_versioning.go
+++ b/restapi/operations/bucket/set_bucket_versioning.go
@@ -48,10 +48,10 @@ func NewSetBucketVersioning(ctx *middleware.Context, handler SetBucketVersioning
 	return &SetBucketVersioning{Context: ctx, Handler: handler}
 }
 
-/* SetBucketVersioning swagger:route PUT /buckets/{bucket_name}/versioning Bucket setBucketVersioning
+/*
+	SetBucketVersioning swagger:route PUT /buckets/{bucket_name}/versioning Bucket setBucketVersioning
 
 Set Bucket Versioning
-
 */
 type SetBucketVersioning struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/set_bucket_versioning_responses.go
+++ b/restapi/operations/bucket/set_bucket_versioning_responses.go
@@ -33,7 +33,8 @@ import (
 // SetBucketVersioningCreatedCode is the HTTP code returned for type SetBucketVersioningCreated
 const SetBucketVersioningCreatedCode int = 201
 
-/*SetBucketVersioningCreated A successful response.
+/*
+SetBucketVersioningCreated A successful response.
 
 swagger:response setBucketVersioningCreated
 */
@@ -54,7 +55,8 @@ func (o *SetBucketVersioningCreated) WriteResponse(rw http.ResponseWriter, produ
 	rw.WriteHeader(201)
 }
 
-/*SetBucketVersioningDefault Generic error response.
+/*
+SetBucketVersioningDefault Generic error response.
 
 swagger:response setBucketVersioningDefault
 */

--- a/restapi/operations/bucket/set_multi_bucket_replication.go
+++ b/restapi/operations/bucket/set_multi_bucket_replication.go
@@ -48,10 +48,10 @@ func NewSetMultiBucketReplication(ctx *middleware.Context, handler SetMultiBucke
 	return &SetMultiBucketReplication{Context: ctx, Handler: handler}
 }
 
-/* SetMultiBucketReplication swagger:route POST /buckets-replication Bucket setMultiBucketReplication
+/*
+	SetMultiBucketReplication swagger:route POST /buckets-replication Bucket setMultiBucketReplication
 
 Sets Multi Bucket Replication in multiple Buckets
-
 */
 type SetMultiBucketReplication struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/set_multi_bucket_replication_responses.go
+++ b/restapi/operations/bucket/set_multi_bucket_replication_responses.go
@@ -33,7 +33,8 @@ import (
 // SetMultiBucketReplicationOKCode is the HTTP code returned for type SetMultiBucketReplicationOK
 const SetMultiBucketReplicationOKCode int = 200
 
-/*SetMultiBucketReplicationOK A successful response.
+/*
+SetMultiBucketReplicationOK A successful response.
 
 swagger:response setMultiBucketReplicationOK
 */
@@ -74,7 +75,8 @@ func (o *SetMultiBucketReplicationOK) WriteResponse(rw http.ResponseWriter, prod
 	}
 }
 
-/*SetMultiBucketReplicationDefault Generic error response.
+/*
+SetMultiBucketReplicationDefault Generic error response.
 
 swagger:response setMultiBucketReplicationDefault
 */

--- a/restapi/operations/bucket/update_bucket_lifecycle.go
+++ b/restapi/operations/bucket/update_bucket_lifecycle.go
@@ -48,10 +48,10 @@ func NewUpdateBucketLifecycle(ctx *middleware.Context, handler UpdateBucketLifec
 	return &UpdateBucketLifecycle{Context: ctx, Handler: handler}
 }
 
-/* UpdateBucketLifecycle swagger:route PUT /buckets/{bucket_name}/lifecycle/{lifecycle_id} Bucket updateBucketLifecycle
+/*
+	UpdateBucketLifecycle swagger:route PUT /buckets/{bucket_name}/lifecycle/{lifecycle_id} Bucket updateBucketLifecycle
 
 Update Lifecycle rule
-
 */
 type UpdateBucketLifecycle struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/update_bucket_lifecycle_responses.go
+++ b/restapi/operations/bucket/update_bucket_lifecycle_responses.go
@@ -33,7 +33,8 @@ import (
 // UpdateBucketLifecycleOKCode is the HTTP code returned for type UpdateBucketLifecycleOK
 const UpdateBucketLifecycleOKCode int = 200
 
-/*UpdateBucketLifecycleOK A successful response.
+/*
+UpdateBucketLifecycleOK A successful response.
 
 swagger:response updateBucketLifecycleOK
 */
@@ -54,7 +55,8 @@ func (o *UpdateBucketLifecycleOK) WriteResponse(rw http.ResponseWriter, producer
 	rw.WriteHeader(200)
 }
 
-/*UpdateBucketLifecycleDefault Generic error response.
+/*
+UpdateBucketLifecycleDefault Generic error response.
 
 swagger:response updateBucketLifecycleDefault
 */

--- a/restapi/operations/bucket/update_multi_bucket_replication.go
+++ b/restapi/operations/bucket/update_multi_bucket_replication.go
@@ -48,10 +48,10 @@ func NewUpdateMultiBucketReplication(ctx *middleware.Context, handler UpdateMult
 	return &UpdateMultiBucketReplication{Context: ctx, Handler: handler}
 }
 
-/* UpdateMultiBucketReplication swagger:route PUT /buckets/{bucket_name}/replication/{rule_id} Bucket updateMultiBucketReplication
+/*
+	UpdateMultiBucketReplication swagger:route PUT /buckets/{bucket_name}/replication/{rule_id} Bucket updateMultiBucketReplication
 
 Update Replication rule
-
 */
 type UpdateMultiBucketReplication struct {
 	Context *middleware.Context

--- a/restapi/operations/bucket/update_multi_bucket_replication_responses.go
+++ b/restapi/operations/bucket/update_multi_bucket_replication_responses.go
@@ -33,7 +33,8 @@ import (
 // UpdateMultiBucketReplicationCreatedCode is the HTTP code returned for type UpdateMultiBucketReplicationCreated
 const UpdateMultiBucketReplicationCreatedCode int = 201
 
-/*UpdateMultiBucketReplicationCreated A successful response.
+/*
+UpdateMultiBucketReplicationCreated A successful response.
 
 swagger:response updateMultiBucketReplicationCreated
 */
@@ -54,7 +55,8 @@ func (o *UpdateMultiBucketReplicationCreated) WriteResponse(rw http.ResponseWrit
 	rw.WriteHeader(201)
 }
 
-/*UpdateMultiBucketReplicationDefault Generic error response.
+/*
+UpdateMultiBucketReplicationDefault Generic error response.
 
 swagger:response updateMultiBucketReplicationDefault
 */

--- a/restapi/operations/configuration/add_notification_endpoint.go
+++ b/restapi/operations/configuration/add_notification_endpoint.go
@@ -48,10 +48,10 @@ func NewAddNotificationEndpoint(ctx *middleware.Context, handler AddNotification
 	return &AddNotificationEndpoint{Context: ctx, Handler: handler}
 }
 
-/* AddNotificationEndpoint swagger:route POST /admin/notification_endpoints Configuration addNotificationEndpoint
+/*
+	AddNotificationEndpoint swagger:route POST /admin/notification_endpoints Configuration addNotificationEndpoint
 
 Allows to configure a new notification endpoint
-
 */
 type AddNotificationEndpoint struct {
 	Context *middleware.Context

--- a/restapi/operations/configuration/add_notification_endpoint_responses.go
+++ b/restapi/operations/configuration/add_notification_endpoint_responses.go
@@ -33,7 +33,8 @@ import (
 // AddNotificationEndpointCreatedCode is the HTTP code returned for type AddNotificationEndpointCreated
 const AddNotificationEndpointCreatedCode int = 201
 
-/*AddNotificationEndpointCreated A successful response.
+/*
+AddNotificationEndpointCreated A successful response.
 
 swagger:response addNotificationEndpointCreated
 */
@@ -74,7 +75,8 @@ func (o *AddNotificationEndpointCreated) WriteResponse(rw http.ResponseWriter, p
 	}
 }
 
-/*AddNotificationEndpointDefault Generic error response.
+/*
+AddNotificationEndpointDefault Generic error response.
 
 swagger:response addNotificationEndpointDefault
 */

--- a/restapi/operations/configuration/config_info.go
+++ b/restapi/operations/configuration/config_info.go
@@ -48,10 +48,10 @@ func NewConfigInfo(ctx *middleware.Context, handler ConfigInfoHandler) *ConfigIn
 	return &ConfigInfo{Context: ctx, Handler: handler}
 }
 
-/* ConfigInfo swagger:route GET /configs/{name} Configuration configInfo
+/*
+	ConfigInfo swagger:route GET /configs/{name} Configuration configInfo
 
 Configuration info
-
 */
 type ConfigInfo struct {
 	Context *middleware.Context

--- a/restapi/operations/configuration/config_info_responses.go
+++ b/restapi/operations/configuration/config_info_responses.go
@@ -33,7 +33,8 @@ import (
 // ConfigInfoOKCode is the HTTP code returned for type ConfigInfoOK
 const ConfigInfoOKCode int = 200
 
-/*ConfigInfoOK A successful response.
+/*
+ConfigInfoOK A successful response.
 
 swagger:response configInfoOK
 */
@@ -74,7 +75,8 @@ func (o *ConfigInfoOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 	}
 }
 
-/*ConfigInfoDefault Generic error response.
+/*
+ConfigInfoDefault Generic error response.
 
 swagger:response configInfoDefault
 */

--- a/restapi/operations/configuration/list_config.go
+++ b/restapi/operations/configuration/list_config.go
@@ -48,10 +48,10 @@ func NewListConfig(ctx *middleware.Context, handler ListConfigHandler) *ListConf
 	return &ListConfig{Context: ctx, Handler: handler}
 }
 
-/* ListConfig swagger:route GET /configs Configuration listConfig
+/*
+	ListConfig swagger:route GET /configs Configuration listConfig
 
 List Configurations
-
 */
 type ListConfig struct {
 	Context *middleware.Context

--- a/restapi/operations/configuration/list_config_responses.go
+++ b/restapi/operations/configuration/list_config_responses.go
@@ -33,7 +33,8 @@ import (
 // ListConfigOKCode is the HTTP code returned for type ListConfigOK
 const ListConfigOKCode int = 200
 
-/*ListConfigOK A successful response.
+/*
+ListConfigOK A successful response.
 
 swagger:response listConfigOK
 */
@@ -74,7 +75,8 @@ func (o *ListConfigOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 	}
 }
 
-/*ListConfigDefault Generic error response.
+/*
+ListConfigDefault Generic error response.
 
 swagger:response listConfigDefault
 */

--- a/restapi/operations/configuration/notification_endpoint_list.go
+++ b/restapi/operations/configuration/notification_endpoint_list.go
@@ -48,10 +48,10 @@ func NewNotificationEndpointList(ctx *middleware.Context, handler NotificationEn
 	return &NotificationEndpointList{Context: ctx, Handler: handler}
 }
 
-/* NotificationEndpointList swagger:route GET /admin/notification_endpoints Configuration notificationEndpointList
+/*
+	NotificationEndpointList swagger:route GET /admin/notification_endpoints Configuration notificationEndpointList
 
 Returns a list of active notification endpoints
-
 */
 type NotificationEndpointList struct {
 	Context *middleware.Context

--- a/restapi/operations/configuration/notification_endpoint_list_responses.go
+++ b/restapi/operations/configuration/notification_endpoint_list_responses.go
@@ -33,7 +33,8 @@ import (
 // NotificationEndpointListOKCode is the HTTP code returned for type NotificationEndpointListOK
 const NotificationEndpointListOKCode int = 200
 
-/*NotificationEndpointListOK A successful response.
+/*
+NotificationEndpointListOK A successful response.
 
 swagger:response notificationEndpointListOK
 */
@@ -74,7 +75,8 @@ func (o *NotificationEndpointListOK) WriteResponse(rw http.ResponseWriter, produ
 	}
 }
 
-/*NotificationEndpointListDefault Generic error response.
+/*
+NotificationEndpointListDefault Generic error response.
 
 swagger:response notificationEndpointListDefault
 */

--- a/restapi/operations/configuration/reset_config.go
+++ b/restapi/operations/configuration/reset_config.go
@@ -48,10 +48,10 @@ func NewResetConfig(ctx *middleware.Context, handler ResetConfigHandler) *ResetC
 	return &ResetConfig{Context: ctx, Handler: handler}
 }
 
-/* ResetConfig swagger:route POST /configs/{name}/reset Configuration resetConfig
+/*
+	ResetConfig swagger:route POST /configs/{name}/reset Configuration resetConfig
 
 Configuration reset
-
 */
 type ResetConfig struct {
 	Context *middleware.Context

--- a/restapi/operations/configuration/reset_config_responses.go
+++ b/restapi/operations/configuration/reset_config_responses.go
@@ -33,7 +33,8 @@ import (
 // ResetConfigOKCode is the HTTP code returned for type ResetConfigOK
 const ResetConfigOKCode int = 200
 
-/*ResetConfigOK A successful response.
+/*
+ResetConfigOK A successful response.
 
 swagger:response resetConfigOK
 */
@@ -74,7 +75,8 @@ func (o *ResetConfigOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 }
 
-/*ResetConfigDefault Generic error response.
+/*
+ResetConfigDefault Generic error response.
 
 swagger:response resetConfigDefault
 */

--- a/restapi/operations/configuration/set_config.go
+++ b/restapi/operations/configuration/set_config.go
@@ -48,10 +48,10 @@ func NewSetConfig(ctx *middleware.Context, handler SetConfigHandler) *SetConfig 
 	return &SetConfig{Context: ctx, Handler: handler}
 }
 
-/* SetConfig swagger:route PUT /configs/{name} Configuration setConfig
+/*
+	SetConfig swagger:route PUT /configs/{name} Configuration setConfig
 
 Set Configuration
-
 */
 type SetConfig struct {
 	Context *middleware.Context

--- a/restapi/operations/configuration/set_config_responses.go
+++ b/restapi/operations/configuration/set_config_responses.go
@@ -33,7 +33,8 @@ import (
 // SetConfigOKCode is the HTTP code returned for type SetConfigOK
 const SetConfigOKCode int = 200
 
-/*SetConfigOK A successful response.
+/*
+SetConfigOK A successful response.
 
 swagger:response setConfigOK
 */
@@ -74,7 +75,8 @@ func (o *SetConfigOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 	}
 }
 
-/*SetConfigDefault Generic error response.
+/*
+SetConfigDefault Generic error response.
 
 swagger:response setConfigDefault
 */

--- a/restapi/operations/group/add_group.go
+++ b/restapi/operations/group/add_group.go
@@ -48,10 +48,10 @@ func NewAddGroup(ctx *middleware.Context, handler AddGroupHandler) *AddGroup {
 	return &AddGroup{Context: ctx, Handler: handler}
 }
 
-/* AddGroup swagger:route POST /groups Group addGroup
+/*
+	AddGroup swagger:route POST /groups Group addGroup
 
 Add Group
-
 */
 type AddGroup struct {
 	Context *middleware.Context

--- a/restapi/operations/group/add_group_responses.go
+++ b/restapi/operations/group/add_group_responses.go
@@ -33,7 +33,8 @@ import (
 // AddGroupCreatedCode is the HTTP code returned for type AddGroupCreated
 const AddGroupCreatedCode int = 201
 
-/*AddGroupCreated A successful response.
+/*
+AddGroupCreated A successful response.
 
 swagger:response addGroupCreated
 */
@@ -54,7 +55,8 @@ func (o *AddGroupCreated) WriteResponse(rw http.ResponseWriter, producer runtime
 	rw.WriteHeader(201)
 }
 
-/*AddGroupDefault Generic error response.
+/*
+AddGroupDefault Generic error response.
 
 swagger:response addGroupDefault
 */

--- a/restapi/operations/group/group_info.go
+++ b/restapi/operations/group/group_info.go
@@ -48,10 +48,10 @@ func NewGroupInfo(ctx *middleware.Context, handler GroupInfoHandler) *GroupInfo 
 	return &GroupInfo{Context: ctx, Handler: handler}
 }
 
-/* GroupInfo swagger:route GET /group/{name} Group groupInfo
+/*
+	GroupInfo swagger:route GET /group/{name} Group groupInfo
 
 Group info
-
 */
 type GroupInfo struct {
 	Context *middleware.Context

--- a/restapi/operations/group/group_info_responses.go
+++ b/restapi/operations/group/group_info_responses.go
@@ -33,7 +33,8 @@ import (
 // GroupInfoOKCode is the HTTP code returned for type GroupInfoOK
 const GroupInfoOKCode int = 200
 
-/*GroupInfoOK A successful response.
+/*
+GroupInfoOK A successful response.
 
 swagger:response groupInfoOK
 */
@@ -74,7 +75,8 @@ func (o *GroupInfoOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 	}
 }
 
-/*GroupInfoDefault Generic error response.
+/*
+GroupInfoDefault Generic error response.
 
 swagger:response groupInfoDefault
 */

--- a/restapi/operations/group/list_groups.go
+++ b/restapi/operations/group/list_groups.go
@@ -48,10 +48,10 @@ func NewListGroups(ctx *middleware.Context, handler ListGroupsHandler) *ListGrou
 	return &ListGroups{Context: ctx, Handler: handler}
 }
 
-/* ListGroups swagger:route GET /groups Group listGroups
+/*
+	ListGroups swagger:route GET /groups Group listGroups
 
 List Groups
-
 */
 type ListGroups struct {
 	Context *middleware.Context

--- a/restapi/operations/group/list_groups_responses.go
+++ b/restapi/operations/group/list_groups_responses.go
@@ -33,7 +33,8 @@ import (
 // ListGroupsOKCode is the HTTP code returned for type ListGroupsOK
 const ListGroupsOKCode int = 200
 
-/*ListGroupsOK A successful response.
+/*
+ListGroupsOK A successful response.
 
 swagger:response listGroupsOK
 */
@@ -74,7 +75,8 @@ func (o *ListGroupsOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 	}
 }
 
-/*ListGroupsDefault Generic error response.
+/*
+ListGroupsDefault Generic error response.
 
 swagger:response listGroupsDefault
 */

--- a/restapi/operations/group/remove_group.go
+++ b/restapi/operations/group/remove_group.go
@@ -48,10 +48,10 @@ func NewRemoveGroup(ctx *middleware.Context, handler RemoveGroupHandler) *Remove
 	return &RemoveGroup{Context: ctx, Handler: handler}
 }
 
-/* RemoveGroup swagger:route DELETE /group/{name} Group removeGroup
+/*
+	RemoveGroup swagger:route DELETE /group/{name} Group removeGroup
 
 Remove group
-
 */
 type RemoveGroup struct {
 	Context *middleware.Context

--- a/restapi/operations/group/remove_group_responses.go
+++ b/restapi/operations/group/remove_group_responses.go
@@ -33,7 +33,8 @@ import (
 // RemoveGroupNoContentCode is the HTTP code returned for type RemoveGroupNoContent
 const RemoveGroupNoContentCode int = 204
 
-/*RemoveGroupNoContent A successful response.
+/*
+RemoveGroupNoContent A successful response.
 
 swagger:response removeGroupNoContent
 */
@@ -54,7 +55,8 @@ func (o *RemoveGroupNoContent) WriteResponse(rw http.ResponseWriter, producer ru
 	rw.WriteHeader(204)
 }
 
-/*RemoveGroupDefault Generic error response.
+/*
+RemoveGroupDefault Generic error response.
 
 swagger:response removeGroupDefault
 */

--- a/restapi/operations/group/update_group.go
+++ b/restapi/operations/group/update_group.go
@@ -48,10 +48,10 @@ func NewUpdateGroup(ctx *middleware.Context, handler UpdateGroupHandler) *Update
 	return &UpdateGroup{Context: ctx, Handler: handler}
 }
 
-/* UpdateGroup swagger:route PUT /group/{name} Group updateGroup
+/*
+	UpdateGroup swagger:route PUT /group/{name} Group updateGroup
 
 Update Group Members or Status
-
 */
 type UpdateGroup struct {
 	Context *middleware.Context

--- a/restapi/operations/group/update_group_responses.go
+++ b/restapi/operations/group/update_group_responses.go
@@ -33,7 +33,8 @@ import (
 // UpdateGroupOKCode is the HTTP code returned for type UpdateGroupOK
 const UpdateGroupOKCode int = 200
 
-/*UpdateGroupOK A successful response.
+/*
+UpdateGroupOK A successful response.
 
 swagger:response updateGroupOK
 */
@@ -74,7 +75,8 @@ func (o *UpdateGroupOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 }
 
-/*UpdateGroupDefault Generic error response.
+/*
+UpdateGroupDefault Generic error response.
 
 swagger:response updateGroupDefault
 */

--- a/restapi/operations/inspect/inspect.go
+++ b/restapi/operations/inspect/inspect.go
@@ -48,10 +48,10 @@ func NewInspect(ctx *middleware.Context, handler InspectHandler) *Inspect {
 	return &Inspect{Context: ctx, Handler: handler}
 }
 
-/* Inspect swagger:route GET /admin/inspect Inspect inspect
+/*
+	Inspect swagger:route GET /admin/inspect Inspect inspect
 
 Inspect Files on Drive
-
 */
 type Inspect struct {
 	Context *middleware.Context

--- a/restapi/operations/inspect/inspect_responses.go
+++ b/restapi/operations/inspect/inspect_responses.go
@@ -34,7 +34,8 @@ import (
 // InspectOKCode is the HTTP code returned for type InspectOK
 const InspectOKCode int = 200
 
-/*InspectOK A successful response.
+/*
+InspectOK A successful response.
 
 swagger:response inspectOK
 */
@@ -73,7 +74,8 @@ func (o *InspectOK) WriteResponse(rw http.ResponseWriter, producer runtime.Produ
 	}
 }
 
-/*InspectDefault Generic error response.
+/*
+InspectDefault Generic error response.
 
 swagger:response inspectDefault
 */

--- a/restapi/operations/logging/log_search.go
+++ b/restapi/operations/logging/log_search.go
@@ -48,10 +48,10 @@ func NewLogSearch(ctx *middleware.Context, handler LogSearchHandler) *LogSearch 
 	return &LogSearch{Context: ctx, Handler: handler}
 }
 
-/* LogSearch swagger:route GET /logs/search Logging logSearch
+/*
+	LogSearch swagger:route GET /logs/search Logging logSearch
 
 Search the logs
-
 */
 type LogSearch struct {
 	Context *middleware.Context

--- a/restapi/operations/logging/log_search_responses.go
+++ b/restapi/operations/logging/log_search_responses.go
@@ -33,7 +33,8 @@ import (
 // LogSearchOKCode is the HTTP code returned for type LogSearchOK
 const LogSearchOKCode int = 200
 
-/*LogSearchOK A successful response.
+/*
+LogSearchOK A successful response.
 
 swagger:response logSearchOK
 */
@@ -74,7 +75,8 @@ func (o *LogSearchOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 	}
 }
 
-/*LogSearchDefault Generic error response.
+/*
+LogSearchDefault Generic error response.
 
 swagger:response logSearchDefault
 */

--- a/restapi/operations/object/delete_multiple_objects.go
+++ b/restapi/operations/object/delete_multiple_objects.go
@@ -48,10 +48,10 @@ func NewDeleteMultipleObjects(ctx *middleware.Context, handler DeleteMultipleObj
 	return &DeleteMultipleObjects{Context: ctx, Handler: handler}
 }
 
-/* DeleteMultipleObjects swagger:route POST /buckets/{bucket_name}/delete-objects Object deleteMultipleObjects
+/*
+	DeleteMultipleObjects swagger:route POST /buckets/{bucket_name}/delete-objects Object deleteMultipleObjects
 
 Delete Multiple Objects
-
 */
 type DeleteMultipleObjects struct {
 	Context *middleware.Context

--- a/restapi/operations/object/delete_multiple_objects_responses.go
+++ b/restapi/operations/object/delete_multiple_objects_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteMultipleObjectsOKCode is the HTTP code returned for type DeleteMultipleObjectsOK
 const DeleteMultipleObjectsOKCode int = 200
 
-/*DeleteMultipleObjectsOK A successful response.
+/*
+DeleteMultipleObjectsOK A successful response.
 
 swagger:response deleteMultipleObjectsOK
 */
@@ -54,7 +55,8 @@ func (o *DeleteMultipleObjectsOK) WriteResponse(rw http.ResponseWriter, producer
 	rw.WriteHeader(200)
 }
 
-/*DeleteMultipleObjectsDefault Generic error response.
+/*
+DeleteMultipleObjectsDefault Generic error response.
 
 swagger:response deleteMultipleObjectsDefault
 */

--- a/restapi/operations/object/delete_object.go
+++ b/restapi/operations/object/delete_object.go
@@ -48,10 +48,10 @@ func NewDeleteObject(ctx *middleware.Context, handler DeleteObjectHandler) *Dele
 	return &DeleteObject{Context: ctx, Handler: handler}
 }
 
-/* DeleteObject swagger:route DELETE /buckets/{bucket_name}/objects Object deleteObject
+/*
+	DeleteObject swagger:route DELETE /buckets/{bucket_name}/objects Object deleteObject
 
 Delete Object
-
 */
 type DeleteObject struct {
 	Context *middleware.Context

--- a/restapi/operations/object/delete_object_responses.go
+++ b/restapi/operations/object/delete_object_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteObjectOKCode is the HTTP code returned for type DeleteObjectOK
 const DeleteObjectOKCode int = 200
 
-/*DeleteObjectOK A successful response.
+/*
+DeleteObjectOK A successful response.
 
 swagger:response deleteObjectOK
 */
@@ -54,7 +55,8 @@ func (o *DeleteObjectOK) WriteResponse(rw http.ResponseWriter, producer runtime.
 	rw.WriteHeader(200)
 }
 
-/*DeleteObjectDefault Generic error response.
+/*
+DeleteObjectDefault Generic error response.
 
 swagger:response deleteObjectDefault
 */

--- a/restapi/operations/object/delete_object_retention.go
+++ b/restapi/operations/object/delete_object_retention.go
@@ -48,10 +48,10 @@ func NewDeleteObjectRetention(ctx *middleware.Context, handler DeleteObjectReten
 	return &DeleteObjectRetention{Context: ctx, Handler: handler}
 }
 
-/* DeleteObjectRetention swagger:route DELETE /buckets/{bucket_name}/objects/retention Object deleteObjectRetention
+/*
+	DeleteObjectRetention swagger:route DELETE /buckets/{bucket_name}/objects/retention Object deleteObjectRetention
 
 Delete Object retention from an object
-
 */
 type DeleteObjectRetention struct {
 	Context *middleware.Context

--- a/restapi/operations/object/delete_object_retention_responses.go
+++ b/restapi/operations/object/delete_object_retention_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteObjectRetentionOKCode is the HTTP code returned for type DeleteObjectRetentionOK
 const DeleteObjectRetentionOKCode int = 200
 
-/*DeleteObjectRetentionOK A successful response.
+/*
+DeleteObjectRetentionOK A successful response.
 
 swagger:response deleteObjectRetentionOK
 */
@@ -54,7 +55,8 @@ func (o *DeleteObjectRetentionOK) WriteResponse(rw http.ResponseWriter, producer
 	rw.WriteHeader(200)
 }
 
-/*DeleteObjectRetentionDefault Generic error response.
+/*
+DeleteObjectRetentionDefault Generic error response.
 
 swagger:response deleteObjectRetentionDefault
 */

--- a/restapi/operations/object/download_object.go
+++ b/restapi/operations/object/download_object.go
@@ -48,10 +48,10 @@ func NewDownloadObject(ctx *middleware.Context, handler DownloadObjectHandler) *
 	return &DownloadObject{Context: ctx, Handler: handler}
 }
 
-/* DownloadObject swagger:route GET /buckets/{bucket_name}/objects/download Object downloadObject
+/*
+	DownloadObject swagger:route GET /buckets/{bucket_name}/objects/download Object downloadObject
 
 Download Object
-
 */
 type DownloadObject struct {
 	Context *middleware.Context

--- a/restapi/operations/object/download_object_responses.go
+++ b/restapi/operations/object/download_object_responses.go
@@ -34,7 +34,8 @@ import (
 // DownloadObjectOKCode is the HTTP code returned for type DownloadObjectOK
 const DownloadObjectOKCode int = 200
 
-/*DownloadObjectOK A successful response.
+/*
+DownloadObjectOK A successful response.
 
 swagger:response downloadObjectOK
 */
@@ -73,7 +74,8 @@ func (o *DownloadObjectOK) WriteResponse(rw http.ResponseWriter, producer runtim
 	}
 }
 
-/*DownloadObjectDefault Generic error response.
+/*
+DownloadObjectDefault Generic error response.
 
 swagger:response downloadObjectDefault
 */

--- a/restapi/operations/object/get_object_metadata.go
+++ b/restapi/operations/object/get_object_metadata.go
@@ -48,10 +48,10 @@ func NewGetObjectMetadata(ctx *middleware.Context, handler GetObjectMetadataHand
 	return &GetObjectMetadata{Context: ctx, Handler: handler}
 }
 
-/* GetObjectMetadata swagger:route GET /buckets/{bucket_name}/objects/metadata Object getObjectMetadata
+/*
+	GetObjectMetadata swagger:route GET /buckets/{bucket_name}/objects/metadata Object getObjectMetadata
 
 Gets the metadata of an object
-
 */
 type GetObjectMetadata struct {
 	Context *middleware.Context

--- a/restapi/operations/object/get_object_metadata_responses.go
+++ b/restapi/operations/object/get_object_metadata_responses.go
@@ -33,7 +33,8 @@ import (
 // GetObjectMetadataOKCode is the HTTP code returned for type GetObjectMetadataOK
 const GetObjectMetadataOKCode int = 200
 
-/*GetObjectMetadataOK A successful response.
+/*
+GetObjectMetadataOK A successful response.
 
 swagger:response getObjectMetadataOK
 */
@@ -74,7 +75,8 @@ func (o *GetObjectMetadataOK) WriteResponse(rw http.ResponseWriter, producer run
 	}
 }
 
-/*GetObjectMetadataDefault Generic error response.
+/*
+GetObjectMetadataDefault Generic error response.
 
 swagger:response getObjectMetadataDefault
 */

--- a/restapi/operations/object/list_objects.go
+++ b/restapi/operations/object/list_objects.go
@@ -48,10 +48,10 @@ func NewListObjects(ctx *middleware.Context, handler ListObjectsHandler) *ListOb
 	return &ListObjects{Context: ctx, Handler: handler}
 }
 
-/* ListObjects swagger:route GET /buckets/{bucket_name}/objects Object listObjects
+/*
+	ListObjects swagger:route GET /buckets/{bucket_name}/objects Object listObjects
 
 List Objects
-
 */
 type ListObjects struct {
 	Context *middleware.Context

--- a/restapi/operations/object/list_objects_responses.go
+++ b/restapi/operations/object/list_objects_responses.go
@@ -33,7 +33,8 @@ import (
 // ListObjectsOKCode is the HTTP code returned for type ListObjectsOK
 const ListObjectsOKCode int = 200
 
-/*ListObjectsOK A successful response.
+/*
+ListObjectsOK A successful response.
 
 swagger:response listObjectsOK
 */
@@ -74,7 +75,8 @@ func (o *ListObjectsOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 }
 
-/*ListObjectsDefault Generic error response.
+/*
+ListObjectsDefault Generic error response.
 
 swagger:response listObjectsDefault
 */

--- a/restapi/operations/object/post_buckets_bucket_name_objects_upload.go
+++ b/restapi/operations/object/post_buckets_bucket_name_objects_upload.go
@@ -48,10 +48,10 @@ func NewPostBucketsBucketNameObjectsUpload(ctx *middleware.Context, handler Post
 	return &PostBucketsBucketNameObjectsUpload{Context: ctx, Handler: handler}
 }
 
-/* PostBucketsBucketNameObjectsUpload swagger:route POST /buckets/{bucket_name}/objects/upload Object postBucketsBucketNameObjectsUpload
+/*
+	PostBucketsBucketNameObjectsUpload swagger:route POST /buckets/{bucket_name}/objects/upload Object postBucketsBucketNameObjectsUpload
 
 Uploads an Object.
-
 */
 type PostBucketsBucketNameObjectsUpload struct {
 	Context *middleware.Context

--- a/restapi/operations/object/post_buckets_bucket_name_objects_upload_responses.go
+++ b/restapi/operations/object/post_buckets_bucket_name_objects_upload_responses.go
@@ -33,7 +33,8 @@ import (
 // PostBucketsBucketNameObjectsUploadOKCode is the HTTP code returned for type PostBucketsBucketNameObjectsUploadOK
 const PostBucketsBucketNameObjectsUploadOKCode int = 200
 
-/*PostBucketsBucketNameObjectsUploadOK A successful response.
+/*
+PostBucketsBucketNameObjectsUploadOK A successful response.
 
 swagger:response postBucketsBucketNameObjectsUploadOK
 */
@@ -54,7 +55,8 @@ func (o *PostBucketsBucketNameObjectsUploadOK) WriteResponse(rw http.ResponseWri
 	rw.WriteHeader(200)
 }
 
-/*PostBucketsBucketNameObjectsUploadDefault Generic error response.
+/*
+PostBucketsBucketNameObjectsUploadDefault Generic error response.
 
 swagger:response postBucketsBucketNameObjectsUploadDefault
 */

--- a/restapi/operations/object/put_object_legal_hold.go
+++ b/restapi/operations/object/put_object_legal_hold.go
@@ -48,10 +48,10 @@ func NewPutObjectLegalHold(ctx *middleware.Context, handler PutObjectLegalHoldHa
 	return &PutObjectLegalHold{Context: ctx, Handler: handler}
 }
 
-/* PutObjectLegalHold swagger:route PUT /buckets/{bucket_name}/objects/legalhold Object putObjectLegalHold
+/*
+	PutObjectLegalHold swagger:route PUT /buckets/{bucket_name}/objects/legalhold Object putObjectLegalHold
 
 Put Object's legalhold status
-
 */
 type PutObjectLegalHold struct {
 	Context *middleware.Context

--- a/restapi/operations/object/put_object_legal_hold_responses.go
+++ b/restapi/operations/object/put_object_legal_hold_responses.go
@@ -33,7 +33,8 @@ import (
 // PutObjectLegalHoldOKCode is the HTTP code returned for type PutObjectLegalHoldOK
 const PutObjectLegalHoldOKCode int = 200
 
-/*PutObjectLegalHoldOK A successful response.
+/*
+PutObjectLegalHoldOK A successful response.
 
 swagger:response putObjectLegalHoldOK
 */
@@ -54,7 +55,8 @@ func (o *PutObjectLegalHoldOK) WriteResponse(rw http.ResponseWriter, producer ru
 	rw.WriteHeader(200)
 }
 
-/*PutObjectLegalHoldDefault Generic error response.
+/*
+PutObjectLegalHoldDefault Generic error response.
 
 swagger:response putObjectLegalHoldDefault
 */

--- a/restapi/operations/object/put_object_restore.go
+++ b/restapi/operations/object/put_object_restore.go
@@ -48,10 +48,10 @@ func NewPutObjectRestore(ctx *middleware.Context, handler PutObjectRestoreHandle
 	return &PutObjectRestore{Context: ctx, Handler: handler}
 }
 
-/* PutObjectRestore swagger:route PUT /buckets/{bucket_name}/objects/restore Object putObjectRestore
+/*
+	PutObjectRestore swagger:route PUT /buckets/{bucket_name}/objects/restore Object putObjectRestore
 
 Restore Object to a selected version
-
 */
 type PutObjectRestore struct {
 	Context *middleware.Context

--- a/restapi/operations/object/put_object_restore_responses.go
+++ b/restapi/operations/object/put_object_restore_responses.go
@@ -33,7 +33,8 @@ import (
 // PutObjectRestoreOKCode is the HTTP code returned for type PutObjectRestoreOK
 const PutObjectRestoreOKCode int = 200
 
-/*PutObjectRestoreOK A successful response.
+/*
+PutObjectRestoreOK A successful response.
 
 swagger:response putObjectRestoreOK
 */
@@ -54,7 +55,8 @@ func (o *PutObjectRestoreOK) WriteResponse(rw http.ResponseWriter, producer runt
 	rw.WriteHeader(200)
 }
 
-/*PutObjectRestoreDefault Generic error response.
+/*
+PutObjectRestoreDefault Generic error response.
 
 swagger:response putObjectRestoreDefault
 */

--- a/restapi/operations/object/put_object_retention.go
+++ b/restapi/operations/object/put_object_retention.go
@@ -48,10 +48,10 @@ func NewPutObjectRetention(ctx *middleware.Context, handler PutObjectRetentionHa
 	return &PutObjectRetention{Context: ctx, Handler: handler}
 }
 
-/* PutObjectRetention swagger:route PUT /buckets/{bucket_name}/objects/retention Object putObjectRetention
+/*
+	PutObjectRetention swagger:route PUT /buckets/{bucket_name}/objects/retention Object putObjectRetention
 
 Put Object's retention status
-
 */
 type PutObjectRetention struct {
 	Context *middleware.Context

--- a/restapi/operations/object/put_object_retention_responses.go
+++ b/restapi/operations/object/put_object_retention_responses.go
@@ -33,7 +33,8 @@ import (
 // PutObjectRetentionOKCode is the HTTP code returned for type PutObjectRetentionOK
 const PutObjectRetentionOKCode int = 200
 
-/*PutObjectRetentionOK A successful response.
+/*
+PutObjectRetentionOK A successful response.
 
 swagger:response putObjectRetentionOK
 */
@@ -54,7 +55,8 @@ func (o *PutObjectRetentionOK) WriteResponse(rw http.ResponseWriter, producer ru
 	rw.WriteHeader(200)
 }
 
-/*PutObjectRetentionDefault Generic error response.
+/*
+PutObjectRetentionDefault Generic error response.
 
 swagger:response putObjectRetentionDefault
 */

--- a/restapi/operations/object/put_object_tags.go
+++ b/restapi/operations/object/put_object_tags.go
@@ -48,10 +48,10 @@ func NewPutObjectTags(ctx *middleware.Context, handler PutObjectTagsHandler) *Pu
 	return &PutObjectTags{Context: ctx, Handler: handler}
 }
 
-/* PutObjectTags swagger:route PUT /buckets/{bucket_name}/objects/tags Object putObjectTags
+/*
+	PutObjectTags swagger:route PUT /buckets/{bucket_name}/objects/tags Object putObjectTags
 
 Put Object's tags
-
 */
 type PutObjectTags struct {
 	Context *middleware.Context

--- a/restapi/operations/object/put_object_tags_responses.go
+++ b/restapi/operations/object/put_object_tags_responses.go
@@ -33,7 +33,8 @@ import (
 // PutObjectTagsOKCode is the HTTP code returned for type PutObjectTagsOK
 const PutObjectTagsOKCode int = 200
 
-/*PutObjectTagsOK A successful response.
+/*
+PutObjectTagsOK A successful response.
 
 swagger:response putObjectTagsOK
 */
@@ -54,7 +55,8 @@ func (o *PutObjectTagsOK) WriteResponse(rw http.ResponseWriter, producer runtime
 	rw.WriteHeader(200)
 }
 
-/*PutObjectTagsDefault Generic error response.
+/*
+PutObjectTagsDefault Generic error response.
 
 swagger:response putObjectTagsDefault
 */

--- a/restapi/operations/object/share_object.go
+++ b/restapi/operations/object/share_object.go
@@ -48,10 +48,10 @@ func NewShareObject(ctx *middleware.Context, handler ShareObjectHandler) *ShareO
 	return &ShareObject{Context: ctx, Handler: handler}
 }
 
-/* ShareObject swagger:route GET /buckets/{bucket_name}/objects/share Object shareObject
+/*
+	ShareObject swagger:route GET /buckets/{bucket_name}/objects/share Object shareObject
 
 Shares an Object on a url
-
 */
 type ShareObject struct {
 	Context *middleware.Context

--- a/restapi/operations/object/share_object_responses.go
+++ b/restapi/operations/object/share_object_responses.go
@@ -33,7 +33,8 @@ import (
 // ShareObjectOKCode is the HTTP code returned for type ShareObjectOK
 const ShareObjectOKCode int = 200
 
-/*ShareObjectOK A successful response.
+/*
+ShareObjectOK A successful response.
 
 swagger:response shareObjectOK
 */
@@ -72,7 +73,8 @@ func (o *ShareObjectOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 }
 
-/*ShareObjectDefault Generic error response.
+/*
+ShareObjectDefault Generic error response.
 
 swagger:response shareObjectDefault
 */

--- a/restapi/operations/policy/add_policy.go
+++ b/restapi/operations/policy/add_policy.go
@@ -48,10 +48,10 @@ func NewAddPolicy(ctx *middleware.Context, handler AddPolicyHandler) *AddPolicy 
 	return &AddPolicy{Context: ctx, Handler: handler}
 }
 
-/* AddPolicy swagger:route POST /policies Policy addPolicy
+/*
+	AddPolicy swagger:route POST /policies Policy addPolicy
 
 Add Policy
-
 */
 type AddPolicy struct {
 	Context *middleware.Context

--- a/restapi/operations/policy/add_policy_responses.go
+++ b/restapi/operations/policy/add_policy_responses.go
@@ -33,7 +33,8 @@ import (
 // AddPolicyCreatedCode is the HTTP code returned for type AddPolicyCreated
 const AddPolicyCreatedCode int = 201
 
-/*AddPolicyCreated A successful response.
+/*
+AddPolicyCreated A successful response.
 
 swagger:response addPolicyCreated
 */
@@ -74,7 +75,8 @@ func (o *AddPolicyCreated) WriteResponse(rw http.ResponseWriter, producer runtim
 	}
 }
 
-/*AddPolicyDefault Generic error response.
+/*
+AddPolicyDefault Generic error response.
 
 swagger:response addPolicyDefault
 */

--- a/restapi/operations/policy/get_s_a_user_policy.go
+++ b/restapi/operations/policy/get_s_a_user_policy.go
@@ -48,10 +48,10 @@ func NewGetSAUserPolicy(ctx *middleware.Context, handler GetSAUserPolicyHandler)
 	return &GetSAUserPolicy{Context: ctx, Handler: handler}
 }
 
-/* GetSAUserPolicy swagger:route GET /user/{name}/policies Policy getSAUserPolicy
+/*
+	GetSAUserPolicy swagger:route GET /user/{name}/policies Policy getSAUserPolicy
 
 returns policies assigned for a specified user
-
 */
 type GetSAUserPolicy struct {
 	Context *middleware.Context

--- a/restapi/operations/policy/get_s_a_user_policy_responses.go
+++ b/restapi/operations/policy/get_s_a_user_policy_responses.go
@@ -33,7 +33,8 @@ import (
 // GetSAUserPolicyOKCode is the HTTP code returned for type GetSAUserPolicyOK
 const GetSAUserPolicyOKCode int = 200
 
-/*GetSAUserPolicyOK A successful response.
+/*
+GetSAUserPolicyOK A successful response.
 
 swagger:response getSAUserPolicyOK
 */
@@ -74,7 +75,8 @@ func (o *GetSAUserPolicyOK) WriteResponse(rw http.ResponseWriter, producer runti
 	}
 }
 
-/*GetSAUserPolicyDefault Generic error response.
+/*
+GetSAUserPolicyDefault Generic error response.
 
 swagger:response getSAUserPolicyDefault
 */

--- a/restapi/operations/policy/get_user_policy.go
+++ b/restapi/operations/policy/get_user_policy.go
@@ -48,10 +48,10 @@ func NewGetUserPolicy(ctx *middleware.Context, handler GetUserPolicyHandler) *Ge
 	return &GetUserPolicy{Context: ctx, Handler: handler}
 }
 
-/* GetUserPolicy swagger:route GET /user/policy Policy getUserPolicy
+/*
+	GetUserPolicy swagger:route GET /user/policy Policy getUserPolicy
 
 returns policies for logged in user
-
 */
 type GetUserPolicy struct {
 	Context *middleware.Context

--- a/restapi/operations/policy/get_user_policy_responses.go
+++ b/restapi/operations/policy/get_user_policy_responses.go
@@ -33,7 +33,8 @@ import (
 // GetUserPolicyOKCode is the HTTP code returned for type GetUserPolicyOK
 const GetUserPolicyOKCode int = 200
 
-/*GetUserPolicyOK A successful response.
+/*
+GetUserPolicyOK A successful response.
 
 swagger:response getUserPolicyOK
 */
@@ -72,7 +73,8 @@ func (o *GetUserPolicyOK) WriteResponse(rw http.ResponseWriter, producer runtime
 	}
 }
 
-/*GetUserPolicyDefault Generic error response.
+/*
+GetUserPolicyDefault Generic error response.
 
 swagger:response getUserPolicyDefault
 */

--- a/restapi/operations/policy/list_groups_for_policy.go
+++ b/restapi/operations/policy/list_groups_for_policy.go
@@ -48,10 +48,10 @@ func NewListGroupsForPolicy(ctx *middleware.Context, handler ListGroupsForPolicy
 	return &ListGroupsForPolicy{Context: ctx, Handler: handler}
 }
 
-/* ListGroupsForPolicy swagger:route GET /policies/{policy}/groups Policy listGroupsForPolicy
+/*
+	ListGroupsForPolicy swagger:route GET /policies/{policy}/groups Policy listGroupsForPolicy
 
 List Groups for a Policy
-
 */
 type ListGroupsForPolicy struct {
 	Context *middleware.Context

--- a/restapi/operations/policy/list_groups_for_policy_responses.go
+++ b/restapi/operations/policy/list_groups_for_policy_responses.go
@@ -33,7 +33,8 @@ import (
 // ListGroupsForPolicyOKCode is the HTTP code returned for type ListGroupsForPolicyOK
 const ListGroupsForPolicyOKCode int = 200
 
-/*ListGroupsForPolicyOK A successful response.
+/*
+ListGroupsForPolicyOK A successful response.
 
 swagger:response listGroupsForPolicyOK
 */
@@ -77,7 +78,8 @@ func (o *ListGroupsForPolicyOK) WriteResponse(rw http.ResponseWriter, producer r
 	}
 }
 
-/*ListGroupsForPolicyDefault Generic error response.
+/*
+ListGroupsForPolicyDefault Generic error response.
 
 swagger:response listGroupsForPolicyDefault
 */

--- a/restapi/operations/policy/list_policies.go
+++ b/restapi/operations/policy/list_policies.go
@@ -48,10 +48,10 @@ func NewListPolicies(ctx *middleware.Context, handler ListPoliciesHandler) *List
 	return &ListPolicies{Context: ctx, Handler: handler}
 }
 
-/* ListPolicies swagger:route GET /policies Policy listPolicies
+/*
+	ListPolicies swagger:route GET /policies Policy listPolicies
 
 List Policies
-
 */
 type ListPolicies struct {
 	Context *middleware.Context

--- a/restapi/operations/policy/list_policies_responses.go
+++ b/restapi/operations/policy/list_policies_responses.go
@@ -33,7 +33,8 @@ import (
 // ListPoliciesOKCode is the HTTP code returned for type ListPoliciesOK
 const ListPoliciesOKCode int = 200
 
-/*ListPoliciesOK A successful response.
+/*
+ListPoliciesOK A successful response.
 
 swagger:response listPoliciesOK
 */
@@ -74,7 +75,8 @@ func (o *ListPoliciesOK) WriteResponse(rw http.ResponseWriter, producer runtime.
 	}
 }
 
-/*ListPoliciesDefault Generic error response.
+/*
+ListPoliciesDefault Generic error response.
 
 swagger:response listPoliciesDefault
 */

--- a/restapi/operations/policy/list_users_for_policy.go
+++ b/restapi/operations/policy/list_users_for_policy.go
@@ -48,10 +48,10 @@ func NewListUsersForPolicy(ctx *middleware.Context, handler ListUsersForPolicyHa
 	return &ListUsersForPolicy{Context: ctx, Handler: handler}
 }
 
-/* ListUsersForPolicy swagger:route GET /policies/{policy}/users Policy listUsersForPolicy
+/*
+	ListUsersForPolicy swagger:route GET /policies/{policy}/users Policy listUsersForPolicy
 
 List Users for a Policy
-
 */
 type ListUsersForPolicy struct {
 	Context *middleware.Context

--- a/restapi/operations/policy/list_users_for_policy_responses.go
+++ b/restapi/operations/policy/list_users_for_policy_responses.go
@@ -33,7 +33,8 @@ import (
 // ListUsersForPolicyOKCode is the HTTP code returned for type ListUsersForPolicyOK
 const ListUsersForPolicyOKCode int = 200
 
-/*ListUsersForPolicyOK A successful response.
+/*
+ListUsersForPolicyOK A successful response.
 
 swagger:response listUsersForPolicyOK
 */
@@ -77,7 +78,8 @@ func (o *ListUsersForPolicyOK) WriteResponse(rw http.ResponseWriter, producer ru
 	}
 }
 
-/*ListUsersForPolicyDefault Generic error response.
+/*
+ListUsersForPolicyDefault Generic error response.
 
 swagger:response listUsersForPolicyDefault
 */

--- a/restapi/operations/policy/policy_info.go
+++ b/restapi/operations/policy/policy_info.go
@@ -48,10 +48,10 @@ func NewPolicyInfo(ctx *middleware.Context, handler PolicyInfoHandler) *PolicyIn
 	return &PolicyInfo{Context: ctx, Handler: handler}
 }
 
-/* PolicyInfo swagger:route GET /policy/{name} Policy policyInfo
+/*
+	PolicyInfo swagger:route GET /policy/{name} Policy policyInfo
 
 Policy info
-
 */
 type PolicyInfo struct {
 	Context *middleware.Context

--- a/restapi/operations/policy/policy_info_responses.go
+++ b/restapi/operations/policy/policy_info_responses.go
@@ -33,7 +33,8 @@ import (
 // PolicyInfoOKCode is the HTTP code returned for type PolicyInfoOK
 const PolicyInfoOKCode int = 200
 
-/*PolicyInfoOK A successful response.
+/*
+PolicyInfoOK A successful response.
 
 swagger:response policyInfoOK
 */
@@ -74,7 +75,8 @@ func (o *PolicyInfoOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 	}
 }
 
-/*PolicyInfoDefault Generic error response.
+/*
+PolicyInfoDefault Generic error response.
 
 swagger:response policyInfoDefault
 */

--- a/restapi/operations/policy/remove_policy.go
+++ b/restapi/operations/policy/remove_policy.go
@@ -48,10 +48,10 @@ func NewRemovePolicy(ctx *middleware.Context, handler RemovePolicyHandler) *Remo
 	return &RemovePolicy{Context: ctx, Handler: handler}
 }
 
-/* RemovePolicy swagger:route DELETE /policy/{name} Policy removePolicy
+/*
+	RemovePolicy swagger:route DELETE /policy/{name} Policy removePolicy
 
 Remove policy
-
 */
 type RemovePolicy struct {
 	Context *middleware.Context

--- a/restapi/operations/policy/remove_policy_responses.go
+++ b/restapi/operations/policy/remove_policy_responses.go
@@ -33,7 +33,8 @@ import (
 // RemovePolicyNoContentCode is the HTTP code returned for type RemovePolicyNoContent
 const RemovePolicyNoContentCode int = 204
 
-/*RemovePolicyNoContent A successful response.
+/*
+RemovePolicyNoContent A successful response.
 
 swagger:response removePolicyNoContent
 */
@@ -54,7 +55,8 @@ func (o *RemovePolicyNoContent) WriteResponse(rw http.ResponseWriter, producer r
 	rw.WriteHeader(204)
 }
 
-/*RemovePolicyDefault Generic error response.
+/*
+RemovePolicyDefault Generic error response.
 
 swagger:response removePolicyDefault
 */

--- a/restapi/operations/policy/set_policy.go
+++ b/restapi/operations/policy/set_policy.go
@@ -48,10 +48,10 @@ func NewSetPolicy(ctx *middleware.Context, handler SetPolicyHandler) *SetPolicy 
 	return &SetPolicy{Context: ctx, Handler: handler}
 }
 
-/* SetPolicy swagger:route PUT /set-policy Policy setPolicy
+/*
+	SetPolicy swagger:route PUT /set-policy Policy setPolicy
 
 Set policy
-
 */
 type SetPolicy struct {
 	Context *middleware.Context

--- a/restapi/operations/policy/set_policy_multiple.go
+++ b/restapi/operations/policy/set_policy_multiple.go
@@ -48,10 +48,10 @@ func NewSetPolicyMultiple(ctx *middleware.Context, handler SetPolicyMultipleHand
 	return &SetPolicyMultiple{Context: ctx, Handler: handler}
 }
 
-/* SetPolicyMultiple swagger:route PUT /set-policy-multi Policy setPolicyMultiple
+/*
+	SetPolicyMultiple swagger:route PUT /set-policy-multi Policy setPolicyMultiple
 
 Set policy to multiple users/groups
-
 */
 type SetPolicyMultiple struct {
 	Context *middleware.Context

--- a/restapi/operations/policy/set_policy_multiple_responses.go
+++ b/restapi/operations/policy/set_policy_multiple_responses.go
@@ -33,7 +33,8 @@ import (
 // SetPolicyMultipleNoContentCode is the HTTP code returned for type SetPolicyMultipleNoContent
 const SetPolicyMultipleNoContentCode int = 204
 
-/*SetPolicyMultipleNoContent A successful response.
+/*
+SetPolicyMultipleNoContent A successful response.
 
 swagger:response setPolicyMultipleNoContent
 */
@@ -54,7 +55,8 @@ func (o *SetPolicyMultipleNoContent) WriteResponse(rw http.ResponseWriter, produ
 	rw.WriteHeader(204)
 }
 
-/*SetPolicyMultipleDefault Generic error response.
+/*
+SetPolicyMultipleDefault Generic error response.
 
 swagger:response setPolicyMultipleDefault
 */

--- a/restapi/operations/policy/set_policy_responses.go
+++ b/restapi/operations/policy/set_policy_responses.go
@@ -33,7 +33,8 @@ import (
 // SetPolicyNoContentCode is the HTTP code returned for type SetPolicyNoContent
 const SetPolicyNoContentCode int = 204
 
-/*SetPolicyNoContent A successful response.
+/*
+SetPolicyNoContent A successful response.
 
 swagger:response setPolicyNoContent
 */
@@ -54,7 +55,8 @@ func (o *SetPolicyNoContent) WriteResponse(rw http.ResponseWriter, producer runt
 	rw.WriteHeader(204)
 }
 
-/*SetPolicyDefault Generic error response.
+/*
+SetPolicyDefault Generic error response.
 
 swagger:response setPolicyDefault
 */

--- a/restapi/operations/profile/profiling_start.go
+++ b/restapi/operations/profile/profiling_start.go
@@ -48,10 +48,10 @@ func NewProfilingStart(ctx *middleware.Context, handler ProfilingStartHandler) *
 	return &ProfilingStart{Context: ctx, Handler: handler}
 }
 
-/* ProfilingStart swagger:route POST /profiling/start Profile profilingStart
+/*
+	ProfilingStart swagger:route POST /profiling/start Profile profilingStart
 
 Start recording profile data
-
 */
 type ProfilingStart struct {
 	Context *middleware.Context

--- a/restapi/operations/profile/profiling_start_responses.go
+++ b/restapi/operations/profile/profiling_start_responses.go
@@ -33,7 +33,8 @@ import (
 // ProfilingStartCreatedCode is the HTTP code returned for type ProfilingStartCreated
 const ProfilingStartCreatedCode int = 201
 
-/*ProfilingStartCreated A successful response.
+/*
+ProfilingStartCreated A successful response.
 
 swagger:response profilingStartCreated
 */
@@ -74,7 +75,8 @@ func (o *ProfilingStartCreated) WriteResponse(rw http.ResponseWriter, producer r
 	}
 }
 
-/*ProfilingStartDefault Generic error response.
+/*
+ProfilingStartDefault Generic error response.
 
 swagger:response profilingStartDefault
 */

--- a/restapi/operations/profile/profiling_stop.go
+++ b/restapi/operations/profile/profiling_stop.go
@@ -48,10 +48,10 @@ func NewProfilingStop(ctx *middleware.Context, handler ProfilingStopHandler) *Pr
 	return &ProfilingStop{Context: ctx, Handler: handler}
 }
 
-/* ProfilingStop swagger:route POST /profiling/stop Profile profilingStop
+/*
+	ProfilingStop swagger:route POST /profiling/stop Profile profilingStop
 
 Stop and download profile data
-
 */
 type ProfilingStop struct {
 	Context *middleware.Context

--- a/restapi/operations/profile/profiling_stop_responses.go
+++ b/restapi/operations/profile/profiling_stop_responses.go
@@ -34,7 +34,8 @@ import (
 // ProfilingStopCreatedCode is the HTTP code returned for type ProfilingStopCreated
 const ProfilingStopCreatedCode int = 201
 
-/*ProfilingStopCreated A successful response.
+/*
+ProfilingStopCreated A successful response.
 
 swagger:response profilingStopCreated
 */
@@ -73,7 +74,8 @@ func (o *ProfilingStopCreated) WriteResponse(rw http.ResponseWriter, producer ru
 	}
 }
 
-/*ProfilingStopDefault Generic error response.
+/*
+ProfilingStopDefault Generic error response.
 
 swagger:response profilingStopDefault
 */

--- a/restapi/operations/service/restart_service.go
+++ b/restapi/operations/service/restart_service.go
@@ -48,10 +48,10 @@ func NewRestartService(ctx *middleware.Context, handler RestartServiceHandler) *
 	return &RestartService{Context: ctx, Handler: handler}
 }
 
-/* RestartService swagger:route POST /service/restart Service restartService
+/*
+	RestartService swagger:route POST /service/restart Service restartService
 
 Restart Service
-
 */
 type RestartService struct {
 	Context *middleware.Context

--- a/restapi/operations/service/restart_service_responses.go
+++ b/restapi/operations/service/restart_service_responses.go
@@ -33,7 +33,8 @@ import (
 // RestartServiceNoContentCode is the HTTP code returned for type RestartServiceNoContent
 const RestartServiceNoContentCode int = 204
 
-/*RestartServiceNoContent A successful response.
+/*
+RestartServiceNoContent A successful response.
 
 swagger:response restartServiceNoContent
 */
@@ -54,7 +55,8 @@ func (o *RestartServiceNoContent) WriteResponse(rw http.ResponseWriter, producer
 	rw.WriteHeader(204)
 }
 
-/*RestartServiceDefault Generic error response.
+/*
+RestartServiceDefault Generic error response.
 
 swagger:response restartServiceDefault
 */

--- a/restapi/operations/service_account/create_service_account.go
+++ b/restapi/operations/service_account/create_service_account.go
@@ -48,10 +48,10 @@ func NewCreateServiceAccount(ctx *middleware.Context, handler CreateServiceAccou
 	return &CreateServiceAccount{Context: ctx, Handler: handler}
 }
 
-/* CreateServiceAccount swagger:route POST /service-accounts ServiceAccount createServiceAccount
+/*
+	CreateServiceAccount swagger:route POST /service-accounts ServiceAccount createServiceAccount
 
 Create Service Account
-
 */
 type CreateServiceAccount struct {
 	Context *middleware.Context

--- a/restapi/operations/service_account/create_service_account_creds.go
+++ b/restapi/operations/service_account/create_service_account_creds.go
@@ -48,10 +48,10 @@ func NewCreateServiceAccountCreds(ctx *middleware.Context, handler CreateService
 	return &CreateServiceAccountCreds{Context: ctx, Handler: handler}
 }
 
-/* CreateServiceAccountCreds swagger:route POST /service-account-credentials ServiceAccount createServiceAccountCreds
+/*
+	CreateServiceAccountCreds swagger:route POST /service-account-credentials ServiceAccount createServiceAccountCreds
 
 Create Service Account With Credentials
-
 */
 type CreateServiceAccountCreds struct {
 	Context *middleware.Context

--- a/restapi/operations/service_account/create_service_account_creds_responses.go
+++ b/restapi/operations/service_account/create_service_account_creds_responses.go
@@ -33,7 +33,8 @@ import (
 // CreateServiceAccountCredsCreatedCode is the HTTP code returned for type CreateServiceAccountCredsCreated
 const CreateServiceAccountCredsCreatedCode int = 201
 
-/*CreateServiceAccountCredsCreated A successful response.
+/*
+CreateServiceAccountCredsCreated A successful response.
 
 swagger:response createServiceAccountCredsCreated
 */
@@ -74,7 +75,8 @@ func (o *CreateServiceAccountCredsCreated) WriteResponse(rw http.ResponseWriter,
 	}
 }
 
-/*CreateServiceAccountCredsDefault Generic error response.
+/*
+CreateServiceAccountCredsDefault Generic error response.
 
 swagger:response createServiceAccountCredsDefault
 */

--- a/restapi/operations/service_account/create_service_account_responses.go
+++ b/restapi/operations/service_account/create_service_account_responses.go
@@ -33,7 +33,8 @@ import (
 // CreateServiceAccountCreatedCode is the HTTP code returned for type CreateServiceAccountCreated
 const CreateServiceAccountCreatedCode int = 201
 
-/*CreateServiceAccountCreated A successful response.
+/*
+CreateServiceAccountCreated A successful response.
 
 swagger:response createServiceAccountCreated
 */
@@ -74,7 +75,8 @@ func (o *CreateServiceAccountCreated) WriteResponse(rw http.ResponseWriter, prod
 	}
 }
 
-/*CreateServiceAccountDefault Generic error response.
+/*
+CreateServiceAccountDefault Generic error response.
 
 swagger:response createServiceAccountDefault
 */

--- a/restapi/operations/service_account/delete_multiple_service_accounts.go
+++ b/restapi/operations/service_account/delete_multiple_service_accounts.go
@@ -48,10 +48,10 @@ func NewDeleteMultipleServiceAccounts(ctx *middleware.Context, handler DeleteMul
 	return &DeleteMultipleServiceAccounts{Context: ctx, Handler: handler}
 }
 
-/* DeleteMultipleServiceAccounts swagger:route DELETE /service-accounts/delete-multi ServiceAccount deleteMultipleServiceAccounts
+/*
+	DeleteMultipleServiceAccounts swagger:route DELETE /service-accounts/delete-multi ServiceAccount deleteMultipleServiceAccounts
 
 Delete Multiple Service Accounts
-
 */
 type DeleteMultipleServiceAccounts struct {
 	Context *middleware.Context

--- a/restapi/operations/service_account/delete_multiple_service_accounts_responses.go
+++ b/restapi/operations/service_account/delete_multiple_service_accounts_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteMultipleServiceAccountsNoContentCode is the HTTP code returned for type DeleteMultipleServiceAccountsNoContent
 const DeleteMultipleServiceAccountsNoContentCode int = 204
 
-/*DeleteMultipleServiceAccountsNoContent A successful response.
+/*
+DeleteMultipleServiceAccountsNoContent A successful response.
 
 swagger:response deleteMultipleServiceAccountsNoContent
 */
@@ -54,7 +55,8 @@ func (o *DeleteMultipleServiceAccountsNoContent) WriteResponse(rw http.ResponseW
 	rw.WriteHeader(204)
 }
 
-/*DeleteMultipleServiceAccountsDefault Generic error response.
+/*
+DeleteMultipleServiceAccountsDefault Generic error response.
 
 swagger:response deleteMultipleServiceAccountsDefault
 */

--- a/restapi/operations/service_account/delete_service_account.go
+++ b/restapi/operations/service_account/delete_service_account.go
@@ -48,10 +48,10 @@ func NewDeleteServiceAccount(ctx *middleware.Context, handler DeleteServiceAccou
 	return &DeleteServiceAccount{Context: ctx, Handler: handler}
 }
 
-/* DeleteServiceAccount swagger:route DELETE /service-accounts/{access_key} ServiceAccount deleteServiceAccount
+/*
+	DeleteServiceAccount swagger:route DELETE /service-accounts/{access_key} ServiceAccount deleteServiceAccount
 
 Delete Service Account
-
 */
 type DeleteServiceAccount struct {
 	Context *middleware.Context

--- a/restapi/operations/service_account/delete_service_account_responses.go
+++ b/restapi/operations/service_account/delete_service_account_responses.go
@@ -33,7 +33,8 @@ import (
 // DeleteServiceAccountNoContentCode is the HTTP code returned for type DeleteServiceAccountNoContent
 const DeleteServiceAccountNoContentCode int = 204
 
-/*DeleteServiceAccountNoContent A successful response.
+/*
+DeleteServiceAccountNoContent A successful response.
 
 swagger:response deleteServiceAccountNoContent
 */
@@ -54,7 +55,8 @@ func (o *DeleteServiceAccountNoContent) WriteResponse(rw http.ResponseWriter, pr
 	rw.WriteHeader(204)
 }
 
-/*DeleteServiceAccountDefault Generic error response.
+/*
+DeleteServiceAccountDefault Generic error response.
 
 swagger:response deleteServiceAccountDefault
 */

--- a/restapi/operations/service_account/get_service_account_policy.go
+++ b/restapi/operations/service_account/get_service_account_policy.go
@@ -48,10 +48,10 @@ func NewGetServiceAccountPolicy(ctx *middleware.Context, handler GetServiceAccou
 	return &GetServiceAccountPolicy{Context: ctx, Handler: handler}
 }
 
-/* GetServiceAccountPolicy swagger:route GET /service-accounts/{access_key}/policy ServiceAccount getServiceAccountPolicy
+/*
+	GetServiceAccountPolicy swagger:route GET /service-accounts/{access_key}/policy ServiceAccount getServiceAccountPolicy
 
 Get Service Account Policy
-
 */
 type GetServiceAccountPolicy struct {
 	Context *middleware.Context

--- a/restapi/operations/service_account/get_service_account_policy_responses.go
+++ b/restapi/operations/service_account/get_service_account_policy_responses.go
@@ -33,7 +33,8 @@ import (
 // GetServiceAccountPolicyOKCode is the HTTP code returned for type GetServiceAccountPolicyOK
 const GetServiceAccountPolicyOKCode int = 200
 
-/*GetServiceAccountPolicyOK A successful response.
+/*
+GetServiceAccountPolicyOK A successful response.
 
 swagger:response getServiceAccountPolicyOK
 */
@@ -72,7 +73,8 @@ func (o *GetServiceAccountPolicyOK) WriteResponse(rw http.ResponseWriter, produc
 	}
 }
 
-/*GetServiceAccountPolicyDefault Generic error response.
+/*
+GetServiceAccountPolicyDefault Generic error response.
 
 swagger:response getServiceAccountPolicyDefault
 */

--- a/restapi/operations/service_account/list_user_service_accounts.go
+++ b/restapi/operations/service_account/list_user_service_accounts.go
@@ -48,10 +48,10 @@ func NewListUserServiceAccounts(ctx *middleware.Context, handler ListUserService
 	return &ListUserServiceAccounts{Context: ctx, Handler: handler}
 }
 
-/* ListUserServiceAccounts swagger:route GET /service-accounts ServiceAccount listUserServiceAccounts
+/*
+	ListUserServiceAccounts swagger:route GET /service-accounts ServiceAccount listUserServiceAccounts
 
 List User's Service Accounts
-
 */
 type ListUserServiceAccounts struct {
 	Context *middleware.Context

--- a/restapi/operations/service_account/list_user_service_accounts_responses.go
+++ b/restapi/operations/service_account/list_user_service_accounts_responses.go
@@ -33,7 +33,8 @@ import (
 // ListUserServiceAccountsOKCode is the HTTP code returned for type ListUserServiceAccountsOK
 const ListUserServiceAccountsOKCode int = 200
 
-/*ListUserServiceAccountsOK A successful response.
+/*
+ListUserServiceAccountsOK A successful response.
 
 swagger:response listUserServiceAccountsOK
 */
@@ -77,7 +78,8 @@ func (o *ListUserServiceAccountsOK) WriteResponse(rw http.ResponseWriter, produc
 	}
 }
 
-/*ListUserServiceAccountsDefault Generic error response.
+/*
+ListUserServiceAccountsDefault Generic error response.
 
 swagger:response listUserServiceAccountsDefault
 */

--- a/restapi/operations/service_account/set_service_account_policy.go
+++ b/restapi/operations/service_account/set_service_account_policy.go
@@ -48,10 +48,10 @@ func NewSetServiceAccountPolicy(ctx *middleware.Context, handler SetServiceAccou
 	return &SetServiceAccountPolicy{Context: ctx, Handler: handler}
 }
 
-/* SetServiceAccountPolicy swagger:route PUT /service-accounts/{access_key}/policy ServiceAccount setServiceAccountPolicy
+/*
+	SetServiceAccountPolicy swagger:route PUT /service-accounts/{access_key}/policy ServiceAccount setServiceAccountPolicy
 
 Set Service Account Policy
-
 */
 type SetServiceAccountPolicy struct {
 	Context *middleware.Context

--- a/restapi/operations/service_account/set_service_account_policy_responses.go
+++ b/restapi/operations/service_account/set_service_account_policy_responses.go
@@ -33,7 +33,8 @@ import (
 // SetServiceAccountPolicyOKCode is the HTTP code returned for type SetServiceAccountPolicyOK
 const SetServiceAccountPolicyOKCode int = 200
 
-/*SetServiceAccountPolicyOK A successful response.
+/*
+SetServiceAccountPolicyOK A successful response.
 
 swagger:response setServiceAccountPolicyOK
 */
@@ -54,7 +55,8 @@ func (o *SetServiceAccountPolicyOK) WriteResponse(rw http.ResponseWriter, produc
 	rw.WriteHeader(200)
 }
 
-/*SetServiceAccountPolicyDefault Generic error response.
+/*
+SetServiceAccountPolicyDefault Generic error response.
 
 swagger:response setServiceAccountPolicyDefault
 */

--- a/restapi/operations/site_replication/get_site_replication_info.go
+++ b/restapi/operations/site_replication/get_site_replication_info.go
@@ -48,10 +48,10 @@ func NewGetSiteReplicationInfo(ctx *middleware.Context, handler GetSiteReplicati
 	return &GetSiteReplicationInfo{Context: ctx, Handler: handler}
 }
 
-/* GetSiteReplicationInfo swagger:route GET /admin/site-replication SiteReplication getSiteReplicationInfo
+/*
+	GetSiteReplicationInfo swagger:route GET /admin/site-replication SiteReplication getSiteReplicationInfo
 
 Get list of Replication Sites
-
 */
 type GetSiteReplicationInfo struct {
 	Context *middleware.Context

--- a/restapi/operations/site_replication/get_site_replication_info_responses.go
+++ b/restapi/operations/site_replication/get_site_replication_info_responses.go
@@ -33,7 +33,8 @@ import (
 // GetSiteReplicationInfoOKCode is the HTTP code returned for type GetSiteReplicationInfoOK
 const GetSiteReplicationInfoOKCode int = 200
 
-/*GetSiteReplicationInfoOK A successful response.
+/*
+GetSiteReplicationInfoOK A successful response.
 
 swagger:response getSiteReplicationInfoOK
 */
@@ -74,7 +75,8 @@ func (o *GetSiteReplicationInfoOK) WriteResponse(rw http.ResponseWriter, produce
 	}
 }
 
-/*GetSiteReplicationInfoDefault Generic error response.
+/*
+GetSiteReplicationInfoDefault Generic error response.
 
 swagger:response getSiteReplicationInfoDefault
 */

--- a/restapi/operations/site_replication/get_site_replication_status.go
+++ b/restapi/operations/site_replication/get_site_replication_status.go
@@ -48,10 +48,10 @@ func NewGetSiteReplicationStatus(ctx *middleware.Context, handler GetSiteReplica
 	return &GetSiteReplicationStatus{Context: ctx, Handler: handler}
 }
 
-/* GetSiteReplicationStatus swagger:route GET /admin/site-replication/status SiteReplication getSiteReplicationStatus
+/*
+	GetSiteReplicationStatus swagger:route GET /admin/site-replication/status SiteReplication getSiteReplicationStatus
 
 Display overall site replication status
-
 */
 type GetSiteReplicationStatus struct {
 	Context *middleware.Context

--- a/restapi/operations/site_replication/get_site_replication_status_responses.go
+++ b/restapi/operations/site_replication/get_site_replication_status_responses.go
@@ -33,7 +33,8 @@ import (
 // GetSiteReplicationStatusOKCode is the HTTP code returned for type GetSiteReplicationStatusOK
 const GetSiteReplicationStatusOKCode int = 200
 
-/*GetSiteReplicationStatusOK A successful response.
+/*
+GetSiteReplicationStatusOK A successful response.
 
 swagger:response getSiteReplicationStatusOK
 */
@@ -74,7 +75,8 @@ func (o *GetSiteReplicationStatusOK) WriteResponse(rw http.ResponseWriter, produ
 	}
 }
 
-/*GetSiteReplicationStatusDefault Generic error response.
+/*
+GetSiteReplicationStatusDefault Generic error response.
 
 swagger:response getSiteReplicationStatusDefault
 */

--- a/restapi/operations/site_replication/site_replication_edit.go
+++ b/restapi/operations/site_replication/site_replication_edit.go
@@ -48,10 +48,10 @@ func NewSiteReplicationEdit(ctx *middleware.Context, handler SiteReplicationEdit
 	return &SiteReplicationEdit{Context: ctx, Handler: handler}
 }
 
-/* SiteReplicationEdit swagger:route PUT /admin/site-replication SiteReplication siteReplicationEdit
+/*
+	SiteReplicationEdit swagger:route PUT /admin/site-replication SiteReplication siteReplicationEdit
 
 Edit a Replication Site
-
 */
 type SiteReplicationEdit struct {
 	Context *middleware.Context

--- a/restapi/operations/site_replication/site_replication_edit_responses.go
+++ b/restapi/operations/site_replication/site_replication_edit_responses.go
@@ -33,7 +33,8 @@ import (
 // SiteReplicationEditOKCode is the HTTP code returned for type SiteReplicationEditOK
 const SiteReplicationEditOKCode int = 200
 
-/*SiteReplicationEditOK A successful response.
+/*
+SiteReplicationEditOK A successful response.
 
 swagger:response siteReplicationEditOK
 */
@@ -74,7 +75,8 @@ func (o *SiteReplicationEditOK) WriteResponse(rw http.ResponseWriter, producer r
 	}
 }
 
-/*SiteReplicationEditDefault Generic error response.
+/*
+SiteReplicationEditDefault Generic error response.
 
 swagger:response siteReplicationEditDefault
 */

--- a/restapi/operations/site_replication/site_replication_info_add.go
+++ b/restapi/operations/site_replication/site_replication_info_add.go
@@ -48,10 +48,10 @@ func NewSiteReplicationInfoAdd(ctx *middleware.Context, handler SiteReplicationI
 	return &SiteReplicationInfoAdd{Context: ctx, Handler: handler}
 }
 
-/* SiteReplicationInfoAdd swagger:route POST /admin/site-replication SiteReplication siteReplicationInfoAdd
+/*
+	SiteReplicationInfoAdd swagger:route POST /admin/site-replication SiteReplication siteReplicationInfoAdd
 
 Add a Replication Site
-
 */
 type SiteReplicationInfoAdd struct {
 	Context *middleware.Context

--- a/restapi/operations/site_replication/site_replication_info_add_responses.go
+++ b/restapi/operations/site_replication/site_replication_info_add_responses.go
@@ -33,7 +33,8 @@ import (
 // SiteReplicationInfoAddOKCode is the HTTP code returned for type SiteReplicationInfoAddOK
 const SiteReplicationInfoAddOKCode int = 200
 
-/*SiteReplicationInfoAddOK A successful response.
+/*
+SiteReplicationInfoAddOK A successful response.
 
 swagger:response siteReplicationInfoAddOK
 */
@@ -74,7 +75,8 @@ func (o *SiteReplicationInfoAddOK) WriteResponse(rw http.ResponseWriter, produce
 	}
 }
 
-/*SiteReplicationInfoAddDefault Generic error response.
+/*
+SiteReplicationInfoAddDefault Generic error response.
 
 swagger:response siteReplicationInfoAddDefault
 */

--- a/restapi/operations/site_replication/site_replication_remove.go
+++ b/restapi/operations/site_replication/site_replication_remove.go
@@ -48,10 +48,10 @@ func NewSiteReplicationRemove(ctx *middleware.Context, handler SiteReplicationRe
 	return &SiteReplicationRemove{Context: ctx, Handler: handler}
 }
 
-/* SiteReplicationRemove swagger:route DELETE /admin/site-replication SiteReplication siteReplicationRemove
+/*
+	SiteReplicationRemove swagger:route DELETE /admin/site-replication SiteReplication siteReplicationRemove
 
 Remove a Replication Site
-
 */
 type SiteReplicationRemove struct {
 	Context *middleware.Context

--- a/restapi/operations/site_replication/site_replication_remove_responses.go
+++ b/restapi/operations/site_replication/site_replication_remove_responses.go
@@ -33,7 +33,8 @@ import (
 // SiteReplicationRemoveNoContentCode is the HTTP code returned for type SiteReplicationRemoveNoContent
 const SiteReplicationRemoveNoContentCode int = 204
 
-/*SiteReplicationRemoveNoContent A successful response.
+/*
+SiteReplicationRemoveNoContent A successful response.
 
 swagger:response siteReplicationRemoveNoContent
 */
@@ -74,7 +75,8 @@ func (o *SiteReplicationRemoveNoContent) WriteResponse(rw http.ResponseWriter, p
 	}
 }
 
-/*SiteReplicationRemoveDefault Generic error response.
+/*
+SiteReplicationRemoveDefault Generic error response.
 
 swagger:response siteReplicationRemoveDefault
 */

--- a/restapi/operations/subnet/subnet_api_key.go
+++ b/restapi/operations/subnet/subnet_api_key.go
@@ -48,10 +48,10 @@ func NewSubnetAPIKey(ctx *middleware.Context, handler SubnetAPIKeyHandler) *Subn
 	return &SubnetAPIKey{Context: ctx, Handler: handler}
 }
 
-/* SubnetAPIKey swagger:route GET /subnet/apikey Subnet subnetApiKey
+/*
+	SubnetAPIKey swagger:route GET /subnet/apikey Subnet subnetApiKey
 
 Subnet api key
-
 */
 type SubnetAPIKey struct {
 	Context *middleware.Context

--- a/restapi/operations/subnet/subnet_api_key_responses.go
+++ b/restapi/operations/subnet/subnet_api_key_responses.go
@@ -33,7 +33,8 @@ import (
 // SubnetAPIKeyOKCode is the HTTP code returned for type SubnetAPIKeyOK
 const SubnetAPIKeyOKCode int = 200
 
-/*SubnetAPIKeyOK A successful response.
+/*
+SubnetAPIKeyOK A successful response.
 
 swagger:response subnetApiKeyOK
 */
@@ -74,7 +75,8 @@ func (o *SubnetAPIKeyOK) WriteResponse(rw http.ResponseWriter, producer runtime.
 	}
 }
 
-/*SubnetAPIKeyDefault Generic error response.
+/*
+SubnetAPIKeyDefault Generic error response.
 
 swagger:response subnetApiKeyDefault
 */

--- a/restapi/operations/subnet/subnet_info.go
+++ b/restapi/operations/subnet/subnet_info.go
@@ -48,10 +48,10 @@ func NewSubnetInfo(ctx *middleware.Context, handler SubnetInfoHandler) *SubnetIn
 	return &SubnetInfo{Context: ctx, Handler: handler}
 }
 
-/* SubnetInfo swagger:route GET /subnet/info Subnet subnetInfo
+/*
+	SubnetInfo swagger:route GET /subnet/info Subnet subnetInfo
 
 Subnet info
-
 */
 type SubnetInfo struct {
 	Context *middleware.Context

--- a/restapi/operations/subnet/subnet_info_responses.go
+++ b/restapi/operations/subnet/subnet_info_responses.go
@@ -33,7 +33,8 @@ import (
 // SubnetInfoOKCode is the HTTP code returned for type SubnetInfoOK
 const SubnetInfoOKCode int = 200
 
-/*SubnetInfoOK A successful response.
+/*
+SubnetInfoOK A successful response.
 
 swagger:response subnetInfoOK
 */
@@ -74,7 +75,8 @@ func (o *SubnetInfoOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 	}
 }
 
-/*SubnetInfoDefault Generic error response.
+/*
+SubnetInfoDefault Generic error response.
 
 swagger:response subnetInfoDefault
 */

--- a/restapi/operations/subnet/subnet_login.go
+++ b/restapi/operations/subnet/subnet_login.go
@@ -48,10 +48,10 @@ func NewSubnetLogin(ctx *middleware.Context, handler SubnetLoginHandler) *Subnet
 	return &SubnetLogin{Context: ctx, Handler: handler}
 }
 
-/* SubnetLogin swagger:route POST /subnet/login Subnet subnetLogin
+/*
+	SubnetLogin swagger:route POST /subnet/login Subnet subnetLogin
 
 Login to subnet
-
 */
 type SubnetLogin struct {
 	Context *middleware.Context

--- a/restapi/operations/subnet/subnet_login_m_f_a.go
+++ b/restapi/operations/subnet/subnet_login_m_f_a.go
@@ -48,10 +48,10 @@ func NewSubnetLoginMFA(ctx *middleware.Context, handler SubnetLoginMFAHandler) *
 	return &SubnetLoginMFA{Context: ctx, Handler: handler}
 }
 
-/* SubnetLoginMFA swagger:route POST /subnet/login/mfa Subnet subnetLoginMFA
+/*
+	SubnetLoginMFA swagger:route POST /subnet/login/mfa Subnet subnetLoginMFA
 
 Login to subnet using mfa
-
 */
 type SubnetLoginMFA struct {
 	Context *middleware.Context

--- a/restapi/operations/subnet/subnet_login_m_f_a_responses.go
+++ b/restapi/operations/subnet/subnet_login_m_f_a_responses.go
@@ -33,7 +33,8 @@ import (
 // SubnetLoginMFAOKCode is the HTTP code returned for type SubnetLoginMFAOK
 const SubnetLoginMFAOKCode int = 200
 
-/*SubnetLoginMFAOK A successful response.
+/*
+SubnetLoginMFAOK A successful response.
 
 swagger:response subnetLoginMFAOK
 */
@@ -74,7 +75,8 @@ func (o *SubnetLoginMFAOK) WriteResponse(rw http.ResponseWriter, producer runtim
 	}
 }
 
-/*SubnetLoginMFADefault Generic error response.
+/*
+SubnetLoginMFADefault Generic error response.
 
 swagger:response subnetLoginMFADefault
 */

--- a/restapi/operations/subnet/subnet_login_responses.go
+++ b/restapi/operations/subnet/subnet_login_responses.go
@@ -33,7 +33,8 @@ import (
 // SubnetLoginOKCode is the HTTP code returned for type SubnetLoginOK
 const SubnetLoginOKCode int = 200
 
-/*SubnetLoginOK A successful response.
+/*
+SubnetLoginOK A successful response.
 
 swagger:response subnetLoginOK
 */
@@ -74,7 +75,8 @@ func (o *SubnetLoginOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 }
 
-/*SubnetLoginDefault Generic error response.
+/*
+SubnetLoginDefault Generic error response.
 
 swagger:response subnetLoginDefault
 */

--- a/restapi/operations/subnet/subnet_reg_token.go
+++ b/restapi/operations/subnet/subnet_reg_token.go
@@ -48,10 +48,10 @@ func NewSubnetRegToken(ctx *middleware.Context, handler SubnetRegTokenHandler) *
 	return &SubnetRegToken{Context: ctx, Handler: handler}
 }
 
-/* SubnetRegToken swagger:route GET /subnet/registration-token Subnet subnetRegToken
+/*
+	SubnetRegToken swagger:route GET /subnet/registration-token Subnet subnetRegToken
 
 Subnet registraton token
-
 */
 type SubnetRegToken struct {
 	Context *middleware.Context

--- a/restapi/operations/subnet/subnet_reg_token_responses.go
+++ b/restapi/operations/subnet/subnet_reg_token_responses.go
@@ -33,7 +33,8 @@ import (
 // SubnetRegTokenOKCode is the HTTP code returned for type SubnetRegTokenOK
 const SubnetRegTokenOKCode int = 200
 
-/*SubnetRegTokenOK A successful response.
+/*
+SubnetRegTokenOK A successful response.
 
 swagger:response subnetRegTokenOK
 */
@@ -74,7 +75,8 @@ func (o *SubnetRegTokenOK) WriteResponse(rw http.ResponseWriter, producer runtim
 	}
 }
 
-/*SubnetRegTokenDefault Generic error response.
+/*
+SubnetRegTokenDefault Generic error response.
 
 swagger:response subnetRegTokenDefault
 */

--- a/restapi/operations/subnet/subnet_register.go
+++ b/restapi/operations/subnet/subnet_register.go
@@ -48,10 +48,10 @@ func NewSubnetRegister(ctx *middleware.Context, handler SubnetRegisterHandler) *
 	return &SubnetRegister{Context: ctx, Handler: handler}
 }
 
-/* SubnetRegister swagger:route POST /subnet/register Subnet subnetRegister
+/*
+	SubnetRegister swagger:route POST /subnet/register Subnet subnetRegister
 
 Register cluster with Subnet
-
 */
 type SubnetRegister struct {
 	Context *middleware.Context

--- a/restapi/operations/subnet/subnet_register_responses.go
+++ b/restapi/operations/subnet/subnet_register_responses.go
@@ -33,7 +33,8 @@ import (
 // SubnetRegisterOKCode is the HTTP code returned for type SubnetRegisterOK
 const SubnetRegisterOKCode int = 200
 
-/*SubnetRegisterOK A successful response.
+/*
+SubnetRegisterOK A successful response.
 
 swagger:response subnetRegisterOK
 */
@@ -54,7 +55,8 @@ func (o *SubnetRegisterOK) WriteResponse(rw http.ResponseWriter, producer runtim
 	rw.WriteHeader(200)
 }
 
-/*SubnetRegisterDefault Generic error response.
+/*
+SubnetRegisterDefault Generic error response.
 
 swagger:response subnetRegisterDefault
 */

--- a/restapi/operations/system/admin_info.go
+++ b/restapi/operations/system/admin_info.go
@@ -48,10 +48,10 @@ func NewAdminInfo(ctx *middleware.Context, handler AdminInfoHandler) *AdminInfo 
 	return &AdminInfo{Context: ctx, Handler: handler}
 }
 
-/* AdminInfo swagger:route GET /admin/info System adminInfo
+/*
+	AdminInfo swagger:route GET /admin/info System adminInfo
 
 Returns information about the deployment
-
 */
 type AdminInfo struct {
 	Context *middleware.Context

--- a/restapi/operations/system/admin_info_responses.go
+++ b/restapi/operations/system/admin_info_responses.go
@@ -33,7 +33,8 @@ import (
 // AdminInfoOKCode is the HTTP code returned for type AdminInfoOK
 const AdminInfoOKCode int = 200
 
-/*AdminInfoOK A successful response.
+/*
+AdminInfoOK A successful response.
 
 swagger:response adminInfoOK
 */
@@ -74,7 +75,8 @@ func (o *AdminInfoOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 	}
 }
 
-/*AdminInfoDefault Generic error response.
+/*
+AdminInfoDefault Generic error response.
 
 swagger:response adminInfoDefault
 */

--- a/restapi/operations/system/arn_list.go
+++ b/restapi/operations/system/arn_list.go
@@ -48,10 +48,10 @@ func NewArnList(ctx *middleware.Context, handler ArnListHandler) *ArnList {
 	return &ArnList{Context: ctx, Handler: handler}
 }
 
-/* ArnList swagger:route GET /admin/arns System arnList
+/*
+	ArnList swagger:route GET /admin/arns System arnList
 
 Returns a list of active ARNs in the instance
-
 */
 type ArnList struct {
 	Context *middleware.Context

--- a/restapi/operations/system/arn_list_responses.go
+++ b/restapi/operations/system/arn_list_responses.go
@@ -33,7 +33,8 @@ import (
 // ArnListOKCode is the HTTP code returned for type ArnListOK
 const ArnListOKCode int = 200
 
-/*ArnListOK A successful response.
+/*
+ArnListOK A successful response.
 
 swagger:response arnListOK
 */
@@ -74,7 +75,8 @@ func (o *ArnListOK) WriteResponse(rw http.ResponseWriter, producer runtime.Produ
 	}
 }
 
-/*ArnListDefault Generic error response.
+/*
+ArnListDefault Generic error response.
 
 swagger:response arnListDefault
 */

--- a/restapi/operations/system/check_min_i_o_version.go
+++ b/restapi/operations/system/check_min_i_o_version.go
@@ -46,10 +46,10 @@ func NewCheckMinIOVersion(ctx *middleware.Context, handler CheckMinIOVersionHand
 	return &CheckMinIOVersion{Context: ctx, Handler: handler}
 }
 
-/* CheckMinIOVersion swagger:route GET /check-version System checkMinIOVersion
+/*
+	CheckMinIOVersion swagger:route GET /check-version System checkMinIOVersion
 
 Checks the current MinIO version against the latest
-
 */
 type CheckMinIOVersion struct {
 	Context *middleware.Context

--- a/restapi/operations/system/check_min_i_o_version_responses.go
+++ b/restapi/operations/system/check_min_i_o_version_responses.go
@@ -33,7 +33,8 @@ import (
 // CheckMinIOVersionOKCode is the HTTP code returned for type CheckMinIOVersionOK
 const CheckMinIOVersionOKCode int = 200
 
-/*CheckMinIOVersionOK A successful response.
+/*
+CheckMinIOVersionOK A successful response.
 
 swagger:response checkMinIOVersionOK
 */
@@ -74,7 +75,8 @@ func (o *CheckMinIOVersionOK) WriteResponse(rw http.ResponseWriter, producer run
 	}
 }
 
-/*CheckMinIOVersionDefault Generic error response.
+/*
+CheckMinIOVersionDefault Generic error response.
 
 swagger:response checkMinIOVersionDefault
 */

--- a/restapi/operations/system/dashboard_widget_details.go
+++ b/restapi/operations/system/dashboard_widget_details.go
@@ -48,10 +48,10 @@ func NewDashboardWidgetDetails(ctx *middleware.Context, handler DashboardWidgetD
 	return &DashboardWidgetDetails{Context: ctx, Handler: handler}
 }
 
-/* DashboardWidgetDetails swagger:route GET /admin/info/widgets/{widgetId} System dashboardWidgetDetails
+/*
+	DashboardWidgetDetails swagger:route GET /admin/info/widgets/{widgetId} System dashboardWidgetDetails
 
 Returns information about the deployment
-
 */
 type DashboardWidgetDetails struct {
 	Context *middleware.Context

--- a/restapi/operations/system/dashboard_widget_details_responses.go
+++ b/restapi/operations/system/dashboard_widget_details_responses.go
@@ -33,7 +33,8 @@ import (
 // DashboardWidgetDetailsOKCode is the HTTP code returned for type DashboardWidgetDetailsOK
 const DashboardWidgetDetailsOKCode int = 200
 
-/*DashboardWidgetDetailsOK A successful response.
+/*
+DashboardWidgetDetailsOK A successful response.
 
 swagger:response dashboardWidgetDetailsOK
 */
@@ -74,7 +75,8 @@ func (o *DashboardWidgetDetailsOK) WriteResponse(rw http.ResponseWriter, produce
 	}
 }
 
-/*DashboardWidgetDetailsDefault Generic error response.
+/*
+DashboardWidgetDetailsDefault Generic error response.
 
 swagger:response dashboardWidgetDetailsDefault
 */

--- a/restapi/operations/system/list_nodes.go
+++ b/restapi/operations/system/list_nodes.go
@@ -48,10 +48,10 @@ func NewListNodes(ctx *middleware.Context, handler ListNodesHandler) *ListNodes 
 	return &ListNodes{Context: ctx, Handler: handler}
 }
 
-/* ListNodes swagger:route GET /nodes System listNodes
+/*
+	ListNodes swagger:route GET /nodes System listNodes
 
 Lists Nodes
-
 */
 type ListNodes struct {
 	Context *middleware.Context

--- a/restapi/operations/system/list_nodes_responses.go
+++ b/restapi/operations/system/list_nodes_responses.go
@@ -33,7 +33,8 @@ import (
 // ListNodesOKCode is the HTTP code returned for type ListNodesOK
 const ListNodesOKCode int = 200
 
-/*ListNodesOK A successful response.
+/*
+ListNodesOK A successful response.
 
 swagger:response listNodesOK
 */
@@ -77,7 +78,8 @@ func (o *ListNodesOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 	}
 }
 
-/*ListNodesDefault Generic error response.
+/*
+ListNodesDefault Generic error response.
 
 swagger:response listNodesDefault
 */

--- a/restapi/operations/tiering/add_tier.go
+++ b/restapi/operations/tiering/add_tier.go
@@ -48,10 +48,10 @@ func NewAddTier(ctx *middleware.Context, handler AddTierHandler) *AddTier {
 	return &AddTier{Context: ctx, Handler: handler}
 }
 
-/* AddTier swagger:route POST /admin/tiers Tiering addTier
+/*
+	AddTier swagger:route POST /admin/tiers Tiering addTier
 
 Allows to configure a new tier
-
 */
 type AddTier struct {
 	Context *middleware.Context

--- a/restapi/operations/tiering/add_tier_responses.go
+++ b/restapi/operations/tiering/add_tier_responses.go
@@ -33,7 +33,8 @@ import (
 // AddTierCreatedCode is the HTTP code returned for type AddTierCreated
 const AddTierCreatedCode int = 201
 
-/*AddTierCreated A successful response.
+/*
+AddTierCreated A successful response.
 
 swagger:response addTierCreated
 */
@@ -54,7 +55,8 @@ func (o *AddTierCreated) WriteResponse(rw http.ResponseWriter, producer runtime.
 	rw.WriteHeader(201)
 }
 
-/*AddTierDefault Generic error response.
+/*
+AddTierDefault Generic error response.
 
 swagger:response addTierDefault
 */

--- a/restapi/operations/tiering/edit_tier_credentials.go
+++ b/restapi/operations/tiering/edit_tier_credentials.go
@@ -48,10 +48,10 @@ func NewEditTierCredentials(ctx *middleware.Context, handler EditTierCredentials
 	return &EditTierCredentials{Context: ctx, Handler: handler}
 }
 
-/* EditTierCredentials swagger:route PUT /admin/tiers/{type}/{name}/credentials Tiering editTierCredentials
+/*
+	EditTierCredentials swagger:route PUT /admin/tiers/{type}/{name}/credentials Tiering editTierCredentials
 
 Edit Tier Credentials
-
 */
 type EditTierCredentials struct {
 	Context *middleware.Context

--- a/restapi/operations/tiering/edit_tier_credentials_responses.go
+++ b/restapi/operations/tiering/edit_tier_credentials_responses.go
@@ -33,7 +33,8 @@ import (
 // EditTierCredentialsOKCode is the HTTP code returned for type EditTierCredentialsOK
 const EditTierCredentialsOKCode int = 200
 
-/*EditTierCredentialsOK A successful response.
+/*
+EditTierCredentialsOK A successful response.
 
 swagger:response editTierCredentialsOK
 */
@@ -54,7 +55,8 @@ func (o *EditTierCredentialsOK) WriteResponse(rw http.ResponseWriter, producer r
 	rw.WriteHeader(200)
 }
 
-/*EditTierCredentialsDefault Generic error response.
+/*
+EditTierCredentialsDefault Generic error response.
 
 swagger:response editTierCredentialsDefault
 */

--- a/restapi/operations/tiering/get_tier.go
+++ b/restapi/operations/tiering/get_tier.go
@@ -48,10 +48,10 @@ func NewGetTier(ctx *middleware.Context, handler GetTierHandler) *GetTier {
 	return &GetTier{Context: ctx, Handler: handler}
 }
 
-/* GetTier swagger:route GET /admin/tiers/{type}/{name} Tiering getTier
+/*
+	GetTier swagger:route GET /admin/tiers/{type}/{name} Tiering getTier
 
 Get Tier
-
 */
 type GetTier struct {
 	Context *middleware.Context

--- a/restapi/operations/tiering/get_tier_responses.go
+++ b/restapi/operations/tiering/get_tier_responses.go
@@ -33,7 +33,8 @@ import (
 // GetTierOKCode is the HTTP code returned for type GetTierOK
 const GetTierOKCode int = 200
 
-/*GetTierOK A successful response.
+/*
+GetTierOK A successful response.
 
 swagger:response getTierOK
 */
@@ -74,7 +75,8 @@ func (o *GetTierOK) WriteResponse(rw http.ResponseWriter, producer runtime.Produ
 	}
 }
 
-/*GetTierDefault Generic error response.
+/*
+GetTierDefault Generic error response.
 
 swagger:response getTierDefault
 */

--- a/restapi/operations/tiering/tiers_list.go
+++ b/restapi/operations/tiering/tiers_list.go
@@ -48,10 +48,10 @@ func NewTiersList(ctx *middleware.Context, handler TiersListHandler) *TiersList 
 	return &TiersList{Context: ctx, Handler: handler}
 }
 
-/* TiersList swagger:route GET /admin/tiers Tiering tiersList
+/*
+	TiersList swagger:route GET /admin/tiers Tiering tiersList
 
 Returns a list of tiers for ilm
-
 */
 type TiersList struct {
 	Context *middleware.Context

--- a/restapi/operations/tiering/tiers_list_responses.go
+++ b/restapi/operations/tiering/tiers_list_responses.go
@@ -33,7 +33,8 @@ import (
 // TiersListOKCode is the HTTP code returned for type TiersListOK
 const TiersListOKCode int = 200
 
-/*TiersListOK A successful response.
+/*
+TiersListOK A successful response.
 
 swagger:response tiersListOK
 */
@@ -74,7 +75,8 @@ func (o *TiersListOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 	}
 }
 
-/*TiersListDefault Generic error response.
+/*
+TiersListDefault Generic error response.
 
 swagger:response tiersListDefault
 */

--- a/restapi/operations/user/add_user.go
+++ b/restapi/operations/user/add_user.go
@@ -48,10 +48,10 @@ func NewAddUser(ctx *middleware.Context, handler AddUserHandler) *AddUser {
 	return &AddUser{Context: ctx, Handler: handler}
 }
 
-/* AddUser swagger:route POST /users User addUser
+/*
+	AddUser swagger:route POST /users User addUser
 
 Add User
-
 */
 type AddUser struct {
 	Context *middleware.Context

--- a/restapi/operations/user/add_user_responses.go
+++ b/restapi/operations/user/add_user_responses.go
@@ -33,7 +33,8 @@ import (
 // AddUserCreatedCode is the HTTP code returned for type AddUserCreated
 const AddUserCreatedCode int = 201
 
-/*AddUserCreated A successful response.
+/*
+AddUserCreated A successful response.
 
 swagger:response addUserCreated
 */
@@ -74,7 +75,8 @@ func (o *AddUserCreated) WriteResponse(rw http.ResponseWriter, producer runtime.
 	}
 }
 
-/*AddUserDefault Generic error response.
+/*
+AddUserDefault Generic error response.
 
 swagger:response addUserDefault
 */

--- a/restapi/operations/user/bulk_update_users_groups.go
+++ b/restapi/operations/user/bulk_update_users_groups.go
@@ -48,10 +48,10 @@ func NewBulkUpdateUsersGroups(ctx *middleware.Context, handler BulkUpdateUsersGr
 	return &BulkUpdateUsersGroups{Context: ctx, Handler: handler}
 }
 
-/* BulkUpdateUsersGroups swagger:route PUT /users-groups-bulk User bulkUpdateUsersGroups
+/*
+	BulkUpdateUsersGroups swagger:route PUT /users-groups-bulk User bulkUpdateUsersGroups
 
 Bulk functionality to Add Users to Groups
-
 */
 type BulkUpdateUsersGroups struct {
 	Context *middleware.Context

--- a/restapi/operations/user/bulk_update_users_groups_responses.go
+++ b/restapi/operations/user/bulk_update_users_groups_responses.go
@@ -33,7 +33,8 @@ import (
 // BulkUpdateUsersGroupsOKCode is the HTTP code returned for type BulkUpdateUsersGroupsOK
 const BulkUpdateUsersGroupsOKCode int = 200
 
-/*BulkUpdateUsersGroupsOK A successful response.
+/*
+BulkUpdateUsersGroupsOK A successful response.
 
 swagger:response bulkUpdateUsersGroupsOK
 */
@@ -54,7 +55,8 @@ func (o *BulkUpdateUsersGroupsOK) WriteResponse(rw http.ResponseWriter, producer
 	rw.WriteHeader(200)
 }
 
-/*BulkUpdateUsersGroupsDefault Generic error response.
+/*
+BulkUpdateUsersGroupsDefault Generic error response.
 
 swagger:response bulkUpdateUsersGroupsDefault
 */

--- a/restapi/operations/user/check_user_service_accounts.go
+++ b/restapi/operations/user/check_user_service_accounts.go
@@ -48,10 +48,10 @@ func NewCheckUserServiceAccounts(ctx *middleware.Context, handler CheckUserServi
 	return &CheckUserServiceAccounts{Context: ctx, Handler: handler}
 }
 
-/* CheckUserServiceAccounts swagger:route POST /users/service-accounts User checkUserServiceAccounts
+/*
+	CheckUserServiceAccounts swagger:route POST /users/service-accounts User checkUserServiceAccounts
 
 Check number of service accounts for each user specified
-
 */
 type CheckUserServiceAccounts struct {
 	Context *middleware.Context

--- a/restapi/operations/user/check_user_service_accounts_responses.go
+++ b/restapi/operations/user/check_user_service_accounts_responses.go
@@ -33,7 +33,8 @@ import (
 // CheckUserServiceAccountsOKCode is the HTTP code returned for type CheckUserServiceAccountsOK
 const CheckUserServiceAccountsOKCode int = 200
 
-/*CheckUserServiceAccountsOK A successful response.
+/*
+CheckUserServiceAccountsOK A successful response.
 
 swagger:response checkUserServiceAccountsOK
 */
@@ -74,7 +75,8 @@ func (o *CheckUserServiceAccountsOK) WriteResponse(rw http.ResponseWriter, produ
 	}
 }
 
-/*CheckUserServiceAccountsDefault Generic error response.
+/*
+CheckUserServiceAccountsDefault Generic error response.
 
 swagger:response checkUserServiceAccountsDefault
 */

--- a/restapi/operations/user/create_a_user_service_account.go
+++ b/restapi/operations/user/create_a_user_service_account.go
@@ -48,10 +48,10 @@ func NewCreateAUserServiceAccount(ctx *middleware.Context, handler CreateAUserSe
 	return &CreateAUserServiceAccount{Context: ctx, Handler: handler}
 }
 
-/* CreateAUserServiceAccount swagger:route POST /user/{name}/service-accounts User createAUserServiceAccount
+/*
+	CreateAUserServiceAccount swagger:route POST /user/{name}/service-accounts User createAUserServiceAccount
 
 Create Service Account for User
-
 */
 type CreateAUserServiceAccount struct {
 	Context *middleware.Context

--- a/restapi/operations/user/create_a_user_service_account_responses.go
+++ b/restapi/operations/user/create_a_user_service_account_responses.go
@@ -33,7 +33,8 @@ import (
 // CreateAUserServiceAccountCreatedCode is the HTTP code returned for type CreateAUserServiceAccountCreated
 const CreateAUserServiceAccountCreatedCode int = 201
 
-/*CreateAUserServiceAccountCreated A successful response.
+/*
+CreateAUserServiceAccountCreated A successful response.
 
 swagger:response createAUserServiceAccountCreated
 */
@@ -74,7 +75,8 @@ func (o *CreateAUserServiceAccountCreated) WriteResponse(rw http.ResponseWriter,
 	}
 }
 
-/*CreateAUserServiceAccountDefault Generic error response.
+/*
+CreateAUserServiceAccountDefault Generic error response.
 
 swagger:response createAUserServiceAccountDefault
 */

--- a/restapi/operations/user/create_service_account_credentials.go
+++ b/restapi/operations/user/create_service_account_credentials.go
@@ -48,10 +48,10 @@ func NewCreateServiceAccountCredentials(ctx *middleware.Context, handler CreateS
 	return &CreateServiceAccountCredentials{Context: ctx, Handler: handler}
 }
 
-/* CreateServiceAccountCredentials swagger:route POST /user/{name}/service-account-credentials User createServiceAccountCredentials
+/*
+	CreateServiceAccountCredentials swagger:route POST /user/{name}/service-account-credentials User createServiceAccountCredentials
 
 Create Service Account for User With Credentials
-
 */
 type CreateServiceAccountCredentials struct {
 	Context *middleware.Context

--- a/restapi/operations/user/create_service_account_credentials_responses.go
+++ b/restapi/operations/user/create_service_account_credentials_responses.go
@@ -33,7 +33,8 @@ import (
 // CreateServiceAccountCredentialsCreatedCode is the HTTP code returned for type CreateServiceAccountCredentialsCreated
 const CreateServiceAccountCredentialsCreatedCode int = 201
 
-/*CreateServiceAccountCredentialsCreated A successful response.
+/*
+CreateServiceAccountCredentialsCreated A successful response.
 
 swagger:response createServiceAccountCredentialsCreated
 */
@@ -74,7 +75,8 @@ func (o *CreateServiceAccountCredentialsCreated) WriteResponse(rw http.ResponseW
 	}
 }
 
-/*CreateServiceAccountCredentialsDefault Generic error response.
+/*
+CreateServiceAccountCredentialsDefault Generic error response.
 
 swagger:response createServiceAccountCredentialsDefault
 */

--- a/restapi/operations/user/get_user_info.go
+++ b/restapi/operations/user/get_user_info.go
@@ -48,10 +48,10 @@ func NewGetUserInfo(ctx *middleware.Context, handler GetUserInfoHandler) *GetUse
 	return &GetUserInfo{Context: ctx, Handler: handler}
 }
 
-/* GetUserInfo swagger:route GET /user/{name} User getUserInfo
+/*
+	GetUserInfo swagger:route GET /user/{name} User getUserInfo
 
 Get User Info
-
 */
 type GetUserInfo struct {
 	Context *middleware.Context

--- a/restapi/operations/user/get_user_info_responses.go
+++ b/restapi/operations/user/get_user_info_responses.go
@@ -33,7 +33,8 @@ import (
 // GetUserInfoOKCode is the HTTP code returned for type GetUserInfoOK
 const GetUserInfoOKCode int = 200
 
-/*GetUserInfoOK A successful response.
+/*
+GetUserInfoOK A successful response.
 
 swagger:response getUserInfoOK
 */
@@ -74,7 +75,8 @@ func (o *GetUserInfoOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 }
 
-/*GetUserInfoDefault Generic error response.
+/*
+GetUserInfoDefault Generic error response.
 
 swagger:response getUserInfoDefault
 */

--- a/restapi/operations/user/list_a_user_service_accounts.go
+++ b/restapi/operations/user/list_a_user_service_accounts.go
@@ -48,10 +48,10 @@ func NewListAUserServiceAccounts(ctx *middleware.Context, handler ListAUserServi
 	return &ListAUserServiceAccounts{Context: ctx, Handler: handler}
 }
 
-/* ListAUserServiceAccounts swagger:route GET /user/{name}/service-accounts User listAUserServiceAccounts
+/*
+	ListAUserServiceAccounts swagger:route GET /user/{name}/service-accounts User listAUserServiceAccounts
 
 returns a list of service accounts for a user
-
 */
 type ListAUserServiceAccounts struct {
 	Context *middleware.Context

--- a/restapi/operations/user/list_a_user_service_accounts_responses.go
+++ b/restapi/operations/user/list_a_user_service_accounts_responses.go
@@ -33,7 +33,8 @@ import (
 // ListAUserServiceAccountsOKCode is the HTTP code returned for type ListAUserServiceAccountsOK
 const ListAUserServiceAccountsOKCode int = 200
 
-/*ListAUserServiceAccountsOK A successful response.
+/*
+ListAUserServiceAccountsOK A successful response.
 
 swagger:response listAUserServiceAccountsOK
 */
@@ -77,7 +78,8 @@ func (o *ListAUserServiceAccountsOK) WriteResponse(rw http.ResponseWriter, produ
 	}
 }
 
-/*ListAUserServiceAccountsDefault Generic error response.
+/*
+ListAUserServiceAccountsDefault Generic error response.
 
 swagger:response listAUserServiceAccountsDefault
 */

--- a/restapi/operations/user/list_users.go
+++ b/restapi/operations/user/list_users.go
@@ -48,10 +48,10 @@ func NewListUsers(ctx *middleware.Context, handler ListUsersHandler) *ListUsers 
 	return &ListUsers{Context: ctx, Handler: handler}
 }
 
-/* ListUsers swagger:route GET /users User listUsers
+/*
+	ListUsers swagger:route GET /users User listUsers
 
 List Users
-
 */
 type ListUsers struct {
 	Context *middleware.Context

--- a/restapi/operations/user/list_users_responses.go
+++ b/restapi/operations/user/list_users_responses.go
@@ -33,7 +33,8 @@ import (
 // ListUsersOKCode is the HTTP code returned for type ListUsersOK
 const ListUsersOKCode int = 200
 
-/*ListUsersOK A successful response.
+/*
+ListUsersOK A successful response.
 
 swagger:response listUsersOK
 */
@@ -74,7 +75,8 @@ func (o *ListUsersOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 	}
 }
 
-/*ListUsersDefault Generic error response.
+/*
+ListUsersDefault Generic error response.
 
 swagger:response listUsersDefault
 */

--- a/restapi/operations/user/remove_user.go
+++ b/restapi/operations/user/remove_user.go
@@ -48,10 +48,10 @@ func NewRemoveUser(ctx *middleware.Context, handler RemoveUserHandler) *RemoveUs
 	return &RemoveUser{Context: ctx, Handler: handler}
 }
 
-/* RemoveUser swagger:route DELETE /user/{name} User removeUser
+/*
+	RemoveUser swagger:route DELETE /user/{name} User removeUser
 
 Remove user
-
 */
 type RemoveUser struct {
 	Context *middleware.Context

--- a/restapi/operations/user/remove_user_responses.go
+++ b/restapi/operations/user/remove_user_responses.go
@@ -33,7 +33,8 @@ import (
 // RemoveUserNoContentCode is the HTTP code returned for type RemoveUserNoContent
 const RemoveUserNoContentCode int = 204
 
-/*RemoveUserNoContent A successful response.
+/*
+RemoveUserNoContent A successful response.
 
 swagger:response removeUserNoContent
 */
@@ -54,7 +55,8 @@ func (o *RemoveUserNoContent) WriteResponse(rw http.ResponseWriter, producer run
 	rw.WriteHeader(204)
 }
 
-/*RemoveUserDefault Generic error response.
+/*
+RemoveUserDefault Generic error response.
 
 swagger:response removeUserDefault
 */

--- a/restapi/operations/user/update_user_groups.go
+++ b/restapi/operations/user/update_user_groups.go
@@ -48,10 +48,10 @@ func NewUpdateUserGroups(ctx *middleware.Context, handler UpdateUserGroupsHandle
 	return &UpdateUserGroups{Context: ctx, Handler: handler}
 }
 
-/* UpdateUserGroups swagger:route PUT /user/{name}/groups User updateUserGroups
+/*
+	UpdateUserGroups swagger:route PUT /user/{name}/groups User updateUserGroups
 
 Update Groups for a user
-
 */
 type UpdateUserGroups struct {
 	Context *middleware.Context

--- a/restapi/operations/user/update_user_groups_responses.go
+++ b/restapi/operations/user/update_user_groups_responses.go
@@ -33,7 +33,8 @@ import (
 // UpdateUserGroupsOKCode is the HTTP code returned for type UpdateUserGroupsOK
 const UpdateUserGroupsOKCode int = 200
 
-/*UpdateUserGroupsOK A successful response.
+/*
+UpdateUserGroupsOK A successful response.
 
 swagger:response updateUserGroupsOK
 */
@@ -74,7 +75,8 @@ func (o *UpdateUserGroupsOK) WriteResponse(rw http.ResponseWriter, producer runt
 	}
 }
 
-/*UpdateUserGroupsDefault Generic error response.
+/*
+UpdateUserGroupsDefault Generic error response.
 
 swagger:response updateUserGroupsDefault
 */

--- a/restapi/operations/user/update_user_info.go
+++ b/restapi/operations/user/update_user_info.go
@@ -48,10 +48,10 @@ func NewUpdateUserInfo(ctx *middleware.Context, handler UpdateUserInfoHandler) *
 	return &UpdateUserInfo{Context: ctx, Handler: handler}
 }
 
-/* UpdateUserInfo swagger:route PUT /user/{name} User updateUserInfo
+/*
+UpdateUserInfo swagger:route PUT /user/{name} User updateUserInfo
 
 Update User Info
-
 */
 type UpdateUserInfo struct {
 	Context *middleware.Context

--- a/restapi/operations/user/update_user_info_responses.go
+++ b/restapi/operations/user/update_user_info_responses.go
@@ -33,7 +33,8 @@ import (
 // UpdateUserInfoOKCode is the HTTP code returned for type UpdateUserInfoOK
 const UpdateUserInfoOKCode int = 200
 
-/*UpdateUserInfoOK A successful response.
+/*
+UpdateUserInfoOK A successful response.
 
 swagger:response updateUserInfoOK
 */
@@ -74,7 +75,8 @@ func (o *UpdateUserInfoOK) WriteResponse(rw http.ResponseWriter, producer runtim
 	}
 }
 
-/*UpdateUserInfoDefault Generic error response.
+/*
+UpdateUserInfoDefault Generic error response.
 
 swagger:response updateUserInfoDefault
 */


### PR DESCRIPTION
Correcting files for `gofmt` to work in version `1.19.0`
Fixes are backward compatible with version `1.18.5` of `gofmt`.