### PR TITLE
Disable Audit Log and Monitoring by default

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/AddTenant/AddTenant.tsx
+++ b/portal-ui/src/screens/Console/Tenants/AddTenant/AddTenant.tsx
@@ -158,13 +158,13 @@ const AddTenant = () => {
     },
     {
       label: "Audit Log",
-      advancedOnly: true,
+      advancedOnly: false,
       componentRender: <ConfigLogSearch />,
       buttons: [cancelButton, createButton],
     },
     {
       label: "Monitoring",
-      advancedOnly: true,
+      advancedOnly: false,
       componentRender: <ConfigPrometheus />,
       buttons: [cancelButton, createButton],
     },


### PR DESCRIPTION
While tenant creation, by default keep the Audit Log and Monitoring option disabled