### PR TITLE
Trust STS IDP connection when the url is localhost

### DIFF
--- a/restapi/user_login.go
+++ b/restapi/user_login.go
@@ -176,7 +176,7 @@ func getLoginDetailsResponse(params authApi.LoginDetailParams, openIDProviders o
 		loginStrategy = models.LoginDetailsLoginStrategyRedirect
 		for name, provider := range openIDProviders {
 			// initialize new oauth2 client
-			oauth2Client, err := openIDProviders.NewOauth2ProviderClient(name, nil, r, GetConsoleHTTPClient(""))
+			oauth2Client, err := openIDProviders.NewOauth2ProviderClient(name, nil, r, GetConsoleHTTPClient(""), GetConsoleHTTPClient(getMinIOServer()))
 			if err != nil {
 				return nil, ErrorWithContext(ctx, err, ErrOauth2Provider)
 			}
@@ -244,7 +244,7 @@ func getLoginOauth2AuthResponse(params authApi.LoginOauth2AuthParams, openIDProv
 		IDPName := requestItems.IDPName
 		state := requestItems.State
 		providerCfg := openIDProviders[IDPName]
-		oauth2Client, err := openIDProviders.NewOauth2ProviderClient(IDPName, nil, r, GetConsoleHTTPClient(""))
+		oauth2Client, err := openIDProviders.NewOauth2ProviderClient(IDPName, nil, r, GetConsoleHTTPClient(""), GetConsoleHTTPClient(getMinIOServer()))
 		if err != nil {
 			return nil, ErrorWithContext(ctx, err)
 		}


### PR DESCRIPTION
During SSO login, Console contacts MinIO server to generate 
new temporary credentials. When TLS is enabled, setting up a
correct TLS certificate is something that needs to be done
correctly by the user. However, recently, we started to skip
the TLS verification when Console talks to MinIO server using
a loopback address, but we missed the case of Console generating
temporary credentials in case of IDP. This commit will get the 
configured MinIO server url to decide if the STS call needs to
 skip the TLS verification or not.