### PR TITLE
Separate out dependency vulnerability checks in CI

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -283,8 +283,8 @@ jobs:
           pip3 install semgrep
           semgrep --config semgrep.yaml $(pwd)/portal-ui --error
 
-  no-warnings-and-make-assets:
-    name: "React Code Has No Vulnerabilities, Warnings & is Prettified, then Make Assets"
+  react-code-known-vulnerabilities:
+    name: "React Code Has No Known Vulnerable Deps"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -338,6 +338,57 @@ jobs:
         continue-on-error: false
         run: |
           yarn audit
+
+  no-warnings-and-make-assets:
+    name: "React Code Has No Warnings & is Prettified, then Make Assets"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ 1.18.x ]
+        os: [ ubuntu-latest ]
+    steps:
+      - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Read .nvmrc
+        id: node_version
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NVMRC }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v3
+        id: yarn-cache
+        name: Yarn Cache
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            ./portal-ui/node_modules/
+          key: ${{ runner.os }}-yarn-${{ hashFiles('./portal-ui/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - uses: actions/cache@v3
+        id: assets-cache
+        name: Assets Cache
+        with:
+          path: |
+            ./portal-ui/build/
+          key: ${{ runner.os }}-assets-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-assets-
+
       - name: Install Dependencies
         working-directory: ./portal-ui
         continue-on-error: false

--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -23,7 +23,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
 
@@ -91,7 +90,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ubuntu-latest
 
@@ -165,7 +163,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ubuntu-latest
 
@@ -443,7 +440,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     timeout-minutes: 10
@@ -547,7 +543,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     timeout-minutes: 10
@@ -644,7 +639,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     timeout-minutes: 10
@@ -742,7 +736,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     timeout-minutes: 15
@@ -829,7 +822,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     strategy:
@@ -915,7 +907,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     strategy:
@@ -1001,7 +992,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     strategy:
@@ -1087,7 +1077,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     strategy:
@@ -1173,7 +1162,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     strategy:
@@ -1269,7 +1257,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     strategy:
@@ -1372,7 +1359,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: [ ubuntu-latest ]
     strategy:
@@ -1475,7 +1461,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -1569,7 +1554,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -1663,7 +1647,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -1757,7 +1740,6 @@ jobs:
   #     - lint-job
   #     - no-warnings-and-make-assets
   #     - reuse-golang-dependencies
-  #     - vulnerable-dependencies-checks
   #     - semgrep-static-code-analysis
   #   runs-on: ${{ matrix.os }}
   #   strategy:
@@ -1851,7 +1833,6 @@ jobs:
   #     - lint-job
   #     - no-warnings-and-make-assets
   #     - reuse-golang-dependencies
-  #     - vulnerable-dependencies-checks
   #     - semgrep-static-code-analysis
   #   runs-on: ${{ matrix.os }}
   #   strategy:
@@ -1945,7 +1926,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -1983,7 +1963,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -2021,7 +2000,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -2059,7 +2037,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -2097,7 +2074,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -2135,7 +2111,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -2173,7 +2148,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -2211,7 +2185,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -2257,7 +2230,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
     strategy:
@@ -2303,7 +2275,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ubuntu-latest
 
@@ -2396,7 +2367,6 @@ jobs:
       - lint-job
       - no-warnings-and-make-assets
       - reuse-golang-dependencies
-      - vulnerable-dependencies-checks
       - semgrep-static-code-analysis
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
These tests are not "requirements" to run other tests. If there are vulnerabilities found, it will still show up as CI failure, it just wont hold back other CI tests.