### PR TITLE
Fixed Visual height for Sites Replication

### DIFF
--- a/portal-ui/src/screens/Console/Configurations/SiteReplication/ReplicationSites.tsx
+++ b/portal-ui/src/screens/Console/Configurations/SiteReplication/ReplicationSites.tsx
@@ -110,11 +110,13 @@ const ReplicationSites = ({
           flex: 1,
           padding: "0",
           marginTop: "25px",
-          height: "calc( 100vh - 450px )",
+          height: "calc( 100vh - 640px )",
+          minHeight: "250px",
           border: "1px solid #eaeaea",
           marginBottom: "25px",
+          overflowY: "auto",
         }}
-        component="nav"
+        component="div"
         aria-labelledby="nested-list-subheader"
       >
         <Box


### PR DESCRIPTION
fixes #2230

## What does this do?

Fixes visual height for sites replication page

## How does it look?

<img width="1509" alt="Screen Shot 2022-09-02 at 17 15 24" src="https://user-images.githubusercontent.com/33497058/188241874-539d2c87-bc64-4a9e-b27b-2a77323da628.png">
<img width="1490" alt="Screen Shot 2022-09-02 at 17 15 13" src="https://user-images.githubusercontent.com/33497058/188241877-f90bc0c5-5433-449a-a1a7-4e05d11c5876.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>