### PR TITLE
Using specific go version for vulncheck

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.19 ]
+        go-version: [ 1.18.7 ]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3


### PR DESCRIPTION
### Objective:

To be able to use specific version for `vulncheck`:

* "version": "1.18.7"

### Additional info:

* `1.18.7` is what is used with Console release