### PR TITLE
Filtered prefixes in versions list

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/VersionsNavigator.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/VersionsNavigator.tsx
@@ -212,13 +212,22 @@ const VersionsNavigator = ({
         )
         .then((res: IFileInfo[]) => {
           const result = get(res, "objects", []);
+
+          const decodedInternalPaths = decodeURLString(internalPaths);
+
+          // Filter the results prefixes as API can return more files than expected.
+          const filteredPrefixes = result.filter(
+            (item: IFileInfo) => item.name === decodedInternalPaths
+          );
+
           if (distributedSetup) {
             setActualInfo(
-              result.find((el: IFileInfo) => el.is_latest) || emptyFile
+              filteredPrefixes.find((el: IFileInfo) => el.is_latest) ||
+                emptyFile
             );
-            setVersions(result);
+            setVersions(filteredPrefixes);
           } else {
-            setActualInfo(result[0]);
+            setActualInfo(filteredPrefixes[0]);
             setVersions([]);
           }
 


### PR DESCRIPTION
fixes #2274

## What does this do?

Filtered prefixes in versions list as by definition we are requesting prefixes to get files list. this can lead to see unwanted files in versions panel.

## How to test

1. Create a versioned bucket
2. Create a file called `file` with no extension and upload it to the bucket
3. Create a file called `file2` with no extension and upload it to the bucket in the same location of the previous file.
4. Upload again file2 in the same location
5. Select the first file and click to explore versions. You should see only one version only.
6. Select the second file and click to explore versions, You should see the 2 uploaded versions only.

## How does it look?
<img width="1151" alt="Screen Shot 2022-08-30 at 15 22 29" src="https://user-images.githubusercontent.com/33497058/187535903-0ca45c5c-6a5e-4554-93a7-032c115284ec.png">
<img width="1162" alt="Screen Shot 2022-08-30 at 15 22 22" src="https://user-images.githubusercontent.com/33497058/187535906-5a02fab8-e4cd-41c2-8a5e-507c8416a245.png">
<img width="1183" alt="Screen Shot 2022-08-30 at 15 22 14" src="https://user-images.githubusercontent.com/33497058/187535911-e2921a0c-1632-4f49-9af8-e2a5a0d95b8a.png">
<img width="1166" alt="Screen Shot 2022-08-30 at 15 22 08" src="https://user-images.githubusercontent.com/33497058/187535913-5fd2f825-c002-4e2e-ac56-527e656b2913.png">
<img width="1181" alt="Screen Shot 2022-08-30 at 15 21 57" src="https://user-images.githubusercontent.com/33497058/187535916-325c073d-9f35-4f9b-aa12-0733cbd1ca52.png">



Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>