### PR TITLE
Removed position fixed to tenant size preview

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/NameTenantMain.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/NameTenantMain.tsx
@@ -45,7 +45,6 @@ import NamespaceSelector from "./NamespaceSelector";
 const styles = (theme: Theme) =>
   createStyles({
     sizePreview: {
-      position: "fixed",
       marginLeft: 10,
       background: "#FFFFFF",
       border: "1px solid #EAEAEA",

--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantYAML.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/TenantYAML.tsx
@@ -152,7 +152,15 @@ const TenantYAML = ({ classes }: ITenantYAMLProps) => {
                 editorHeight={"550px"}
               />
             </Grid>
-            <Grid item xs={12} style={{ display: "flex", justifyContent: "flex-end", paddingTop: 16 }}>
+            <Grid
+              item
+              xs={12}
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                paddingTop: 16,
+              }}
+            >
               <Button
                 id={"cancel-tenant-yaml"}
                 type="button"


### PR DESCRIPTION
## What does this do?

Removed position fixed to tenant size preview to avoid overlap of create buttons

## How does it look?
<img width="1698" alt="Screen Shot 2022-10-05 at 22 15 12" src="https://user-images.githubusercontent.com/33497058/194206392-62718458-7417-4a01-a2e0-219d22a25483.png">



Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>