### PR TITLE
Fixed refresh button on ListObjects screen

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -416,7 +416,7 @@ const ListObjects = () => {
 
   // bucket info
   useEffect(() => {
-    if (loadingObjects || (loadingBucket && !anonymousMode)) {
+    if ((loadingObjects || loadingBucket) && !anonymousMode) {
       api
         .invoke("GET", `/api/v1/buckets/${bucketName}`)
         .then((res: BucketInfo) => {

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -416,7 +416,7 @@ const ListObjects = () => {
 
   // bucket info
   useEffect(() => {
-    if (loadingBucket && !anonymousMode) {
+    if (loadingObjects || (loadingBucket && !anonymousMode)) {
       api
         .invoke("GET", `/api/v1/buckets/${bucketName}`)
         .then((res: BucketInfo) => {
@@ -429,7 +429,7 @@ const ListObjects = () => {
           dispatch(setErrorSnackMessage(err));
         });
     }
-  }, [bucketName, loadingBucket, dispatch, anonymousMode]);
+  }, [bucketName, loadingBucket, dispatch, anonymousMode, loadingObjects]);
 
   // Load retention Config
 


### PR DESCRIPTION
Refresh button on ListObjects screen now reloads latest bucketInfo. 

https://user-images.githubusercontent.com/65002498/226708716-6fd070d6-e0f2-4056-b170-09d713e8b8da.mov

closes https://github.com/miniohq/engineering/issues/1181
