### PR TITLE
Fixed navigation after bucket creation

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/AddBucket/addBucketsSlice.ts
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/AddBucket/addBucketsSlice.ts
@@ -175,7 +175,7 @@ export const addBucketsSlice = createSlice({
       })
       .addCase(addBucketAsync.fulfilled, (state, action) => {
         state.loading = false;
-        state.navigateTo = `/buckets/${action.payload}/browse`;
+        state.navigateTo = `/buckets/${action.payload}/admin`;
       });
   },
 });

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/BucketListItem.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/BucketListItem.tsx
@@ -271,7 +271,7 @@ const BucketListItem = ({
       <Grid item xs={12} className={classes.bucketStats}>
         <Grid container justifyContent={"flex-start"} spacing={4}>
           <Grid item className={classes.bucketIcon}>
-            <Link to={`/buckets/${bucket.name}/browse`}>
+            <Link to={`/buckets/${bucket.name}/admin`}>
               <BucketsIcon />
             </Link>
           </Grid>


### PR DESCRIPTION
## What does this do?

Creation of a new bucket needs to redirect you to bucket details instead of buckets listing