### PR TITLE
Condensing Successful responses

### DIFF
--- a/integration/user_api_bucket_test.go
+++ b/integration/user_api_bucket_test.go
@@ -167,6 +167,10 @@ func setupBucketForEndpoint(name string, locking, versioning bool, quota, retent
 		return false
 	}
 	if response != nil {
+		if response.StatusCode >= 200 && response.StatusCode <= 299 {
+			fmt.Println("setupBucketForEndpoint(): HTTP Status is in the 2xx range")
+			return true
+		}
 		if response.StatusCode != expected {
 			assert.Fail(inspectHTTPResponse(response))
 			return false


### PR DESCRIPTION
### Objective:

Condensing Successful responses (200 – 299) and as long as Bucket is created with no errors, we should proceed testing. We can be very very strict in the codes but I believe is better to be flexible for the successful ones because it is time consuming debugging and fixing for minor changes that are giving little in return. For other responses like 400s or 500s being strict is much more reasonable.

### Note:

This is for testing only, but related to https://github.com/minio/console/pull/2721

### How to test locally:

https://github.com/cniackz/public/wiki/Integration-tests-in-console