### PR TITLE
fix preview modal title

### DIFF
--- a/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
+++ b/portal-ui/src/screens/Console/Common/FormComponents/common/styleLibrary.ts
@@ -1257,7 +1257,7 @@ export const fileInputStyles = {
   },
 };
 
-export const deleteDialogStyles = {
+export const deleteDialogStyles: any = {
   root: {
     "& .MuiPaper-root": {
       padding: "1rem 2rem 2rem 1rem",
@@ -1276,6 +1276,8 @@ export const deleteDialogStyles = {
     "& svg": {
       marginRight: 10,
     },
+    wordBreak: "break-all",
+    whiteSpace: "normal",
   },
   closeContainer: {
     "& .MuiIconButton-root": {


### PR DESCRIPTION
Issue: Long title is causing preview modal to scroll horizontally and the close button is hidden.

post fix:

![image](https://user-images.githubusercontent.com/23444145/197127950-d6358a43-d795-461b-94da-0d698e987d98.png)
