### PR TITLE
Fixed Tenant License crash in tenant details

### DIFF
--- a/portal-ui/src/screens/Console/Tenants/TenantDetails/SubnetLicenseTenant.tsx
+++ b/portal-ui/src/screens/Console/Tenants/TenantDetails/SubnetLicenseTenant.tsx
@@ -99,7 +99,7 @@ const SubnetLicenseTenant = ({
   licenseInfo,
   activateProduct,
 }: ISubnetLicenseTenant) => {
-  const expiryTime = tenant
+  const expiryTime = tenant?.subnet_license
     ? DateTime.fromISO(tenant.subnet_license.expires_at)
     : DateTime.now();
 


### PR DESCRIPTION
## What does this do?

Fixed a Tenant License page crash 

Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>