### PR TITLE
Added bucket icons to object browser buckets listing

### DIFF
--- a/portal-ui/src/screens/Console/ObjectBrowser/OBBucketList.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/OBBucketList.tsx
@@ -18,12 +18,11 @@ import React, { Fragment, useEffect, useState } from "react";
 
 import { useNavigate } from "react-router-dom";
 import { Theme } from "@mui/material/styles";
-import { Button } from "mds";
+import { BucketsIcon, Button, RefreshIcon } from "mds";
 import createStyles from "@mui/styles/createStyles";
 import { LinearProgress } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import { Bucket, BucketList } from "../Buckets/types";
-import { BucketsIcon } from "mds";
 import {
   actionsTray,
   containerForHeader,
@@ -34,7 +33,6 @@ import api from "../../../common/api";
 import PageHeader from "../Common/PageHeader/PageHeader";
 
 import HelpBox from "../../../common/HelpBox";
-import { RefreshIcon } from "mds";
 import { SecureComponent } from "../../../common/SecureComponent";
 import {
   CONSOLE_UI_RESOURCE,
@@ -205,7 +203,22 @@ const OBListBuckets = () => {
                     label: "Name",
                     elementKey: "name",
                     renderFunction: (label) => (
-                      <span id={`browse-${label}`}>{label}</span>
+                      <div style={{ display: "flex" }}>
+                        <BucketsIcon
+                          style={{ width: 15, marginRight: 5, minWidth: 15 }}
+                        />
+                        <span
+                          id={`browse-${label}`}
+                          style={{
+                            whiteSpace: "nowrap",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            minWidth: 0,
+                          }}
+                        >
+                          {label}
+                        </span>
+                      </div>
                     ),
                   },
                   {
@@ -220,6 +233,7 @@ const OBListBuckets = () => {
                   },
                   {
                     label: "Access",
+                    elementKey: "rw_access",
                     renderFullObject: true,
                     renderFunction: (bucket: Bucket) => {
                       let access = [];


### PR DESCRIPTION
## What does this do?

Added bucket icons to object browser buckets listing

## How does it look?

<img width="476" alt="Screenshot 2023-01-26 at 17 02 19" src="https://user-images.githubusercontent.com/33497058/214970157-6ce95e23-39e5-4703-8e5f-64185458da7b.png">
<img width="807" alt="Screenshot 2023-01-26 at 17 02 11" src="https://user-images.githubusercontent.com/33497058/214970163-aa142146-6084-4815-b99d-b6186466b311.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>