### PR TITLE
Format all files after swagger-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,12 @@ install: console
 	@mkdir -p $(GOPATH)/bin && cp -f $(PWD)/console $(GOPATH)/bin/console
 	@echo "Installation successful. To learn more, try \"console --help\"."
 
-swagger-gen: clean-swagger swagger-console swagger-operator
+swagger-gen: clean-swagger swagger-console swagger-operator apply-gofmt
 	@echo "Done Generating swagger server code from yaml"
+
+apply-gofmt:
+	@echo "Applying gofmt to all generated an existing files"
+	@GO111MODULE=on gofmt -w .
 
 clean-swagger:
 	@echo "cleaning"


### PR DESCRIPTION
@bexsoft had a good idea in https://github.com/minio/console/pull/2266 where we can actually format all the files generated by swagger; hence our validation process will automatically pass when commiting without to manually perform this step every time we update our API.