### PR TITLE
fix: login function was returning fixed error

### DIFF
--- a/restapi/user_login.go
+++ b/restapi/user_login.go
@@ -125,7 +125,7 @@ func getLoginResponse(params authApi.LoginParams) (*models.LoginResponse, *model
 		// prepare console credentials
 		consoleCreds, err = getConsoleCredentials(lr.AccessKey, lr.SecretKey)
 		if err != nil {
-			return nil, ErrorWithContext(ctx, ErrInvalidLogin)
+			return nil, ErrorWithContext(ctx, err, ErrInvalidLogin)
 		}
 	}
 
@@ -135,7 +135,7 @@ func getLoginResponse(params authApi.LoginParams) (*models.LoginResponse, *model
 	}
 	sessionID, err := login(consoleCreds, sf)
 	if err != nil {
-		return nil, ErrorWithContext(ctx, ErrInvalidLogin)
+		return nil, ErrorWithContext(ctx, err, ErrInvalidLogin)
 	}
 	// serialize output
 	loginResponse := &models.LoginResponse{


### PR DESCRIPTION
On login failure console is returning a fixed error message instead of the real error, this makes debugging extremely difficult

After the fix:

![Screenshot from 2022-09-10 16-03-33](https://user-images.githubusercontent.com/1795553/189504649-9f9db5ac-266d-4b60-8ba7-30a855e639a8.png)
![Screenshot from 2022-09-10 16-04-01](https://user-images.githubusercontent.com/1795553/189504651-c993ca4a-6ef7-4bfe-ae82-c644cba5b268.png)

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>