### PR TITLE
Fix UpdateTierCredentialsModal For MinIO tier

### DIFF
--- a/portal-ui/src/screens/Console/Configurations/TiersConfiguration/UpdateTierCredentialsModal.tsx
+++ b/portal-ui/src/screens/Console/Configurations/TiersConfiguration/UpdateTierCredentialsModal.tsx
@@ -152,21 +152,21 @@ const UpdateTierCredentialsModal = ({
                     name="accessKey"
                     label="Access Key"
                     placeholder="Enter Access Key"
-                    value={accessKey}
+                    value={accountName}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      setAccessKey(e.target.value);
+                      setAccountName(e.target.value);
                     }}
                   />
                 </div>
                 <div className={classes.formFieldRow}>
                   <InputBoxWrapper
-                    id="secretKey"
-                    name="secretKey"
+                    id="accountKey"
+                    name="accountKey"
                     label="Secret Key"
                     placeholder="Enter Secret Key"
-                    value={secretKey}
+                    value={accountKey}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      setSecretKey(e.target.value);
+                      setAccountKey(e.target.value);
                     }}
                   />
                 </div>

--- a/portal-ui/src/screens/Console/Configurations/TiersConfiguration/UpdateTierCredentialsModal.tsx
+++ b/portal-ui/src/screens/Console/Configurations/TiersConfiguration/UpdateTierCredentialsModal.tsx
@@ -62,9 +62,6 @@ const UpdateTierCredentialsModal = ({
 }: ITierCredentialsModal) => {
   const dispatch = useAppDispatch();
   const [savingTiers, setSavingTiers] = useState<boolean>(false);
-  const [accessKey, setAccessKey] = useState<string>("");
-  const [secretKey, setSecretKey] = useState<string>("");
-
   const [creds, setCreds] = useState<string>("");
   const [encodedCreds, setEncodedCreds] = useState<string>("");
 
@@ -160,8 +157,8 @@ const UpdateTierCredentialsModal = ({
                 </div>
                 <div className={classes.formFieldRow}>
                   <InputBoxWrapper
-                    id="accountKey"
-                    name="accountKey"
+                    id="secretKey"
+                    name="secretKey"
                     label="Secret Key"
                     placeholder="Enter Secret Key"
                     value={accountKey}


### PR DESCRIPTION
Users were unable to update credentials for MinIO type tiers, now credentials can be updated. 
![Screen Shot 2022-11-15 at 1 54 46 PM](https://user-images.githubusercontent.com/65002498/202033299-19e24721-a33c-400f-8317-c6ae1627c997.png)
