### PR TITLE
Fix font size appearing smaller for links on AGPL consent modal

### DIFF
--- a/portal-ui/src/screens/Console/License/LicenseConsentModal.tsx
+++ b/portal-ui/src/screens/Console/License/LicenseConsentModal.tsx
@@ -48,7 +48,7 @@ const LicenseConsentModal = ({
           flexFlow: "column",
           "& .link-text": {
             color: "#2781B0",
-            fontSize: "12px",
+            fontSize: "16px",
             fontWeight: 600,
           },
         }}


### PR DESCRIPTION
Before:

<img width="785" alt="Screen Shot 2022-11-02 at 2 20 40 PM" src="https://user-images.githubusercontent.com/27314853/199477099-fcc659b8-9177-4171-a40f-fd7fe33d3fd0.png">

After:

<img width="782" alt="Screen Shot 2022-11-02 at 2 20 28 PM" src="https://user-images.githubusercontent.com/27314853/199477152-86250109-2458-4664-92a1-06601268a4f7.png">
