### PR TITLE
To add missing file for coverage

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -85,6 +85,13 @@ jobs:
             ./replication/coverage/
           key: ${{ runner.os }}-replication-coverage-2-${{ github.run_id }}
 
+      # To save our replication.out file into an artifact.
+      # By default, GitHub stores build logs and artifacts for 90 days.
+      - uses: actions/upload-artifact@v3
+        with:
+          name: replication-artifact
+          path: ./replication/coverage/replication.out
+
   sso-integration:
 
     name: SSO Integration Test
@@ -1806,6 +1813,12 @@ jobs:
           path: |
             ./pkg/coverage/
           key: ${{ runner.os }}-coverage-pkg-2-${{ github.run_id }}
+
+      # Get the replication.out file from the artifact since this is working for self host runner.
+      - uses: actions/download-artifact@v3
+        with:
+          name: replication-artifact
+          path: replication/coverage
 
       - name: Get coverage
         run: |


### PR DESCRIPTION
### Objective:

Since we moved Site Replication Test to self host runner, our file was no longer replicated and coverage test was failing.
One way I found to fix it, it is by saving our coverage file into an artifact.
The good thing about it, is that by default artifact is only saved for 90 days, so we don't need to worry for the deletion.

<img width="510" alt="Screen Shot 2022-09-15 at 7 24 01 PM" src="https://user-images.githubusercontent.com/6667358/190525506-1d890e38-379e-4eaf-9352-a78a59310713.png">


```console
Result:
53.9%
It is equal or greater than threshold (53.40%), passed!
```