### PR TITLE
Made default EC:4 parity when available without restrictions

### DIFF
--- a/portal-ui/src/common/utils.ts
+++ b/portal-ui/src/common/utils.ts
@@ -471,7 +471,7 @@ export const erasureCodeCalc = (
 
   const fourVar = parityValidValues.find((element) => element === "EC:4");
 
-  if (totalDisks >= 8 && totalNodes > 16 && fourVar) {
+  if (fourVar) {
     defaultEC = "EC:4";
   }
 


### PR DESCRIPTION
## What does this do?

Removes the minimum servers / disks restriction and set EC:4 parity as default when available

## How does it look?

<img width="898" alt="Screenshot 2022-10-31 at 14 27 05" src="https://user-images.githubusercontent.com/33497058/199104964-7ef04ccd-372f-41f2-b839-edd6ad7ba2d7.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>