### PR TITLE
Removed double border in raw policy / yaml containers

### DIFF
--- a/portal-ui/src/screens/Console/Policies/PolicyDetails.tsx
+++ b/portal-ui/src/screens/Console/Policies/PolicyDetails.tsx
@@ -484,7 +484,7 @@ const PolicyDetails = ({ classes }: IPolicyDetailsProps) => {
                   }}
                 >
                   <Grid container>
-                    <Grid item xs={12} style={{ border: "1px solid #eaeaea" }}>
+                    <Grid item xs={12}>
                       <CodeMirrorWrapper
                         readOnly={!editPolicy}
                         value={policyDefinition}

--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantYAML.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantYAML.tsx
@@ -141,7 +141,7 @@ const TenantYAML = ({ classes }: ITenantYAMLProps) => {
             <Grid item xs={12}>
               <SectionTitle>Tenant Specification</SectionTitle>
             </Grid>
-            <Grid item xs={12} style={{ border: "1px solid #eaeaea" }}>
+            <Grid item xs={12}>
               <CodeMirrorWrapper
                 value={tenantYaml}
                 mode={"yaml"}


### PR DESCRIPTION
## What does this do?

Removed double border in raw policy / yaml containers

## How does it look?
<img width="1396" alt="Screen Shot 2022-08-26 at 14 44 16" src="https://user-images.githubusercontent.com/33497058/186980042-3a34e2f9-82bd-4243-ac0d-e9e12260d223.png">

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>