### PR TITLE
Migrate reuse golang dependencies

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -344,7 +344,7 @@ jobs:
 
   reuse-golang-dependencies:
     name: reuse golang dependencies
-    runs-on: ${{ matrix.os }}
+    runs-on: self-hosted
     strategy:
       matrix:
         go-version: [ 1.18.x, 1.19.x ]


### PR DESCRIPTION
### Objective:

Migrate reuse golang dependencies test to datacenter.

### Testing:

Currently working in our Datacenter Runners:

* Runner name: 'console-runner-2'
* Runner name: 'console-runner-3'