### PR TITLE
Add Role ARN as part of OIDC provider

### DIFF
--- a/pkg/auth/idp/oauth2/config.go
+++ b/pkg/auth/idp/oauth2/config.go
@@ -37,6 +37,7 @@ type ProviderConfig struct {
 	Userinfo                 bool
 	RedirectCallbackDynamic  bool
 	RedirectCallback         string
+	RoleArn                  string // can be empty
 }
 
 // GetStateKeyFunc - return the key function used to generate the authorization


### PR DESCRIPTION
- RoleARN needs to be used in the STS API call when present. Code to use this value needs to be added.