### PR TITLE
[WIP] - Fixing Unused params Linter Check

### DIFF
--- a/pkg/logger/console.go
+++ b/pkg/logger/console.go
@@ -164,7 +164,7 @@ func (i infoMsg) json(msg string, args ...interface{}) {
 	fmt.Println(string(logJSON))
 }
 
-func (i infoMsg) quiet(msg string, args ...interface{}) {
+func (i infoMsg) quiet(_ string, _ ...interface{}) {
 }
 
 func (i infoMsg) pretty(msg string, args ...interface{}) {

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func testServer(w http.ResponseWriter, r *http.Request) {
+	fmt.Println(w)
+	fmt.Println(r)
 }
 
 func TestInitializeLogger(t *testing.T) {

--- a/pkg/logger/target/http/http.go
+++ b/pkg/logger/target/http/http.go
@@ -194,7 +194,7 @@ func New(config Config) *Target {
 }
 
 // Send log message 'e' to http target.
-func (h *Target) Send(entry interface{}, errKind string) error {
+func (h *Target) Send(entry interface{}) error {
 	if atomic.LoadInt32(&h.status) == 0 {
 		// Channel was closed or used before init.
 		return nil

--- a/pkg/logger/targets.go
+++ b/pkg/logger/targets.go
@@ -98,7 +98,6 @@ func initSystemTargets(cfgMap map[string]http.Config) (tgts []Target, err error)
 			if err = t.Init(); err != nil {
 				return tgts, err
 			}
-			tgts = append(tgts, t)
 		}
 	}
 	return tgts, err

--- a/restapi/logs.go
+++ b/restapi/logs.go
@@ -39,7 +39,7 @@ func logError(msg string, data ...interface{}) {
 	errorLog.Printf(msg+"\n", data...)
 }
 
-func logIf(ctx context.Context, err error, errKind ...interface{}) {
+func logIf(_ context.Context, _ error, _ ...interface{}) {
 }
 
 // globally changeable logger styles


### PR DESCRIPTION
### Objective:

To improve our code to pass linter, regardless of the previous state, the complains from the linter are valid and if we are having vars that are unsed and things like that, we should correct the code first.

I think there was a recent change in revive and now it is checking for unused params.

### Spot 1:

* `pkg/logger/target/http/http.go` removed var here
* no need to append it here `console/pkg/logger/targets.go`

### Spot 2:

* Using function for testing, printed unused params `console/pkg/logger/logger_test.go`

### Spot 3:

* `pkg/logger/console.go:167:24: unused-parameter: parameter 'msg'`

### Spot 4:

* `restapi/logs.go:42:12: unused-parameter: parameter 'ctx'`