### PR TITLE
Fixed logo visibility in Safari

### DIFF
--- a/portal-ui/src/screens/Console/Menu/MenuToggle.tsx
+++ b/portal-ui/src/screens/Console/Menu/MenuToggle.tsx
@@ -127,8 +127,9 @@ const MenuToggle = ({ isOpen, onToggle }: MenuToggleProps) => {
             "&.wide": {
               flex: "1",
               "& svg": {
-                fill: "white",
+                width: "100%",
                 maxWidth: 180,
+                fill: "white",
               },
             },
             "&.mini": {


### PR DESCRIPTION
## What does this do?

Fixes an issue with Safari where logo was not visible

## How does it look?

<img width="1818" alt="Screenshot 2022-11-18 at 13 24 18" src="https://user-images.githubusercontent.com/33497058/202786098-98af57d2-7101-41f6-b95d-0bb8117a5ce1.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>

