### PR TITLE
Fixed WS reconnection logic onError and onClose

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/BrowserHandler.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/BrowserHandler.tsx
@@ -139,7 +139,7 @@ const initWSConnection = (
   objectsWS.onerror = () => {
     wsInFlight = false;
     console.error("Error in websocket connection. Attempting reconnection...");
-    // Reconnect function will be called in the onClose by specification.
+    // Onclose will be triggered by specification, reconnect function will be executed there to avoid duplicated requests
   };
 };
 

--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/BrowserHandler.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/BrowserHandler.tsx
@@ -121,7 +121,7 @@ const initWSConnection = (
 
   const reconnectFn = () => {
     if (errorCounter <= 5) {
-      initWSConnection(openCallback, onMessageCallback);
+      initWSConnection(() => {}, onMessageCallback);
       errorCounter += 1;
     } else {
       console.error("Websocket not available.");
@@ -139,9 +139,7 @@ const initWSConnection = (
   objectsWS.onerror = () => {
     wsInFlight = false;
     console.error("Error in websocket connection. Attempting reconnection...");
-
-    // We reconnect after 3 seconds
-    setTimeout(reconnectFn, 3000);
+    // Reconnect function will be called in the onClose by specification.
   };
 };
 


### PR DESCRIPTION
## What does this do?

Removes duplicated reconnection request when error is reached on Object Browser websocket, also removed the use of the connect call back as it will contain references to the initial request and it is not necessary as we already have information available.  

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>