### PR TITLE
Updated mds to v0.0.3

### DIFF
--- a/portal-ui/package.json
+++ b/portal-ui/package.json
@@ -30,7 +30,7 @@
     "kbar": "^0.1.0-beta.34",
     "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.21",
-    "mds": "https://github.com/minio/mds.git#v0.0.2",
+    "mds": "https://github.com/minio/mds.git#v0.0.3",
     "minio": "^7.0.28",
     "moment": "^2.29.4",
     "react": "^18.1.0",

--- a/portal-ui/yarn.lock
+++ b/portal-ui/yarn.lock
@@ -7974,12 +7974,12 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-"mds@https://github.com/minio/mds.git#v0.0.2":
-  version "0.0.2"
-  resolved "https://github.com/minio/mds.git#ce6082e11a5c52283914491fe094417a1dd07457"
+"mds@https://github.com/minio/mds.git#v0.0.3":
+  version "0.0.3"
+  resolved "https://github.com/minio/mds.git#788ee3d5db7718c87abbf2d4687791ef9e04ffbc"
   dependencies:
     "@types/styled-components" "^5.1.25"
-    styled-components "^5.3.5"
+    styled-components "^5.3.6"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -10743,10 +10743,10 @@ style-loader@^3.3.1:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
   integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
 
-styled-components@^5.3.5:
-  version "5.3.5"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.5.tgz#a750a398d01f1ca73af16a241dec3da6deae5ec4"
-  integrity sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==
+styled-components@^5.3.6:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.6.tgz#27753c8c27c650bee9358e343fc927966bfd00d1"
+  integrity sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.4.5"


### PR DESCRIPTION
## What does this do?

Updated mds to v0.0.3

## How does it look?

<img width="1653" alt="Screenshot 2022-11-01 at 19 23 38" src="https://user-images.githubusercontent.com/33497058/199374216-383023cc-83f7-4825-8b26-63135bd75fdb.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>