### PR TITLE
Removing old cache spot for permission test and incrementing the timeout.

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -700,7 +700,7 @@ jobs:
       - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
-    timeout-minutes: 5
+    timeout-minutes: 15
     strategy:
       matrix:
         go-version: [ 1.18.x ]
@@ -750,12 +750,6 @@ jobs:
           echo "There was no hit, hence we generate the assets"
           make assets
 
-      - name: Generate Assets
-        if: steps.assets-cache.outputs.cache-hit != 'true'
-        run: |
-          echo "There was no hit, hence we generate the assets"
-          make assets
-
       - uses: actions/cache@v3
         name: Go Mod Cache
         with:
@@ -779,7 +773,7 @@ jobs:
         run: |
           (./console server) & (make initialize-permissions)
       - name: Run TestCafe Tests
-        timeout-minutes: 5
+        timeout-minutes: 10
         uses: DevExpress/testcafe-action@latest
         with:
           args: '"chrome --headless --no-sandbox" portal-ui/tests/permissions-4/ --skip-js-errors'


### PR DESCRIPTION
### Objective:

To fix `Permissions Tests Part 4` by removing old cache spot that is no longer needed and incrementing the timeout.

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/6667358/196547598-d8f74c7c-8f52-4a06-827b-64900ebbd723.png">

### Additional information:

Also incrementing the timeout from 5 minutes to 15 minutes for the overall test. And from 5 minutes to 10 minutes for the testcafe test as 5 minutes is not enough.

### Result:

<img width="1025" alt="Screen Shot 2022-10-18 at 5 55 39 PM" src="https://user-images.githubusercontent.com/6667358/196552359-4833f5dc-b2d8-4798-bca7-0dec257d12f9.png">

