### PR TITLE
Fix: Labels for Node Selector in Pod Placement

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Affinity.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Affinity.tsx
@@ -417,25 +417,25 @@ const Affinity = ({ classes }: IAffinityProps) => {
 
                               dispatch(setKeyValuePairs(arrCp));
                             }}
+                            disabled={i !== keyValuePairs.length - 1}
                           >
                             <AddIcon />
                           </IconButton>
                         </div>
-                        {keyValuePairs.length > 1 && (
-                          <div className={classes.overlayAction}>
-                            <IconButton
-                              size={"small"}
-                              onClick={() => {
-                                const arrCp = keyValuePairs.filter(
-                                  (item, index) => index !== i
-                                );
-                                dispatch(setKeyValuePairs(arrCp));
-                              }}
-                            >
-                              <RemoveIcon />
-                            </IconButton>
-                          </div>
-                        )}
+                        <div className={classes.overlayAction}>
+                          <IconButton
+                            size={"small"}
+                            onClick={() => {
+                              const arrCp = keyValuePairs.filter(
+                                (item, index) => index !== i
+                              );
+                              dispatch(setKeyValuePairs(arrCp));
+                            }}
+                            disabled={keyValuePairs.length <= 1}
+                          >
+                            <RemoveIcon />
+                          </IconButton>
+                        </div>
                       </Grid>
                     </Grid>
                   );


### PR DESCRIPTION
Enabling/disabling buttons correctly in pod placement > labels to be consistent with all other screens in the application

![Screenshot from 2022-09-15 17-20-39](https://user-images.githubusercontent.com/1795553/190530795-992c6f44-d7a3-43c1-ad12-66a1f834bfc7.png)
![Screenshot from 2022-09-15 17-20-55](https://user-images.githubusercontent.com/1795553/190530797-624d32ca-5c45-41ff-b312-1dd31956d405.png)


Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>