### PR TITLE
Fixed Delete all object versions selector functionality

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/DeleteMultipleObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/DeleteMultipleObjects.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { useState } from "react";
+import React, { Fragment, useState } from "react";
 import { DialogContentText } from "@mui/material";
 
 import { ErrorResponseHandler } from "../../../../../../common/types";
@@ -96,18 +96,42 @@ const DeleteObject = ({
           Are you sure you want to delete the selected {selectedObjects.length}{" "}
           objects?{" "}
           {versioning && (
-            <FormSwitchWrapper
-              label={"Delete All Versions"}
-              indicatorLabels={["Yes", "No"]}
-              checked={deleteVersions}
-              value={"delete_versions"}
-              id="delete-versions"
-              name="delete-versions"
-              onChange={(e) => {
-                setDeleteVersions(!deleteVersions);
-              }}
-              description=""
-            />
+            <Fragment>
+              <br />
+              <br />
+              <FormSwitchWrapper
+                label={"Delete All Versions"}
+                indicatorLabels={["Yes", "No"]}
+                checked={deleteVersions}
+                value={"delete_versions"}
+                id="delete-versions"
+                name="delete-versions"
+                onChange={(e) => {
+                  setDeleteVersions(!deleteVersions);
+                }}
+                description=""
+              />
+              {deleteVersions && (
+                <Fragment>
+                  <div
+                    style={{
+                      marginTop: 10,
+                      border: "#c83b51 1px solid",
+                      borderRadius: 3,
+                      padding: 5,
+                      backgroundColor: "#c83b5120",
+                      color: "#c83b51",
+                    }}
+                  >
+                    This will remove the objects as well as all of their
+                    versions, <br />
+                    This action is irreversible.
+                  </div>
+                  <br />
+                  Are you sure you want to continue?
+                </Fragment>
+              )}
+            </Fragment>
           )}
         </DialogContentText>
       }

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/DeleteObject.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/DeleteObject.tsx
@@ -81,7 +81,11 @@ const DeleteObject = ({
       onConfirm={onConfirmDelete}
       onClose={onClose}
       confirmationContent={
-        <DialogContentText>
+        <DialogContentText
+          sx={{
+            width: "430px",
+          }}
+        >
           Are you sure you want to delete: <br />
           <b>{decodeURLString(selectedObject)}</b>{" "}
           {selectedVersion !== "" ? (
@@ -98,18 +102,40 @@ const DeleteObject = ({
           ? <br />
           <br />
           {versioning && selectedVersion === "" && (
-            <FormSwitchWrapper
-              label={"Delete All Versions"}
-              indicatorLabels={["Yes", "No"]}
-              checked={deleteVersions}
-              value={"delete_versions"}
-              id="delete-versions"
-              name="delete-versions"
-              onChange={(e) => {
-                setDeleteVersions(!deleteVersions);
-              }}
-              description=""
-            />
+            <Fragment>
+              <FormSwitchWrapper
+                label={"Delete All Versions"}
+                indicatorLabels={["Yes", "No"]}
+                checked={deleteVersions}
+                value={"delete_versions"}
+                id="delete-versions"
+                name="delete-versions"
+                onChange={(e) => {
+                  setDeleteVersions(!deleteVersions);
+                }}
+                description=""
+              />
+              {deleteVersions && (
+                <Fragment>
+                  <div
+                    style={{
+                      marginTop: 10,
+                      border: "#c83b51 1px solid",
+                      borderRadius: 3,
+                      padding: 5,
+                      backgroundColor: "#c83b5120",
+                      color: "#c83b51",
+                    }}
+                  >
+                    This will remove the object as well as all of its versions,{" "}
+                    <br />
+                    This action is irreversible.
+                  </div>
+                  <br />
+                  Are you sure you want to continue?
+                </Fragment>
+              )}
+            </Fragment>
           )}
         </DialogContentText>
       }

--- a/restapi/client.go
+++ b/restapi/client.go
@@ -228,7 +228,7 @@ type MCClient interface {
 	addNotificationConfig(ctx context.Context, arn string, events []string, prefix, suffix string, ignoreExisting bool) *probe.Error
 	removeNotificationConfig(ctx context.Context, arn string, event string, prefix string, suffix string) *probe.Error
 	watch(ctx context.Context, options mc.WatchOptions) (*mc.WatchObject, *probe.Error)
-	remove(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult
+	remove(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult
 	list(ctx context.Context, opts mc.ListOptions) <-chan *mc.ClientContent
 	get(ctx context.Context, opts mc.GetOptions) (io.ReadCloser, *probe.Error)
 	shareDownload(ctx context.Context, versionID string, expires time.Duration) (string, *probe.Error)
@@ -269,8 +269,8 @@ func (c mcClient) setVersioning(ctx context.Context, status string) *probe.Error
 	return c.client.SetVersion(ctx, status, []string{}, false)
 }
 
-func (c mcClient) remove(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
-	return c.client.Remove(ctx, isIncomplete, isRemoveBucket, isBypass, false, contentCh)
+func (c mcClient) remove(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
+	return c.client.Remove(ctx, isIncomplete, isRemoveBucket, isBypass, forceDelete, contentCh)
 }
 
 func (c mcClient) list(ctx context.Context, opts mc.ListOptions) <-chan *mc.ClientContent {

--- a/restapi/user_objects_test.go
+++ b/restapi/user_objects_test.go
@@ -49,7 +49,7 @@ var (
 
 var (
 	mcListMock          func(ctx context.Context, opts mc.ListOptions) <-chan *mc.ClientContent
-	mcRemoveMock        func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult
+	mcRemoveMock        func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult
 	mcGetMock           func(ctx context.Context, opts mc.GetOptions) (io.ReadCloser, *probe.Error)
 	mcShareDownloadMock func(ctx context.Context, versionID string, expires time.Duration) (string, *probe.Error)
 )
@@ -96,8 +96,8 @@ func (c s3ClientMock) list(ctx context.Context, opts mc.ListOptions) <-chan *mc.
 	return mcListMock(ctx, opts)
 }
 
-func (c s3ClientMock) remove(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
-	return mcRemoveMock(ctx, isIncomplete, isRemoveBucket, isBypass, contentCh)
+func (c s3ClientMock) remove(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
+	return mcRemoveMock(ctx, isIncomplete, isRemoveBucket, isBypass, forceDelete, contentCh)
 }
 
 func (c s3ClientMock) get(ctx context.Context, opts mc.GetOptions) (io.ReadCloser, *probe.Error) {
@@ -595,7 +595,7 @@ func Test_deleteObjects(t *testing.T) {
 		recursive  bool
 		nonCurrent bool
 		listFunc   func(ctx context.Context, opts mc.ListOptions) <-chan *mc.ClientContent
-		removeFunc func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult
+		removeFunc func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult
 	}
 	tests := []struct {
 		test      string
@@ -609,7 +609,7 @@ func Test_deleteObjects(t *testing.T) {
 				versionID:  "",
 				recursive:  false,
 				nonCurrent: false,
-				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
+				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
 					resultCh := make(chan mc.RemoveResult, 1)
 					resultCh <- mc.RemoveResult{Err: nil}
 					close(resultCh)
@@ -625,7 +625,7 @@ func Test_deleteObjects(t *testing.T) {
 				versionID:  "",
 				recursive:  false,
 				nonCurrent: false,
-				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
+				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
 					resultCh := make(chan mc.RemoveResult, 1)
 					resultCh <- mc.RemoveResult{Err: probe.NewError(errors.New("probe error"))}
 					close(resultCh)
@@ -641,7 +641,7 @@ func Test_deleteObjects(t *testing.T) {
 				versionID:  "",
 				recursive:  true,
 				nonCurrent: false,
-				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
+				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
 					resultCh := make(chan mc.RemoveResult, 1)
 					resultCh <- mc.RemoveResult{Err: nil}
 					close(resultCh)
@@ -665,7 +665,7 @@ func Test_deleteObjects(t *testing.T) {
 				versionID:  "",
 				recursive:  true,
 				nonCurrent: false,
-				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
+				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
 					resultCh := make(chan mc.RemoveResult, 1)
 					resultCh <- mc.RemoveResult{Err: probe.NewError(errors.New("probe error"))}
 					close(resultCh)
@@ -687,7 +687,7 @@ func Test_deleteObjects(t *testing.T) {
 				versionID:  "",
 				recursive:  true,
 				nonCurrent: true,
-				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
+				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
 					resultCh := make(chan mc.RemoveResult, 1)
 					resultCh <- mc.RemoveResult{Err: nil}
 					close(resultCh)
@@ -711,7 +711,7 @@ func Test_deleteObjects(t *testing.T) {
 				versionID:  "",
 				recursive:  true,
 				nonCurrent: true,
-				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
+				removeFunc: func(ctx context.Context, isIncomplete, isRemoveBucket, isBypass, forceDelete bool, contentCh <-chan *mc.ClientContent) <-chan mc.RemoveResult {
 					resultCh := make(chan mc.RemoveResult, 1)
 					resultCh <- mc.RemoveResult{Err: probe.NewError(errors.New("probe error"))}
 					close(resultCh)


### PR DESCRIPTION
## What does this do?

Fixed an issue were deleting all versions selector was not working as intended. Also added a notification that this action is dangerous.

This change doesn't include the bypass option yet.

## How does it look?
<img width="734" alt="Screenshot 2022-12-15 at 17 48 04" src="https://user-images.githubusercontent.com/33497058/207990727-25d7391d-f53b-4b4d-a32f-4e76e92a9924.png">
<img width="760" alt="Screenshot 2022-12-15 at 17 48 00" src="https://user-images.githubusercontent.com/33497058/207990731-9956e545-fca3-43b2-a7b8-86f5d4d38d5b.png">
<img width="728" alt="Screenshot 2022-12-15 at 17 47 52" src="https://user-images.githubusercontent.com/33497058/207990732-55baaa22-fd93-4005-aad6-fb3fe5eac152.png">
<img width="1113" alt="Screenshot 2022-12-15 at 17 47 49" src="https://user-images.githubusercontent.com/33497058/207990735-3c612c58-b2df-41d9-b95e-2048799b8426.png">

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>