### PR TITLE
Updated loader utils to avoid ReDoS issue

### DIFF
--- a/portal-ui/package.json
+++ b/portal-ui/package.json
@@ -91,6 +91,6 @@
     "react-scripts/webpack-dev-server/portfinder/async": "^2.6.4",
     "react-scripts/**/glob-parent": "^6.0.1",
     "react-scripts/**/minimatch": "^3.0.5",
-    "react-scripts/**/loader-utils": "^2.0.3"
+    "react-scripts/**/loader-utils": "^2.0.4"
   }
 }

--- a/portal-ui/yarn.lock
+++ b/portal-ui/yarn.lock
@@ -7773,10 +7773,10 @@ loader-runner@^4.2.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"
   integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
 
-loader-utils@^2.0.0, loader-utils@^2.0.3, loader-utils@^3.2.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.3.tgz#d4b15b8504c63d1fc3f2ade52d41bc8459d6ede1"
-  integrity sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==
+loader-utils@^2.0.0, loader-utils@^2.0.4, loader-utils@^3.2.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
## What does this do?

Updates loader-utils library

## How does it look?
<img width="369" alt="Screenshot 2022-11-15 at 17 50 38" src="https://user-images.githubusercontent.com/33497058/202049175-08af5305-a71c-46ef-9a64-a9cd44d46a65.png">



Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>