### PR TITLE
Add support for manual edit of KES configuration file

### DIFF
--- a/models/encryption_configuration.go
+++ b/models/encryption_configuration.go
@@ -54,6 +54,9 @@ type EncryptionConfiguration struct {
 	// image
 	Image string `json:"image,omitempty"`
 
+	// raw
+	Raw string `json:"raw,omitempty"`
+
 	// replicas
 	Replicas string `json:"replicas,omitempty"`
 
@@ -93,6 +96,8 @@ func (m *EncryptionConfiguration) UnmarshalJSON(raw []byte) error {
 
 		Image string `json:"image,omitempty"`
 
+		Raw string `json:"raw,omitempty"`
+
 		Replicas string `json:"replicas,omitempty"`
 
 		SecretsToBeDeleted []string `json:"secretsToBeDeleted"`
@@ -118,6 +123,8 @@ func (m *EncryptionConfiguration) UnmarshalJSON(raw []byte) error {
 	m.Gemalto = dataAO1.Gemalto
 
 	m.Image = dataAO1.Image
+
+	m.Raw = dataAO1.Raw
 
 	m.Replicas = dataAO1.Replicas
 
@@ -154,6 +161,8 @@ func (m EncryptionConfiguration) MarshalJSON() ([]byte, error) {
 
 		Image string `json:"image,omitempty"`
 
+		Raw string `json:"raw,omitempty"`
+
 		Replicas string `json:"replicas,omitempty"`
 
 		SecretsToBeDeleted []string `json:"secretsToBeDeleted"`
@@ -176,6 +185,8 @@ func (m EncryptionConfiguration) MarshalJSON() ([]byte, error) {
 	dataAO1.Gemalto = m.Gemalto
 
 	dataAO1.Image = m.Image
+
+	dataAO1.Raw = m.Raw
 
 	dataAO1.Replicas = m.Replicas
 

--- a/models/encryption_configuration_response.go
+++ b/models/encryption_configuration_response.go
@@ -54,6 +54,9 @@ type EncryptionConfigurationResponse struct {
 	// mtls client
 	MtlsClient *CertificateInfo `json:"mtls_client,omitempty"`
 
+	// raw
+	Raw string `json:"raw,omitempty"`
+
 	// replicas
 	Replicas string `json:"replicas,omitempty"`
 
@@ -90,6 +93,8 @@ func (m *EncryptionConfigurationResponse) UnmarshalJSON(raw []byte) error {
 
 		MtlsClient *CertificateInfo `json:"mtls_client,omitempty"`
 
+		Raw string `json:"raw,omitempty"`
+
 		Replicas string `json:"replicas,omitempty"`
 
 		SecurityContext *SecurityContext `json:"securityContext,omitempty"`
@@ -113,6 +118,8 @@ func (m *EncryptionConfigurationResponse) UnmarshalJSON(raw []byte) error {
 	m.Image = dataAO1.Image
 
 	m.MtlsClient = dataAO1.MtlsClient
+
+	m.Raw = dataAO1.Raw
 
 	m.Replicas = dataAO1.Replicas
 
@@ -147,6 +154,8 @@ func (m EncryptionConfigurationResponse) MarshalJSON() ([]byte, error) {
 
 		MtlsClient *CertificateInfo `json:"mtls_client,omitempty"`
 
+		Raw string `json:"raw,omitempty"`
+
 		Replicas string `json:"replicas,omitempty"`
 
 		SecurityContext *SecurityContext `json:"securityContext,omitempty"`
@@ -167,6 +176,8 @@ func (m EncryptionConfigurationResponse) MarshalJSON() ([]byte, error) {
 	dataAO1.Image = m.Image
 
 	dataAO1.MtlsClient = m.MtlsClient
+
+	dataAO1.Raw = m.Raw
 
 	dataAO1.Replicas = m.Replicas
 

--- a/operatorapi/embedded_spec.go
+++ b/operatorapi/embedded_spec.go
@@ -3060,6 +3060,9 @@ func init() {
             "image": {
               "type": "string"
             },
+            "raw": {
+              "type": "string"
+            },
             "replicas": {
               "type": "string"
             },
@@ -3115,6 +3118,9 @@ func init() {
             "mtls_client": {
               "type": "object",
               "$ref": "#/definitions/certificateInfo"
+            },
+            "raw": {
+              "type": "string"
             },
             "replicas": {
               "type": "string"
@@ -9126,6 +9132,9 @@ func init() {
             "image": {
               "type": "string"
             },
+            "raw": {
+              "type": "string"
+            },
             "replicas": {
               "type": "string"
             },
@@ -9181,6 +9190,9 @@ func init() {
             "mtls_client": {
               "type": "object",
               "$ref": "#/definitions/certificateInfo"
+            },
+            "raw": {
+              "type": "string"
             },
             "replicas": {
               "type": "string"

--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Encryption.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Encryption.tsx
@@ -51,6 +51,9 @@ import GCPKMSAdd from "./Encryption/GCPKMSAdd";
 import GemaltoKMSAdd from "./Encryption/GemaltoKMSAdd";
 import AWSKMSAdd from "./Encryption/AWSKMSAdd";
 import SelectWrapper from "../../../Common/FormComponents/SelectWrapper/SelectWrapper";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import CodeMirrorWrapper from "../../../Common/FormComponents/CodeMirrorWrapper/CodeMirrorWrapper";
 
 interface IEncryptionProps {
   classes: any;
@@ -87,6 +90,12 @@ const Encryption = ({ classes }: IEncryptionProps) => {
 
   const replicas = useSelector(
     (state: AppState) => state.createTenant.fields.encryption.replicas
+  );
+  const rawConfiguration = useSelector(
+    (state: AppState) => state.createTenant.fields.encryption.rawConfiguration
+  );
+  const encryptionTab = useSelector(
+    (state: AppState) => state.createTenant.fields.encryption.encryptionTab
   );
   const enableEncryption = useSelector(
     (state: AppState) => state.createTenant.fields.encryption.enableEncryption
@@ -176,6 +185,11 @@ const Encryption = ({ classes }: IEncryptionProps) => {
       encryptionValidation = [
         ...encryptionValidation,
         {
+          fieldKey: "rawConfiguration",
+          required: encryptionTab > 0,
+          value: rawConfiguration,
+        },
+        {
           fieldKey: "replicas",
           required: true,
           value: replicas,
@@ -239,7 +253,6 @@ const Encryption = ({ classes }: IEncryptionProps) => {
     }
 
     const commonVal = commonFormValidation(encryptionValidation);
-
     dispatch(
       isPageValid({
         pageName: "encryption",
@@ -249,6 +262,8 @@ const Encryption = ({ classes }: IEncryptionProps) => {
 
     setValidationErrors(commonVal);
   }, [
+    rawConfiguration,
+    encryptionTab,
     enableEncryption,
     encryptionType,
     gcpProjectID,
@@ -309,29 +324,64 @@ const Encryption = ({ classes }: IEncryptionProps) => {
 
         {enableEncryption && (
           <Fragment>
-            <Grid item xs={12} className={classes.encryptionTypeOptions}>
-              <RadioGroupSelector
-                currentSelection={encryptionType}
-                id="encryptionType"
-                name="encryptionType"
-                label="Encryption Options"
-                onChange={(e) => {
-                  updateField("encryptionType", e.target.value);
+            <Grid item xs={12}>
+              <Tabs
+                value={encryptionTab}
+                onChange={(e: React.ChangeEvent<{}>, value: number) => {
+                  updateField("encryptionTab", value);
                 }}
-                selectorOptions={[
-                  { label: "Vault", value: "vault" },
-                  { label: "AWS", value: "aws" },
-                  { label: "Gemalto", value: "gemalto" },
-                  { label: "GCP", value: "gcp" },
-                  { label: "Azure", value: "azure" },
-                ]}
-              />
+                indicatorColor="primary"
+                textColor="primary"
+                aria-label="cluster-tabs"
+                variant="scrollable"
+                scrollButtons="auto"
+              >
+                <Tab id="kms-options" label="Options" />
+                <Tab id="kms-raw-configuration" label="Raw Edit" />
+              </Tabs>
             </Grid>
-            {encryptionType === "vault" && <VaultKMSAdd />}
-            {encryptionType === "azure" && <AzureKMSAdd />}
-            {encryptionType === "gcp" && <GCPKMSAdd />}
-            {encryptionType === "aws" && <AWSKMSAdd />}
-            {encryptionType === "gemalto" && <GemaltoKMSAdd />}
+
+            {encryptionTab ? (
+              <Fragment>
+                <Grid item xs={12}>
+                  <CodeMirrorWrapper
+                    value={rawConfiguration}
+                    mode={"yaml"}
+                    onBeforeChange={(editor, data, value) => {
+                      updateField("rawConfiguration", value);
+                    }}
+                    editorHeight={"550px"}
+                  />
+                </Grid>
+              </Fragment>
+            ) : (
+              <Fragment>
+                <Grid item xs={12} className={classes.encryptionTypeOptions}>
+                  <RadioGroupSelector
+                    currentSelection={encryptionType}
+                    id="encryptionType"
+                    name="encryptionType"
+                    label="KMS"
+                    onChange={(e) => {
+                      updateField("encryptionType", e.target.value);
+                    }}
+                    selectorOptions={[
+                      { label: "Vault", value: "vault" },
+                      { label: "AWS", value: "aws" },
+                      { label: "Gemalto", value: "gemalto" },
+                      { label: "GCP", value: "gcp" },
+                      { label: "Azure", value: "azure" },
+                    ]}
+                  />
+                </Grid>
+                {encryptionType === "vault" && <VaultKMSAdd />}
+                {encryptionType === "azure" && <AzureKMSAdd />}
+                {encryptionType === "gcp" && <GCPKMSAdd />}
+                {encryptionType === "aws" && <AWSKMSAdd />}
+                {encryptionType === "gemalto" && <GemaltoKMSAdd />}
+              </Fragment>
+            )}
+
             <div className={classes.headerElement}>
               <h4 className={classes.h3Section}>Additional Configurations</h4>
             </div>

--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Encryption/AWSKMSAdd.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Encryption/AWSKMSAdd.tsx
@@ -48,6 +48,9 @@ const AWSKMSAdd = () => {
   const dispatch = useAppDispatch();
   const classes = useStyles();
 
+  const encryptionTab = useSelector(
+    (state: AppState) => state.createTenant.fields.encryption.encryptionTab
+  );
   const awsEndpoint = useSelector(
     (state: AppState) => state.createTenant.fields.encryption.awsEndpoint
   );
@@ -72,29 +75,31 @@ const AWSKMSAdd = () => {
   useEffect(() => {
     let encryptionValidation: IValidation[] = [];
 
-    encryptionValidation = [
-      ...encryptionValidation,
-      {
-        fieldKey: "aws_endpoint",
-        required: true,
-        value: awsEndpoint,
-      },
-      {
-        fieldKey: "aws_region",
-        required: true,
-        value: awsRegion,
-      },
-      {
-        fieldKey: "aws_accessKey",
-        required: true,
-        value: awsAccessKey,
-      },
-      {
-        fieldKey: "aws_secretKey",
-        required: true,
-        value: awsSecretKey,
-      },
-    ];
+    if (!encryptionTab) {
+      encryptionValidation = [
+        ...encryptionValidation,
+        {
+          fieldKey: "aws_endpoint",
+          required: true,
+          value: awsEndpoint,
+        },
+        {
+          fieldKey: "aws_region",
+          required: true,
+          value: awsRegion,
+        },
+        {
+          fieldKey: "aws_accessKey",
+          required: true,
+          value: awsAccessKey,
+        },
+        {
+          fieldKey: "aws_secretKey",
+          required: true,
+          value: awsSecretKey,
+        },
+      ];
+    }
 
     const commonVal = commonFormValidation(encryptionValidation);
 
@@ -106,7 +111,14 @@ const AWSKMSAdd = () => {
     );
 
     setValidationErrors(commonVal);
-  }, [awsEndpoint, awsRegion, awsSecretKey, awsAccessKey, dispatch]);
+  }, [
+    encryptionTab,
+    awsEndpoint,
+    awsRegion,
+    awsSecretKey,
+    awsAccessKey,
+    dispatch,
+  ]);
 
   // Common
   const updateField = useCallback(

--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Encryption/AzureKMSAdd.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Encryption/AzureKMSAdd.tsx
@@ -48,6 +48,9 @@ const AzureKMSAdd = () => {
   const dispatch = useAppDispatch();
   const classes = useStyles();
 
+  const encryptionTab = useSelector(
+    (state: AppState) => state.createTenant.fields.encryption.encryptionTab
+  );
   const azureEndpoint = useSelector(
     (state: AppState) => state.createTenant.fields.encryption.azureEndpoint
   );
@@ -67,29 +70,31 @@ const AzureKMSAdd = () => {
   useEffect(() => {
     let encryptionValidation: IValidation[] = [];
 
-    encryptionValidation = [
-      ...encryptionValidation,
-      {
-        fieldKey: "azure_endpoint",
-        required: true,
-        value: azureEndpoint,
-      },
-      {
-        fieldKey: "azure_tenant_id",
-        required: true,
-        value: azureTenantID,
-      },
-      {
-        fieldKey: "azure_client_id",
-        required: true,
-        value: azureClientID,
-      },
-      {
-        fieldKey: "azure_client_secret",
-        required: true,
-        value: azureClientSecret,
-      },
-    ];
+    if (!encryptionTab) {
+      encryptionValidation = [
+        ...encryptionValidation,
+        {
+          fieldKey: "azure_endpoint",
+          required: true,
+          value: azureEndpoint,
+        },
+        {
+          fieldKey: "azure_tenant_id",
+          required: true,
+          value: azureTenantID,
+        },
+        {
+          fieldKey: "azure_client_id",
+          required: true,
+          value: azureClientID,
+        },
+        {
+          fieldKey: "azure_client_secret",
+          required: true,
+          value: azureClientSecret,
+        },
+      ];
+    }
 
     const commonVal = commonFormValidation(encryptionValidation);
 
@@ -102,6 +107,7 @@ const AzureKMSAdd = () => {
 
     setValidationErrors(commonVal);
   }, [
+    encryptionTab,
     azureEndpoint,
     azureTenantID,
     azureClientID,

--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Encryption/GemaltoKMSAdd.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Encryption/GemaltoKMSAdd.tsx
@@ -53,6 +53,9 @@ const GemaltoKMSAdd = () => {
   const dispatch = useAppDispatch();
   const classes = useStyles();
 
+  const encryptionTab = useSelector(
+    (state: AppState) => state.createTenant.fields.encryption.encryptionTab
+  );
   const gemaltoCA = useSelector(
     (state: AppState) => state.createTenant.certificates.gemaltoCA
   );
@@ -75,31 +78,33 @@ const GemaltoKMSAdd = () => {
   useEffect(() => {
     let encryptionValidation: IValidation[] = [];
 
-    encryptionValidation = [
-      ...encryptionValidation,
-      {
-        fieldKey: "gemalto_endpoint",
-        required: true,
-        value: gemaltoEndpoint,
-      },
-      {
-        fieldKey: "gemalto_token",
-        required: true,
-        value: gemaltoToken,
-      },
-      {
-        fieldKey: "gemalto_domain",
-        required: true,
-        value: gemaltoDomain,
-      },
-      {
-        fieldKey: "gemalto_retry",
-        required: false,
-        value: gemaltoRetry,
-        customValidation: parseInt(gemaltoRetry) < 0,
-        customValidationMessage: "Value needs to be 0 or greater",
-      },
-    ];
+    if (!encryptionTab) {
+      encryptionValidation = [
+        ...encryptionValidation,
+        {
+          fieldKey: "gemalto_endpoint",
+          required: true,
+          value: gemaltoEndpoint,
+        },
+        {
+          fieldKey: "gemalto_token",
+          required: true,
+          value: gemaltoToken,
+        },
+        {
+          fieldKey: "gemalto_domain",
+          required: true,
+          value: gemaltoDomain,
+        },
+        {
+          fieldKey: "gemalto_retry",
+          required: false,
+          value: gemaltoRetry,
+          customValidation: parseInt(gemaltoRetry) < 0,
+          customValidationMessage: "Value needs to be 0 or greater",
+        },
+      ];
+    }
 
     const commonVal = commonFormValidation(encryptionValidation);
 
@@ -111,7 +116,14 @@ const GemaltoKMSAdd = () => {
     );
 
     setValidationErrors(commonVal);
-  }, [gemaltoEndpoint, gemaltoToken, gemaltoDomain, gemaltoRetry, dispatch]);
+  }, [
+    encryptionTab,
+    gemaltoEndpoint,
+    gemaltoToken,
+    gemaltoDomain,
+    gemaltoRetry,
+    dispatch,
+  ]);
 
   // Common
   const updateField = useCallback(

--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Encryption/VaultKMSAdd.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/Encryption/VaultKMSAdd.tsx
@@ -55,6 +55,9 @@ const VaultKMSAdd = () => {
   const dispatch = useAppDispatch();
   const classes = useStyles();
 
+  const encryptionTab = useSelector(
+    (state: AppState) => state.createTenant.fields.encryption.encryptionTab
+  );
   const vaultEndpoint = useSelector(
     (state: AppState) => state.createTenant.fields.encryption.vaultEndpoint
   );
@@ -95,38 +98,40 @@ const VaultKMSAdd = () => {
   useEffect(() => {
     let encryptionValidation: IValidation[] = [];
 
-    encryptionValidation = [
-      ...encryptionValidation,
-      {
-        fieldKey: "vault_endpoint",
-        required: true,
-        value: vaultEndpoint,
-      },
-      {
-        fieldKey: "vault_id",
-        required: true,
-        value: vaultId,
-      },
-      {
-        fieldKey: "vault_secret",
-        required: true,
-        value: vaultSecret,
-      },
-      {
-        fieldKey: "vault_ping",
-        required: false,
-        value: vaultPing,
-        customValidation: parseInt(vaultPing) < 0,
-        customValidationMessage: "Value needs to be 0 or greater",
-      },
-      {
-        fieldKey: "vault_retry",
-        required: false,
-        value: vaultRetry,
-        customValidation: parseInt(vaultRetry) < 0,
-        customValidationMessage: "Value needs to be 0 or greater",
-      },
-    ];
+    if (!encryptionTab) {
+      encryptionValidation = [
+        ...encryptionValidation,
+        {
+          fieldKey: "vault_endpoint",
+          required: true,
+          value: vaultEndpoint,
+        },
+        {
+          fieldKey: "vault_id",
+          required: true,
+          value: vaultId,
+        },
+        {
+          fieldKey: "vault_secret",
+          required: true,
+          value: vaultSecret,
+        },
+        {
+          fieldKey: "vault_ping",
+          required: false,
+          value: vaultPing,
+          customValidation: parseInt(vaultPing) < 0,
+          customValidationMessage: "Value needs to be 0 or greater",
+        },
+        {
+          fieldKey: "vault_retry",
+          required: false,
+          value: vaultRetry,
+          customValidation: parseInt(vaultRetry) < 0,
+          customValidationMessage: "Value needs to be 0 or greater",
+        },
+      ];
+    }
 
     const commonVal = commonFormValidation(encryptionValidation);
 
@@ -139,6 +144,7 @@ const VaultKMSAdd = () => {
 
     setValidationErrors(commonVal);
   }, [
+    encryptionTab,
     vaultEndpoint,
     vaultEngine,
     vaultId,

--- a/portal-ui/src/screens/Console/Tenants/AddTenant/createTenantSlice.ts
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/createTenantSlice.ts
@@ -180,6 +180,8 @@ const initialState: ICreateTenant = {
       enableTLS: true,
     },
     encryption: {
+      rawConfiguration: "",
+      encryptionTab: 0,
       enableEncryption: false,
       encryptionType: "vault",
       gemaltoEndpoint: "",

--- a/portal-ui/src/screens/Console/Tenants/AddTenant/thunks/createTenantThunk.ts
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/thunks/createTenantThunk.ts
@@ -70,6 +70,8 @@ export const createTenantAsync = createAsyncThunk(
     const vaultCertificate = certificates.vaultCertificate;
     const vaultCA = certificates.vaultCA;
     const gemaltoCA = certificates.gemaltoCA;
+    const rawConfiguration = fields.encryption.rawConfiguration;
+    const encryptionTab = fields.encryption.encryptionTab;
     const enableEncryption = fields.encryption.enableEncryption;
     const encryptionType = fields.encryption.encryptionType;
     const gemaltoEndpoint = fields.encryption.gemaltoEndpoint;
@@ -490,6 +492,7 @@ export const createTenantAsync = createAsyncThunk(
       dataSend = {
         ...dataSend,
         encryption: {
+          raw: encryptionTab ? rawConfiguration : "",
           replicas: kesReplicas,
           securityContext: kesSecurityContext,
           image: kesImage,

--- a/portal-ui/src/screens/Console/Tenants/types.ts
+++ b/portal-ui/src/screens/Console/Tenants/types.ts
@@ -96,6 +96,7 @@ export interface IGemaltoConfiguration {
 }
 
 export interface ITenantEncryptionResponse {
+  raw: string;
   image: string;
   replicas: string;
   securityContext: ISecurityContext;
@@ -219,6 +220,8 @@ export interface ISecurityFields {
 }
 
 export interface IEncryptionFields {
+  rawConfiguration: string;
+  encryptionTab: number;
   enableEncryption: boolean;
   encryptionType: string;
   gemaltoEndpoint: string;

--- a/restapi/errors.go
+++ b/restapi/errors.go
@@ -162,6 +162,10 @@ func ErrorWithContext(ctx context.Context, err ...interface{}) *models.Error {
 				errorCode = 404
 				errorMessage = ErrSSENotConfigured.Error()
 			}
+			if errors.Is(err1, ErrEncryptionConfigNotFound) {
+				errorCode = 404
+				errorMessage = err1.Error()
+			}
 			// account change password
 			if errors.Is(err1, ErrChangePassword) {
 				errorCode = 403

--- a/restapi/errors_test.go
+++ b/restapi/errors_test.go
@@ -82,7 +82,7 @@ func TestError(t *testing.T) {
 		"ErrUnableToUpdateTenantCertificates": {code: 500, err: ErrUnableToUpdateTenantCertificates},
 		"ErrUpdatingEncryptionConfig":         {code: 500, err: ErrUpdatingEncryptionConfig},
 		"ErrDeletingEncryptionConfig":         {code: 500, err: ErrDeletingEncryptionConfig},
-		"ErrEncryptionConfigNotFound":         {code: 500, err: ErrEncryptionConfigNotFound},
+		"ErrEncryptionConfigNotFound":         {code: 404, err: ErrEncryptionConfigNotFound},
 	}
 
 	for k, e := range appErrors {

--- a/swagger-operator.yml
+++ b/swagger-operator.yml
@@ -2233,6 +2233,8 @@ definitions:
       - $ref: "#/definitions/metadataFields"
       - type: object
         properties:
+          raw:
+            type: string
           image:
             type: string
           replicas:
@@ -2271,6 +2273,8 @@ definitions:
       - $ref: "#/definitions/metadataFields"
       - type: object
         properties:
+          raw:
+            type: string
           image:
             type: string
           replicas:


### PR DESCRIPTION
This PR adds the raw edit tab for the `Encryption` configuration of a tenant. Newest versions of KES add support to additional customization and variables via the KES `server-config.yaml`

## Create Tenant

![Screenshot from 2022-10-03 17-57-47](https://user-images.githubusercontent.com/1795553/193716022-d0400768-c747-4e35-b244-294169cffc3a.png)

## Update Tenant

![Screenshot from 2022-10-03 17-57-04](https://user-images.githubusercontent.com/1795553/193716037-ba93fb5f-b00f-4d1e-90de-86fcbfcdb520.png)
![Screenshot from 2022-10-03 17-57-19](https://user-images.githubusercontent.com/1795553/193716041-e8bc894e-cc95-46ef-a7cf-b00b83ff316f.png)
![Screenshot from 2022-10-06 17-05-49](https://user-images.githubusercontent.com/1795553/194441858-480302ab-dffb-4c76-a6e4-d64c624a60c0.png)



Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>