### PR TITLE
Tiers permission UI fix

### DIFF
--- a/portal-ui/src/common/SecureComponent/permissions.ts
+++ b/portal-ui/src/common/SecureComponent/permissions.ts
@@ -368,13 +368,14 @@ export const IAM_PAGES_PERMISSIONS = {
   ],
   [IAM_PAGES.TIERS]: [
     IAM_SCOPES.ADMIN_LIST_TIERS, // display tiers list
-    IAM_SCOPES.ADMIN_SET_TIER, // display "add tier" button
   ],
   [IAM_PAGES.TIERS_ADD]: [
     IAM_SCOPES.ADMIN_SET_TIER, // display "add tier" button / shows add service tier page
+    IAM_SCOPES.ADMIN_LIST_TIERS, // display tiers list
   ],
   [IAM_PAGES.TIERS_ADD_SERVICE]: [
     IAM_SCOPES.ADMIN_SET_TIER, // display "add tier" button / shows add service tier page
+    IAM_SCOPES.ADMIN_LIST_TIERS, // display tiers list
   ],
   [IAM_PAGES.TOOLS]: [
     IAM_SCOPES.S3_LISTEN_NOTIFICATIONS, // displays watch notifications

--- a/portal-ui/src/screens/Console/Configurations/TiersConfiguration/ListTiersConfiguration.tsx
+++ b/portal-ui/src/screens/Console/Configurations/TiersConfiguration/ListTiersConfiguration.tsx
@@ -291,20 +291,19 @@ const ListTiersConfiguration = ({ classes }: IListTiersConfig) => {
                     setIsLoading(true);
                   }}
                 />
-
-                <SecureComponent
-                  scopes={[IAM_SCOPES.ADMIN_SET_TIER]}
-                  resource={CONSOLE_UI_RESOURCE}
-                  errorProps={{ disabled: true }}
+                <TooltipWrapper
+                  tooltip={
+                    hasSetTier
+                      ? ""
+                      : "You require additional permissions in order to create a new Tier. Please ask your MinIO administrator to grant you " +
+                        IAM_SCOPES.ADMIN_SET_TIER +
+                        " permission in order to create a Tier."
+                  }
                 >
-                  <TooltipWrapper
-                    tooltip={
-                      hasSetTier
-                        ? ""
-                        : "You require additional permissions in order to create a new Tier. Please ask your MinIO administrator to grant you " +
-                          IAM_SCOPES.ADMIN_SET_TIER +
-                          " permission in order to create a Tier."
-                    }
+                  <SecureComponent
+                    scopes={[IAM_SCOPES.ADMIN_SET_TIER]}
+                    resource={CONSOLE_UI_RESOURCE}
+                    errorProps={{ disabled: true }}
                   >
                     <Button
                       id={"add-tier"}
@@ -312,10 +311,9 @@ const ListTiersConfiguration = ({ classes }: IListTiersConfig) => {
                       label={`Create Tier`}
                       onClick={addTier}
                       variant="callAction"
-                      disabled={!hasSetTier}
                     />
-                  </TooltipWrapper>
-                </SecureComponent>
+                  </SecureComponent>
+                </TooltipWrapper>
               </div>
             </Grid>
             {isLoading && <LinearProgress />}
@@ -466,13 +464,7 @@ const ListTiersConfiguration = ({ classes }: IListTiersConfig) => {
                                 .
                               </div>
                             ) : (
-                              <div>
-                                You require additional permissions in order to
-                                create a new Tier. Please ask your MinIO
-                                administrator to grant you{" "}
-                                <b>{IAM_SCOPES.ADMIN_SET_TIER}</b> permission in
-                                order to create a Tier.
-                              </div>
+                              ""
                             )}
                           </Fragment>
                         }

--- a/portal-ui/src/screens/Console/Configurations/TiersConfiguration/ListTiersConfiguration.tsx
+++ b/portal-ui/src/screens/Console/Configurations/TiersConfiguration/ListTiersConfiguration.tsx
@@ -111,7 +111,9 @@ const ListTiersConfiguration = ({ classes }: IListTiersConfig) => {
     type: "unsupported",
   });
 
