### PR TITLE
Hidden red notification in License menu when cluster is registered

### DIFF
--- a/portal-ui/src/screens/Console/Menu/LicenseBadge.tsx
+++ b/portal-ui/src/screens/Console/Menu/LicenseBadge.tsx
@@ -20,6 +20,7 @@ import { AppState } from "../../../store";
 import { Box } from "@mui/material";
 import { CircleIcon } from "mds";
 import { getLicenseConsent } from "../License/utils";
+import { registeredCluster } from "../../../config";
 
 const LicenseBadge = () => {
   const licenseInfo = useSelector(
@@ -27,10 +28,11 @@ const LicenseBadge = () => {
   );
 
   const isAgplAckDone = getLicenseConsent();
+  const clusterRegistered = registeredCluster();
 
   const { plan = "" } = licenseInfo || {};
 
-  if (plan || isAgplAckDone) {
+  if (plan || isAgplAckDone || clusterRegistered) {
     return null;
   }
 


### PR DESCRIPTION
## What does this do?

Hidden red notification in License menu when cluster is registered as it is not required

## How does it look?

<img width="1421" alt="Screenshot 2023-02-21 at 17 41 16" src="https://user-images.githubusercontent.com/33497058/220484114-eb56026d-1bac-4eba-b0bc-2d7c3b9e90f9.png">
