### PR TITLE
fix prometheus dashboard values for luxon migration

### DIFF
--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/BarChartWidget.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/BarChartWidget.tsx
@@ -116,7 +116,8 @@ const BarChartWidget = ({
     if (loading) {
       let stepCalc = 0;
       if (timeStart !== null && timeEnd !== null) {
-        const secondsInPeriod = timeEnd.unix() - timeStart.unix();
+        const secondsInPeriod =
+          timeEnd.toUnixInteger() - timeStart.toUnixInteger();
         const periods = Math.floor(secondsInPeriod / 60);
 
         stepCalc = periods < 1 ? 15 : periods;
@@ -128,9 +129,9 @@ const BarChartWidget = ({
           `/api/v1/${apiPrefix}/info/widgets/${
             panelItem.id
           }/?step=${stepCalc}&${
-            timeStart !== null ? `&start=${timeStart.unix()}` : ""
+            timeStart !== null ? `&start=${timeStart.toUnixInteger()}` : ""
           }${timeStart !== null && timeEnd !== null ? "&" : ""}${
-            timeEnd !== null ? `end=${timeEnd.unix()}` : ""
+            timeEnd !== null ? `end=${timeEnd.toUnixInteger()}` : ""
           }`
         )
         .then((res: any) => {

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/CapacityItem.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/CapacityItem.tsx
@@ -65,7 +65,8 @@ const CapacityItem = ({
     if (loading) {
       let stepCalc = 0;
       if (timeStart !== null && timeEnd !== null) {
-        const secondsInPeriod = timeEnd.unix() - timeStart.unix();
+        const secondsInPeriod =
+          timeEnd.toUnixInteger() - timeStart.toUnixInteger();
         const periods = Math.floor(secondsInPeriod / 60);
 
         stepCalc = periods < 1 ? 15 : periods;
@@ -75,9 +76,9 @@ const CapacityItem = ({
         .invoke(
           "GET",
           `/api/v1/${apiPrefix}/info/widgets/${value.id}/?step=${stepCalc}&${
-            timeStart !== null ? `&start=${timeStart.unix()}` : ""
+            timeStart !== null ? `&start=${timeStart.toUnixInteger()}` : ""
           }${timeStart !== null && timeEnd !== null ? "&" : ""}${
-            timeEnd !== null ? `end=${timeEnd.unix()}` : ""
+            timeEnd !== null ? `end=${timeEnd.toUnixInteger()}` : ""
           }`
         )
         .then((res: any) => {

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/EntityStateStatItem.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/EntityStateStatItem.tsx
@@ -56,7 +56,8 @@ const EntityStateStatItem = ({
     if (loading) {
       let stepCalc = 0;
       if (timeStart !== null && timeEnd !== null) {
-        const secondsInPeriod = timeEnd.unix() - timeStart.unix();
+        const secondsInPeriod =
+          timeEnd.toUnixInteger() - timeStart.toUnixInteger();
         const periods = Math.floor(secondsInPeriod / 60);
 
         stepCalc = periods < 1 ? 15 : periods;
@@ -68,9 +69,9 @@ const EntityStateStatItem = ({
           `/api/v1/${apiPrefix}/info/widgets/${
             panelItem.id
           }/?step=${stepCalc}&${
-            timeStart !== null ? `&start=${timeStart.unix()}` : ""
+            timeStart !== null ? `&start=${timeStart.toUnixInteger()}` : ""
           }${timeStart !== null && timeEnd !== null ? "&" : ""}${
-            timeEnd !== null ? `end=${timeEnd.unix()}` : ""
+            timeEnd !== null ? `end=${timeEnd.toUnixInteger()}` : ""
           }`
         )
         .then((res: any) => {

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/LinearGraphWidget.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/LinearGraphWidget.tsx
@@ -127,7 +127,8 @@ const LinearGraphWidget = ({
     if (loading) {
       let stepCalc = 0;
       if (timeStart !== null && timeEnd !== null) {
-        const secondsInPeriod = timeEnd.unix() - timeStart.unix();
+        const secondsInPeriod =
+          timeEnd.toUnixInteger() - timeStart.toUnixInteger();
         const periods = Math.floor(secondsInPeriod / 60);
 
         stepCalc = periods < 1 ? 15 : periods;
@@ -139,9 +140,9 @@ const LinearGraphWidget = ({
           `/api/v1/${apiPrefix}/info/widgets/${
             panelItem.id
           }/?step=${stepCalc}&${
-            timeStart !== null ? `&start=${timeStart.unix()}` : ""
+            timeStart !== null ? `&start=${timeStart.toUnixInteger()}` : ""
           }${timeStart !== null && timeEnd !== null ? "&" : ""}${
-            timeEnd !== null ? `end=${timeEnd.unix()}` : ""
+            timeEnd !== null ? `end=${timeEnd.toUnixInteger()}` : ""
           }`
         )
         .then((res: any) => {

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/PieChartWidget.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/PieChartWidget.tsx
@@ -96,7 +96,8 @@ const PieChartWidget = ({
     if (loading) {
       let stepCalc = 0;
       if (timeStart !== null && timeEnd !== null) {
-        const secondsInPeriod = timeEnd.unix() - timeStart.unix();
+        const secondsInPeriod =
+          timeEnd.toUnixInteger() - timeStart.toUnixInteger();
         const periods = Math.floor(secondsInPeriod / 60);
 
         stepCalc = periods < 1 ? 15 : periods;
@@ -108,9 +109,9 @@ const PieChartWidget = ({
           `/api/v1/${apiPrefix}/info/widgets/${
             panelItem.id
           }/?step=${stepCalc}&${
-            timeStart !== null ? `&start=${timeStart.unix()}` : ""
+            timeStart !== null ? `&start=${timeStart.toUnixInteger()}` : ""
           }${timeStart !== null && timeEnd !== null ? "&" : ""}${
-            timeEnd !== null ? `end=${timeEnd.unix()}` : ""
+            timeEnd !== null ? `end=${timeEnd.toUnixInteger()}` : ""
           }`
         )
         .then((res: any) => {

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/SimpleWidget.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/SimpleWidget.tsx
@@ -90,7 +90,8 @@ const SimpleWidget = ({
     if (loading) {
       let stepCalc = 0;
       if (timeStart !== null && timeEnd !== null) {
-        const secondsInPeriod = timeEnd.unix() - timeStart.unix();
+        const secondsInPeriod =
+          timeEnd.toUnixInteger() - timeStart.toUnixInteger();
         const periods = Math.floor(secondsInPeriod / 60);
 
         stepCalc = periods < 1 ? 15 : periods;
@@ -102,9 +103,9 @@ const SimpleWidget = ({
           `/api/v1/${apiPrefix}/info/widgets/${
             panelItem.id
           }/?step=${stepCalc}&${
-            timeStart !== null ? `&start=${timeStart.unix()}` : ""
+            timeStart !== null ? `&start=${timeStart.toUnixInteger()}` : ""
           }${timeStart !== null && timeEnd !== null ? "&" : ""}${
-            timeEnd !== null ? `end=${timeEnd.unix()}` : ""
+            timeEnd !== null ? `end=${timeEnd.toUnixInteger()}` : ""
           }`
         )
         .then((res: any) => {

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/SingleRepWidget.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/SingleRepWidget.tsx
@@ -63,7 +63,8 @@ const SingleRepWidget = ({
     if (loading) {
       let stepCalc = 0;
       if (timeStart !== null && timeEnd !== null) {
-        const secondsInPeriod = timeEnd.unix() - timeStart.unix();
+        const secondsInPeriod =
+          timeEnd.toUnixInteger() - timeStart.toUnixInteger();
         const periods = Math.floor(secondsInPeriod / 60);
 
         stepCalc = periods < 1 ? 15 : periods;
@@ -75,9 +76,9 @@ const SingleRepWidget = ({
           `/api/v1/${apiPrefix}/info/widgets/${
             panelItem.id
           }/?step=${stepCalc}&${
-            timeStart !== null ? `&start=${timeStart.unix()}` : ""
+            timeStart !== null ? `&start=${timeStart.toUnixInteger()}` : ""
           }${timeStart !== null && timeEnd !== null ? "&" : ""}${
-            timeEnd !== null ? `end=${timeEnd.unix()}` : ""
+            timeEnd !== null ? `end=${timeEnd.toUnixInteger()}` : ""
           }`
         )
         .then((res: any) => {

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/SingleValueWidget.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/Widgets/SingleValueWidget.tsx
@@ -96,7 +96,8 @@ const SingleValueWidget = ({
     if (loading) {
       let stepCalc = 0;
       if (timeStart !== null && timeEnd !== null) {
-        const secondsInPeriod = timeEnd.unix() - timeStart.unix();
+        const secondsInPeriod =
+          timeEnd.toUnixInteger() - timeStart.toUnixInteger();
         const periods = Math.floor(secondsInPeriod / 60);
 
         stepCalc = periods < 1 ? 15 : periods;
@@ -108,9 +109,9 @@ const SingleValueWidget = ({
           `/api/v1/${apiPrefix}/info/widgets/${
             panelItem.id
           }/?step=${stepCalc}&${
-            timeStart !== null ? `&start=${timeStart.unix()}` : ""
+            timeStart !== null ? `&start=${timeStart.toUnixInteger()}` : ""
           }${timeStart !== null && timeEnd !== null ? "&" : ""}${
-            timeEnd !== null ? `end=${timeEnd.unix()}` : ""
+            timeEnd !== null ? `end=${timeEnd.toUnixInteger()}` : ""
           }`
         )
         .then((res: any) => {


### PR DESCRIPTION
UI Crash in master in prometheus widgets :
```
Uncaught TypeError: timeEnd.unix is not a function
```



Navigate to Prometheus dashboard  ( Monitoring -> Metrics), select a date range and click Sync observe the error in master.

With fix, it should not crash . 
Also verify the data displayed in the date range.