-  const hasSetTier = hasPermission(CONSOLE_UI_RESOURCE, [IAM_SCOPES.ADMIN_SET_TIER,])
+  const hasSetTier = hasPermission(CONSOLE_UI_RESOURCE, [
+    IAM_SCOPES.ADMIN_SET_TIER,
+  ]);
 
   useEffect(() => {
     if (isLoading) {
@@ -291,21 +293,27 @@ const ListTiersConfiguration = ({ classes }: IListTiersConfig) => {
                 />
 
                 <SecureComponent
-                  scopes={[
-                    IAM_SCOPES.ADMIN_SET_TIER,
-                  ]}
+                  scopes={[IAM_SCOPES.ADMIN_SET_TIER]}
                   resource={CONSOLE_UI_RESOURCE}
                   errorProps={{ disabled: true }}
                 >
-                  <TooltipWrapper tooltip={hasSetTier ? "" : "You require additional permissions in order to create a new Tier. Please ask your MinIO administrator to grant you " + IAM_SCOPES.ADMIN_SET_TIER +" permission in order to create a Tier."}>
-                  <Button
-                    id={"add-tier"}
-                    icon={<AddIcon />}
-                    label={`Create Tier`}
-                    onClick={addTier}
-                    variant="callAction"
-                    disabled={!hasSetTier}
-                  />
+                  <TooltipWrapper
+                    tooltip={
+                      hasSetTier
+                        ? ""
+                        : "You require additional permissions in order to create a new Tier. Please ask your MinIO administrator to grant you " +
+                          IAM_SCOPES.ADMIN_SET_TIER +
+                          " permission in order to create a Tier."
+                    }
+                  >
+                    <Button
+                      id={"add-tier"}
+                      icon={<AddIcon />}
+                      label={`Create Tier`}
+                      onClick={addTier}
+                      variant="callAction"
+                      disabled={!hasSetTier}
+                    />
                   </TooltipWrapper>
                 </SecureComponent>
               </div>
@@ -451,11 +459,21 @@ const ListTiersConfiguration = ({ classes }: IListTiersConfig) => {
                             tier.
                             <br />
                             <br />
-                            {hasSetTier ?
-                            <div>To get started,{" "}
-                            <AButton onClick={addTier}>Create Tier</AButton>.
-                            </div>
-                            : <div>You require additional permissions in order to create a new Tier. Please ask your MinIO administrator to grant you <b>{IAM_SCOPES.ADMIN_SET_TIER}</b> permission in order to create a Tier.</div>}
+                            {hasSetTier ? (
+                              <div>
+                                To get started,{" "}
+                                <AButton onClick={addTier}>Create Tier</AButton>
+                                .
+                              </div>
+                            ) : (
+                              <div>
+                                You require additional permissions in order to
+                                create a new Tier. Please ask your MinIO
+                                administrator to grant you{" "}
+                                <b>{IAM_SCOPES.ADMIN_SET_TIER}</b> permission in
+                                order to create a Tier.
+                              </div>
+                            )}
                           </Fragment>
                         }
                       />

--- a/portal-ui/src/screens/Console/Configurations/TiersConfiguration/ListTiersConfiguration.tsx
+++ b/portal-ui/src/screens/Console/Configurations/TiersConfiguration/ListTiersConfiguration.tsx
@@ -58,6 +58,8 @@ import { tierTypes } from "./utils";
 import { selDistSet, setErrorSnackMessage } from "../../../../systemSlice";
 import { useNavigate } from "react-router-dom";
 import { useAppDispatch } from "../../../../store";
+import { hasPermission } from "../../../../common/SecureComponent";
+import TooltipWrapper from "../../Common/TooltipWrapper/TooltipWrapper";
 
 const UpdateTierCredentialsModal = withSuspense(
   React.lazy(() => import("./UpdateTierCredentialsModal"))
@@ -108,6 +110,8 @@ const ListTiersConfiguration = ({ classes }: IListTiersConfig) => {
   const [selectedTier, setSelectedTier] = useState<ITierElement>({
     type: "unsupported",
   });
+
+  const hasSetTier = hasPermission(CONSOLE_UI_RESOURCE, [IAM_SCOPES.ADMIN_SET_TIER,])
 
   useEffect(() => {
     if (isLoading) {
@@ -287,17 +291,22 @@ const ListTiersConfiguration = ({ classes }: IListTiersConfig) => {
                 />
 
                 <SecureComponent
-                  scopes={[IAM_SCOPES.ADMIN_SET_TIER]}
+                  scopes={[
+                    IAM_SCOPES.ADMIN_SET_TIER,
+                  ]}
                   resource={CONSOLE_UI_RESOURCE}
                   errorProps={{ disabled: true }}
                 >
+                  <TooltipWrapper tooltip={hasSetTier ? "" : "You require additional permissions in order to create a new Tier. Please ask your MinIO administrator to grant you " + IAM_SCOPES.ADMIN_SET_TIER +" permission in order to create a Tier."}>
                   <Button
                     id={"add-tier"}
                     icon={<AddIcon />}
                     label={`Create Tier`}
                     onClick={addTier}
                     variant="callAction"
+                    disabled={!hasSetTier}
                   />
+                  </TooltipWrapper>
                 </SecureComponent>
               </div>
             </Grid>
@@ -442,8 +451,11 @@ const ListTiersConfiguration = ({ classes }: IListTiersConfig) => {
                             tier.
                             <br />
                             <br />
-                            To get started,{" "}
+                            {hasSetTier ?
+                            <div>To get started,{" "}
                             <AButton onClick={addTier}>Create Tier</AButton>.
+                            </div>
+                            : <div>You require additional permissions in order to create a new Tier. Please ask your MinIO administrator to grant you <b>{IAM_SCOPES.ADMIN_SET_TIER}</b> permission in order to create a Tier.</div>}
                           </Fragment>
                         }
                       />


### PR DESCRIPTION
Fixes incorrect UI for users with standalone admin:SetTier or admin:ListTier permissions:
- Tiers tab no longer on Menu if admin:ListTier not enabled
- Helpbox on empty Tiers landing screen prompts user with only admin:ListTier permission to enable  admin:SetTier
- Create Tier button disabled if admin:SetTier not enabled , tooltip advising how to configure permissions
<img width="812" alt="Screen Shot 2022-09-14 at 12 35 15 PM" src="https://user-images.githubusercontent.com/65002498/190248631-dab40945-7962-46b8-b193-757065c85940.png">
