### PR TITLE
do not log random errors using Go logger

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,24 +14,19 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - typecheck
     - goimports
     - misspell
     - govet
     - revive
     - ineffassign
     - gosimple
-    - deadcode
-    - structcheck
     - gomodguard
     - gofmt
     - unused
-    - structcheck
     - unconvert
     - varcheck
     - gocritic
     - gofumpt
-    - tenv
     - durationcheck
 
 service:

--- a/pkg/subnet/subnet.go
+++ b/pkg/subnet/subnet.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/minio/console/pkg/http"
 
@@ -150,7 +149,6 @@ func ParseLicense(client http.ClientI, license string) (*licverifier.LicenseInfo
 
 	subnetPubKey, err := downloadSubnetPublicKey(client)
 	if err != nil {
-		log.Print(err)
 		// there was an issue getting the subnet public key
 		// use hardcoded public keys instead
 		publicKeys = OfflinePublicKeys

--- a/restapi/configure_console.go
+++ b/restapi/configure_console.go
@@ -372,20 +372,23 @@ func handleSPA(w http.ResponseWriter, r *http.Request) {
 		sf.ObjectBrowser = true
 
 		err := ValidateEncodedStyles(overridenStyles)
-
 		if err != nil {
-			log.Println(err)
-		} else {
-			sf.CustomStyleOB = overridenStyles
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
+
+		sf.CustomStyleOB = overridenStyles
 
 		sessionID, err := login(consoleCreds, sf)
 		if err != nil {
-			log.Println(err)
-		} else {
-			cookie := NewSessionCookieForConsole(*sessionID)
-			http.SetCookie(w, &cookie)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
+
+		cookie := NewSessionCookieForConsole(*sessionID)
+
+		http.SetCookie(w, &cookie)
+
 		// Allow us to be iframed
 		w.Header().Del("X-Frame-Options")
 	}


### PR DESCRIPTION
we need to make sure that we print in consistent
format for the logs, remove the unnecessary logs
everywhere used via `log.Print*`