### PR TITLE
Made improvements to title bar & break points

### DIFF
--- a/portal-ui/src/screens/Console/Common/PageHeader/PageHeader.tsx
+++ b/portal-ui/src/screens/Console/Common/PageHeader/PageHeader.tsx
@@ -205,7 +205,7 @@ const PageHeader = ({
           item
           xs={12}
           sm={12}
-          md={5}
+          md={4}
           className={classes.middleComponent}
           sx={{ marginTop: ["10px", "10px", "0", "0"] }}
         >
@@ -216,7 +216,7 @@ const PageHeader = ({
         item
         xs={12}
         sm={12}
-        md={middleComponent ? 3 : 6}
+        md={middleComponent ? 4 : 6}
         className={classes.rightMenu}
       >
         {actions && actions}

--- a/portal-ui/src/screens/Console/Console.tsx
+++ b/portal-ui/src/screens/Console/Console.tsx
@@ -259,7 +259,7 @@ const Console = ({ classes }: IConsoleProps) => {
   useLayoutEffect(() => {
     // Debounce to not execute constantly
     const debounceSize = debounce(() => {
-      if (open && window.innerWidth <= 800) {
+      if (open && window.innerWidth <= 1024) {
         dispatch(menuOpen(false));
       }
     }, 300);

--- a/portal-ui/src/screens/Console/Tenants/ListTenants/ListTenants.tsx
+++ b/portal-ui/src/screens/Console/Tenants/ListTenants/ListTenants.tsx
@@ -272,7 +272,6 @@ const ListTenants = ({ classes }: ITenantsList) => {
           <Grid
             item
             xs={12}
-            marginRight={"30px"}
             sx={{ display: "flex", justifyContent: "flex-end" }}
           >
             <TooltipWrapper tooltip={"Refresh Tenant List"}>


### PR DESCRIPTION
## What does this do?

Removed extra margin & changed breakpoints for console / operator pages title bar

## How does it look?

<img width="962" alt="Screenshot 2022-12-14 at 13 07 26" src="https://user-images.githubusercontent.com/33497058/207691003-9df6d72c-6170-4520-9252-f53e2744f179.png">
<img width="1019" alt="Screenshot 2022-12-14 at 13 07 19" src="https://user-images.githubusercontent.com/33497058/207691008-5b626ab2-3489-44ee-993c-731bb67c88a2.png">
<img width="1570" alt="Screenshot 2022-12-14 at 13 07 06" src="https://user-images.githubusercontent.com/33497058/207691012-901b5593-0dbd-421a-ba97-aed112524fe5.png">



Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>