### PR TITLE
Fixed Drives offline card UI

### DIFF
--- a/models/backend_properties.go
+++ b/models/backend_properties.go
@@ -37,6 +37,12 @@ type BackendProperties struct {
 	// backend type
 	BackendType string `json:"backendType,omitempty"`
 
+	// offline drives
+	OfflineDrives int64 `json:"offlineDrives,omitempty"`
+
+	// online drives
+	OnlineDrives int64 `json:"onlineDrives,omitempty"`
+
 	// rr s c parity
 	RrSCParity int64 `json:"rrSCParity,omitempty"`
 

--- a/portal-ui/src/api/consoleApi.ts
+++ b/portal-ui/src/api/consoleApi.ts
@@ -609,6 +609,8 @@ export interface BackendProperties {
   backendType?: string;
   rrSCParity?: number;
   standardSCParity?: number;
+  onlineDrives?: number;
+  offlineDrives?: number;
 }
 
 export interface ArnsResponse {

--- a/portal-ui/src/screens/Console/Dashboard/BasicDashboard/BasicDashboard.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/BasicDashboard/BasicDashboard.tsx
@@ -201,8 +201,8 @@ const BasicDashboard = ({ usage }: IDashboardProps) => {
             </BoxItem>
             <BoxItem>
               <StatusCountCard
-                offlineCount={offlineDrives.length}
-                onlineCount={onlineDrives.length}
+                offlineCount={usage?.backend.offlineDrives || offlineDrives.length}
+                onlineCount={usage?.backend.onlineDrives || onlineDrives.length}
                 label={"Drives"}
                 icon={<DrivesIcon />}
               />

--- a/portal-ui/src/screens/Console/Dashboard/BasicDashboard/BasicDashboard.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/BasicDashboard/BasicDashboard.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Box, Grid } from "@mui/material";
 import {
   ArrowRightIcon,
@@ -201,7 +201,9 @@ const BasicDashboard = ({ usage }: IDashboardProps) => {
             </BoxItem>
             <BoxItem>
               <StatusCountCard
-                offlineCount={usage?.backend.offlineDrives || offlineDrives.length}
+                offlineCount={
+                  usage?.backend.offlineDrives || offlineDrives.length
+                }
                 onlineCount={usage?.backend.onlineDrives || onlineDrives.length}
                 label={"Drives"}
                 icon={<DrivesIcon />}

--- a/portal-ui/src/screens/Console/Dashboard/BasicDashboard/BasicDashboard.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/BasicDashboard/BasicDashboard.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { useEffect } from "react";
+import React from "react";
 import { Box, Grid } from "@mui/material";
 import {
   ArrowRightIcon,

--- a/portal-ui/src/screens/Console/Dashboard/types.ts
+++ b/portal-ui/src/screens/Console/Dashboard/types.ts
@@ -34,6 +34,8 @@ export interface Backend {
   backendType: string;
   standardSCParity: number;
   rrSCParity: number;
+  onlineDrives: number;
+  offlineDrives: number;
 }
 
 export interface ServerInfo {

--- a/restapi/admin_info.go
+++ b/restapi/admin_info.go
@@ -76,6 +76,8 @@ func GetAdminInfo(ctx context.Context, client MinioAdmin) (*UsageInfo, error) {
 	var backendType string
 	var rrSCParity float64
 	var standardSCParity float64
+	var onlineDrives float64
+	var offlineDrives float64
 
 	if v, success := serverInfo.Backend.(map[string]interface{}); success {
 		bt, ok := v["backendType"]
@@ -89,6 +91,14 @@ func GetAdminInfo(ctx context.Context, client MinioAdmin) (*UsageInfo, error) {
 		sp, ok := v["standardSCParity"]
 		if ok {
 			standardSCParity = sp.(float64)
+		}
+		onDrives, ok := v["onlineDisks"]
+		if ok {
+			onlineDrives = onDrives.(float64)
+		}
+		offDrives, ok := v["offlineDisks"]
+		if ok {
+			offlineDrives = offDrives.(float64)
 		}
 	}
 
@@ -132,8 +142,9 @@ func GetAdminInfo(ctx context.Context, client MinioAdmin) (*UsageInfo, error) {
 		BackendType:      backendType,
 		RrSCParity:       int64(rrSCParity),
 		StandardSCParity: int64(standardSCParity),
+		OnlineDrives:     int64(onlineDrives),
+		OfflineDrives:    int64(offlineDrives),
 	}
-
 	return &UsageInfo{
 		Buckets:    int64(serverInfo.Buckets.Count),
 		Objects:    int64(serverInfo.Objects.Count),

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5301,6 +5301,12 @@ func init() {
         "backendType": {
           "type": "string"
         },
+        "offlineDrives": {
+          "type": "integer"
+        },
+        "onlineDrives": {
+          "type": "integer"
+        },
         "rrSCParity": {
           "type": "integer"
         },
@@ -14296,6 +14302,12 @@ func init() {
       "properties": {
         "backendType": {
           "type": "string"
+        },
+        "offlineDrives": {
+          "type": "integer"
+        },
+        "onlineDrives": {
+          "type": "integer"
         },
         "rrSCParity": {
           "type": "integer"

--- a/swagger.yml
+++ b/swagger.yml
@@ -4616,6 +4616,10 @@ definitions:
         type: integer
       standardSCParity:
         type: integer
+      onlineDrives:
+        type: integer
+      offlineDrives:
+        type: integer    
   arnsResponse:
     type: object
     properties:


### PR DESCRIPTION
Offline drives were being reported incorrectly, this adds the more accurate backend.onlineDisks and backend.offlineDisks to the admin info api, and uses them as the first choice for the drive status UI card. 


https://user-images.githubusercontent.com/65002498/227064364-65514d2d-84a6-42fd-8edd-8f7afa546339.mov

https://github.com/minio/console/issues/2731

### Testing:

* Once deployed with MinIO, we should also test in k8s: https://github.com/minio/wiki/wiki/How-to-have-only-one-disk-offline-in-Kubernetes