### PR TITLE
Implements CONSOLE_DEV_MODE env var

### DIFF
--- a/restapi/config.go
+++ b/restapi/config.go
@@ -272,3 +272,7 @@ func getMaxConcurrentDownloadsLimit() int64 {
 
 	return cu
 }
+
+func getConsoleDevMode() bool {
+	return strings.ToLower(env.Get(ConsoleDevMode, "off")) == "on"
+}

--- a/restapi/consts.go
+++ b/restapi/consts.go
@@ -53,6 +53,7 @@ const (
 	ConsoleLogQueryAuthToken                     = "CONSOLE_LOG_QUERY_AUTH_TOKEN"
 	ConsoleMaxConcurrentUploads                  = "CONSOLE_MAX_CONCURRENT_UPLOADS"
 	ConsoleMaxConcurrentDownloads                = "CONSOLE_MAX_CONCURRENT_DOWNLOADS"
+	ConsoleDevMode                               = "CONSOLE_DEV_MODE"
 	LogSearchQueryAuthToken                      = "LOGSEARCH_QUERY_AUTH_TOKEN"
 	SlashSeparator                               = "/"
 )

--- a/restapi/ws_handle.go
+++ b/restapi/ws_handle.go
@@ -148,10 +148,12 @@ func serveWS(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Un-comment for development so websockets work on port 5005
-	/*upgrader.CheckOrigin = func(r *http.Request) bool {
-		return true
-	}*/
+	// Development mode validation
+	if getConsoleDevMode() {
+		upgrader.CheckOrigin = func(r *http.Request) bool {
+			return true
+		}
+	}
 
 	// upgrades the HTTP server connection to the WebSocket protocol.
 	conn, err := upgrader.Upgrade(w, req, nil)


### PR DESCRIPTION
## What does his do?

Implements `CONSOLE_DEV_MODE` to override WS CORS validation 

To test, set `CONSOLE_DEV_MODE=on` env var and start console server as usual. Then go to Object browser & see if objects list is available on localhost

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>