### PR TITLE
Add playwright Test

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1307,3 +1307,45 @@ jobs:
             echo "It is smaller than threshold ($threshold%) value, failed!"
             exit 1
           fi
+
+  playwright:
+    needs:
+      - compile-binary
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: |
+        echo "Run tests under playwright folder only"
+        echo "package-lock.json required"
+        cd $GITHUB_WORKSPACE/playwright
+        npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+
+    - uses: actions/cache@v3
+      name: Console Binary Cache
+      with:
+        path: |
+          ./console
+        key: ${{ runner.os }}-binary-${{ github.run_id }}
+
+    - name: Start Console, front-end app and initialize users/policies
+      run: |
+        (./console server) & (make initialize-permissions)
+
+    - name: Run Playwright tests
+      run: |
+        echo "Run tests under playwright folder only"
+        cd $GITHUB_WORKSPACE/playwright
+        npx playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/playwright/.github/workflows/playwright.yml
+++ b/playwright/.github/workflows/playwright.yml
@@ -1,0 +1,209 @@
+name: Workflow
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+# This ensures that previous jobs for the PR are canceled when the PR is
+# updated.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  lint-job:
+    name: Checking Lint
+    runs-on: [ ubuntu-latest ]
+    strategy:
+      matrix:
+        go-version: [ 1.19.x ]
+        os: [ ubuntu-latest ]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+        id: go
+
+      - name: Build on ${{ matrix.os }}
+        env:
+          GO111MODULE: on
+          GOOS: linux
+        run: |
+          make verifiers
+
+  ui-assets:
+    name: "React Code Has No Warnings & Prettified"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ 1.19.x ]
+        os: [ ubuntu-latest ]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Read .nvmrc
+        id: node_version
+        run: echo "$(cat .nvmrc)" && echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_ENV
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NVMRC }}
+          cache: 'yarn'
+          cache-dependency-path: portal-ui/yarn.lock
+      - uses: actions/cache@v3
+        id: assets-cache
+        name: Assets Cache
+        with:
+          path: |
+            ./portal-ui/build/
+          key: ${{ runner.os }}-assets-${{ github.run_id }}
+      - name: Install Dependencies
+        working-directory: ./portal-ui
+        continue-on-error: false
+        run: |
+          yarn install --frozen-lockfile --immutable
+      - name: Check for Warnings in build output
+        working-directory: ./portal-ui
+        continue-on-error: false
+        run: |
+          ./check-warnings.sh
+      - name: Check if Files are Prettified
+        working-directory: ./portal-ui
+        continue-on-error: false
+        run: |
+          ./check-prettier.sh
+
+  reuse-golang-dependencies:
+    name: reuse golang dependencies
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ 1.19.x ]
+        os: [ ubuntu-latest ]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+        id: go
+      - name: Build on ${{ matrix.os }}
+        env:
+          GO111MODULE: on
+          GOOS: linux
+        run: |
+          go mod download
+
+  semgrep-static-code-analysis:
+    name: "semgrep checks"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v3
+      - name: Scanning code on ${{ matrix.os }}
+        continue-on-error: false
+        run: |
+          # Install semgrep rather than using a container due to:
+          # https://github.com/actions/checkout/issues/334
+          sudo apt install -y python3-pip || apt install -y python3-pip
+          pip3 install semgrep
+          semgrep --config semgrep.yaml $(pwd)/portal-ui --error
+
+
+  compile-binary:
+    name: Compiles on Go ${{ matrix.go-version }} and ${{ matrix.os }}
+    needs:
+      - lint-job
+      - ui-assets
+      - reuse-golang-dependencies
+      - semgrep-static-code-analysis
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go-version: [ 1.19.x ]
+        os: [ ubuntu-latest ]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+        id: go
+      - uses: actions/cache@v3
+        name: Console Binary Cache
+        with:
+          path: |
+            ./console
+          key: ${{ runner.os }}-binary-${{ github.run_id }}
+      - uses: actions/cache@v3
+        id: assets-cache
+        name: Assets Cache
+        with:
+          path: |
+            ./portal-ui/build/
+          key: ${{ runner.os }}-assets-${{ github.run_id }}
+      - name: Build on ${{ matrix.os }}
+        env:
+          GO111MODULE: on
+          GOOS: linux
+        run: |
+          make console
+
+  playwright:
+    needs:
+      - compile-binary
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: |
+        echo "Run tests under playwright folder only"
+        echo "package-lock.json required"
+        cd $GITHUB_WORKSPACE/playwright
+        npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+
+    - uses: actions/cache@v3
+      name: Console Binary Cache
+      with:
+        path: |
+          ./console
+        key: ${{ runner.os }}-binary-${{ github.run_id }}
+
+    - name: Start Console, front-end app and initialize users/policies
+      run: |
+        (./console server) & (make initialize-permissions)
+
+    - name: Run Playwright tests
+      run: |
+        echo "Run tests under playwright folder only"
+        cd $GITHUB_WORKSPACE/playwright
+        npx playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/playwright/.gitignore
+++ b/playwright/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "playwright",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "playwright",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.31.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
+      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.31.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
+      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  }
+}

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "playwright",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "^1.31.2"
+  }
+}

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,90 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { channel: 'chrome' },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+});

--- a/playwright/tests/verify-title.spec.ts
+++ b/playwright/tests/verify-title.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('http://localhost:9090/login');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/MinIO/);
+});


### PR DESCRIPTION
### Objective:

Start exploring playwright to complement testcafe and if we like it, migrate to playwright little by little.

### How to manually test:

1. Have `console` running at port `5005` as we normally test
2. Under `playwright/tests` new added folder run:

```
npx playwright test
```

* This will execute `verify-title.spec.ts` which is a TypeScript test that checks just the title to contain `MinIO`
* Expected result is:

```sh
$ npx playwright test

Running 1 test using 1 worker

  ✓  1 example.spec.ts:3:5 › has title (624ms)

  1 passed (1.1s)
```

### Dependencies:

<img width="952" alt="Screenshot 2023-03-07 at 9 33 31 AM" src="https://user-images.githubusercontent.com/6667358/223453016-c6e7a588-1ea6-491c-896b-20419999d9f2.png">
