### PR TITLE
Migrate semgrep to datacenter

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -262,18 +262,20 @@ jobs:
 
   semgrep-static-code-analysis:
     name: "semgrep checks"
-    runs-on: ${{ matrix.os }}
-    container:
-      image: "returntocorp/semgrep"
+    runs-on: self-hosted
     strategy:
       matrix:
         os: [ ubuntu-latest ]
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Scanning code on ${{ matrix.os }}
         continue-on-error: false
         run: |
+          # Install semgrep rather than using a container due to:
+          # https://github.com/actions/checkout/issues/334
+          sudo apt install -y python3-pip || apt install -y python3-pip
+          pip3 install semgrep
           semgrep --config semgrep.yaml $(pwd)/portal-ui --error
 
   no-warnings-and-make-assets:


### PR DESCRIPTION
### Objective:

Migrate semgrep to datacenter

```sh
Scanning across multiple languages:
    ts | 7 rules × 730 files
    js | 7 rules ×   1 file 


Some files were skipped or only partially analyzed.
  Scan was limited to files tracked by git.
  Scan skipped: 1 files larger than 1.0 MB, 171 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 7 rules on 731 files: 0 findings.
If Semgrep missed a finding, please send us feedback to let us know!
```