### PR TITLE
Fix oauth state generation for OIDC login

### DIFF
--- a/operatorapi/login.go
+++ b/operatorapi/login.go
@@ -111,7 +111,10 @@ func getLoginDetailsResponse(params authApi.LoginDetailParams) (*models.LoginDet
 			return nil, restapi.ErrorWithContext(ctx, err)
 		}
 		// Validate user against IDP
-		identityProvider := &auth.IdentityProvider{Client: oauth2Client}
+		identityProvider := &auth.IdentityProvider{
+			KeyFunc: oauth2.DefaultDerivedKey,
+			Client:  oauth2Client,
+		}
 		redirectURL = append(redirectURL, identityProvider.GenerateLoginURL())
 	}
 
@@ -146,7 +149,10 @@ func getLoginOauth2AuthResponse(params authApi.LoginOauth2AuthParams) (*models.L
 			return nil, restapi.ErrorWithContext(ctx, err)
 		}
 		// initialize new identity provider
-		identityProvider := auth.IdentityProvider{Client: oauth2Client}
+		identityProvider := auth.IdentityProvider{
+			KeyFunc: oauth2.DefaultDerivedKey,
+			Client:  oauth2Client,
+		}
 		// Validate user against IDP
 		_, err = verifyUserAgainstIDP(ctx, identityProvider, *lr.Code, *lr.State)
 		if err != nil {

--- a/pkg/auth/idp.go
+++ b/pkg/auth/idp.go
@@ -38,20 +38,21 @@ type IdentityProviderI interface {
 // Define the structure of a IdentityProvider with Client inside and define the functions that are used
 // during the authentication flow.
 type IdentityProvider struct {
-	Client *oauth2.Provider
+	KeyFunc oauth2.StateKeyFunc
+	Client  *oauth2.Provider
 }
 
 // VerifyIdentity will verify the user identity against the idp using the authorization code flow
 func (c IdentityProvider) VerifyIdentity(ctx context.Context, code, state string) (*credentials.Credentials, error) {
-	return c.Client.VerifyIdentity(ctx, code, state)
+	return c.Client.VerifyIdentity(ctx, code, state, c.KeyFunc)
 }
 
 // VerifyIdentityForOperator will verify the user identity against the idp using the authorization code flow
 func (c IdentityProvider) VerifyIdentityForOperator(ctx context.Context, code, state string) (*xoauth2.Token, error) {
-	return c.Client.VerifyIdentityForOperator(ctx, code, state)
+	return c.Client.VerifyIdentityForOperator(ctx, code, state, c.KeyFunc)
 }
 
 // GenerateLoginURL returns a new URL used by the user to login against the idp
 func (c IdentityProvider) GenerateLoginURL() string {
-	return c.Client.GenerateLoginURL()
+	return c.Client.GenerateLoginURL(c.KeyFunc)
 }

--- a/pkg/auth/idp/oauth2/config.go
+++ b/pkg/auth/idp/oauth2/config.go
@@ -19,10 +19,12 @@
 package oauth2
 
 import (
+	"crypto/sha1"
 	"strings"
 
 	"github.com/minio/console/pkg/auth/utils"
 	"github.com/minio/pkg/env"
+	"golang.org/x/crypto/pbkdf2"
 )
 
 // ProviderConfig - OpenID IDP Configuration for console.
@@ -35,6 +37,14 @@ type ProviderConfig struct {
 	Userinfo                 bool
 	RedirectCallbackDynamic  bool
 	RedirectCallback         string
+}
+
+// GetStateKeyFunc - return the key function used to generate the authorization
+// code flow state parameter.
+func (pc ProviderConfig) GetStateKeyFunc() StateKeyFunc {
+	return func() []byte {
+		return pbkdf2.Key([]byte(pc.HMACPassphrase), []byte(pc.HMACSalt), 4096, 32, sha1.New)
+	}
 }
 
 type OpenIDPCfg map[string]ProviderConfig

--- a/pkg/auth/idp/oauth2/provider_test.go
+++ b/pkg/auth/idp/oauth2/provider_test.go
@@ -66,6 +66,6 @@ func TestGenerateLoginURL(t *testing.T) {
 		// a non-empty string
 		return state
 	}
-	url := oauth2Provider.GenerateLoginURL()
+	url := oauth2Provider.GenerateLoginURL(DefaultDerivedKey)
 	funcAssert.NotEqual("", url)
 }

--- a/restapi/user_login.go
+++ b/restapi/user_login.go
@@ -162,7 +162,10 @@ func getLoginDetailsResponse(params authApi.LoginDetailParams, openIDProviders o
 				return nil, ErrorWithContext(ctx, err, ErrOauth2Provider)
 			}
 			// Validate user against IDP
-			identityProvider := &auth.IdentityProvider{Client: oauth2Client}
+			identityProvider := &auth.IdentityProvider{
+				KeyFunc: provider.GetStateKeyFunc(),
+				Client:  oauth2Client,
+			}
 			redirectURL = append(redirectURL, identityProvider.GenerateLoginURL())
 			if provider.DisplayName != "" {
 				displayNames = append(displayNames, provider.DisplayName)
@@ -201,7 +204,10 @@ func getLoginOauth2AuthResponse(params authApi.LoginOauth2AuthParams, openIDProv
 			return nil, ErrorWithContext(ctx, err)
 		}
 		// initialize new identity provider
-		identityProvider := auth.IdentityProvider{Client: oauth2Client}
+		identityProvider := auth.IdentityProvider{
+			KeyFunc: openIDProviders[idpName].GetStateKeyFunc(),
+			Client:  oauth2Client,
+		}
 		// Validate user against IDP
 		userCredentials, err := verifyUserAgainstIDP(ctx, identityProvider, *lr.Code, *lr.State)
 		if err != nil {


### PR DESCRIPTION
This is a regression from 118cf97e1d2313fe67839210706c45fcb5ed4e1d when env var support for passing console configuration from MinIO was removed.

This change ensures that all MinIO nodes in a cluster are able to verify state tokens generated by other nodes in the cluster. Without this, it is necessary to use sticky sessions in a loadbalancer to ensure that OIDC authorization code login flow steps for a client happens on the same minio node.

Fixes https://github.com/minio/minio/issues/15527