### PR TITLE
Removing slash at the end of GCS tier screen endpoint

### DIFF
--- a/portal-ui/src/screens/Console/Configurations/TiersConfiguration/AddTierConfiguration.tsx
+++ b/portal-ui/src/screens/Console/Configurations/TiersConfiguration/AddTierConfiguration.tsx
@@ -280,7 +280,7 @@ const AddTierConfiguration = ({ classes }: IAddNotificationEndpointProps) => {
   useEffect(() => {
     switch (type) {
       case "gcs":
-        setEndpoint("https://storage.googleapis.com/");
+        setEndpoint("https://storage.googleapis.com");
         setTitleSelection("Google Cloud");
         break;
       case "s3":


### PR DESCRIPTION
https://storage.googleapis.com/ will generate https://storage.googleapis.com//bucket-name and tier creation will fail