### PR TITLE
Fixed edit yaml buttons position

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantYAML.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantYAML.tsx
@@ -152,7 +152,7 @@ const TenantYAML = ({ classes }: ITenantYAMLProps) => {
                 editorHeight={"550px"}
               />
             </Grid>
-            <Grid item xs={12} style={{ textAlign: "right", paddingTop: 16 }}>
+            <Grid item xs={12} style={{ display: "flex", justifyContent: "flex-end", paddingTop: 16 }}>
               <Button
                 id={"cancel-tenant-yaml"}
                 type="button"


### PR DESCRIPTION
## What does this do?

Fixes the position of save buttons in edit tenant YAML screen

## How does it look?
<img width="1442" alt="Screen Shot 2022-10-05 at 21 48 08" src="https://user-images.githubusercontent.com/33497058/194203074-cd363ff4-02fd-4f60-ab52-6daca1d0fab5.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>