### PR TITLE
Make playwright run faster

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1308,9 +1308,92 @@ jobs:
             exit 1
           fi
 
+  ui-assets-istanbul-coverage:
+    name: "Assets with Istanbul Plugin for coverage"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.19.x]
+        os: [ubuntu-latest]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Read .nvmrc
+        id: node_version
+        run: echo "$(cat .nvmrc)" && echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_ENV
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NVMRC }}
+          cache: "yarn"
+          cache-dependency-path: portal-ui/yarn.lock
+      - uses: actions/cache@v3
+        id: assets-cache-istanbul-coverage
+        name: Assets Cache Istanbul Coverage
+        with:
+          path: |
+            ./portal-ui/build/
+          key: ${{ runner.os }}-assets-istanbul-coverage-${{ github.run_id }}
+      - name: Install Dependencies
+        working-directory: ./portal-ui
+        continue-on-error: false
+        run: |
+          yarn install --frozen-lockfile --immutable
+      - name: Check for Warnings in build output
+        working-directory: ./portal-ui
+        continue-on-error: false
+        run: |
+          ./check-warnings-istanbul-coverage.sh
+      - name: Check if Files are Prettified
+        working-directory: ./portal-ui
+        continue-on-error: false
+        run: |
+          ./check-prettier.sh
+
+  compile-binary-istanbul-coverage:
+    name: "Compile Console Binary with Istanbul Plugin for Coverage"
+    needs:
+      - lint-job
+      - ui-assets-istanbul-coverage
+      - reuse-golang-dependencies
+      - semgrep-static-code-analysis
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go-version: [1.19.x]
+        os: [ubuntu-latest]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+        id: go
+      - uses: actions/cache@v3
+        name: Console Binary Cache Istanbul Coverage
+        with:
+          path: |
+            ./console
+          key: ${{ runner.os }}-binary-istanbul-coverage-${{ github.run_id }}
+      - uses: actions/cache@v3
+        id: assets-cache-istanbul-coverage
+        name: Assets Cache Istanbul Coverage
+        with:
+          path: |
+            ./portal-ui/build/
+          key: ${{ runner.os }}-assets-istanbul-coverage-${{ github.run_id }}
+      - name: Build on ${{ matrix.os }}
+        env:
+          GO111MODULE: on
+          GOOS: linux
+        run: |
+          make console
+
   playwright:
     needs:
-      - compile-binary
+      - compile-binary-istanbul-coverage
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -1337,20 +1420,15 @@ jobs:
         run: npx playwright install --with-deps
 
       - uses: actions/cache@v3
-        name: Console Binary Cache
+        name: Console Binary Cache Istanbul Coverage
         with:
           path: |
             ./console
-          key: ${{ runner.os }}-binary-${{ github.run_id }}
+          key: ${{ runner.os }}-binary-istanbul-coverage-${{ github.run_id }}
 
       - name: Start Console, front-end app and initialize users/policies
         run: |
           (./console server) & (make initialize-permissions)
-
-      - name: Start Browser at port 5005
-        run: |
-          echo "yarn playwright"
-          (cd $GITHUB_WORKSPACE/portal-ui; yarn playwright) & (sleep 120) # To start port 5005 with Istanbul Plugin Injected
 
       - name: Run Playwright tests
         run: |

--- a/portal-ui/Makefile
+++ b/portal-ui/Makefile
@@ -5,6 +5,11 @@ build-static:
 	@if [ -f "${NVM_DIR}/nvm.sh" ]; then \. "${NVM_DIR}/nvm.sh" && nvm install && nvm use; fi && \
 	  NODE_OPTIONS=--openssl-legacy-provider yarn build
 
+build-static-istanbul-coverage:
+	@echo "Building frontend static assets to 'build'"
+	@if [ -f "${NVM_DIR}/nvm.sh" ]; then \. "${NVM_DIR}/nvm.sh" && nvm install && nvm use; fi && \
+	  NODE_OPTIONS=--openssl-legacy-provider yarn buildistanbulcoverage
+
 test-warnings:
 	./check-warnings.sh
 

--- a/portal-ui/check-warnings-istanbul-coverage.sh
+++ b/portal-ui/check-warnings-istanbul-coverage.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+yell() { echo "$0: $*" >&2; }
+
+die() {
+  yell "$*"
+  cat yarn.log
+  exit 111
+}
+
+try() { "$@" &> yarn.log || die "cannot $*"; }
+
+rm -f yarn.log
+try make build-static-istanbul-coverage
+
+if cat yarn.log | grep "Compiled with warnings"; then
+  echo "There are warnings in the code"
+  exit 1
+fi

--- a/portal-ui/e2e/auth.setup.ts
+++ b/portal-ui/e2e/auth.setup.ts
@@ -15,10 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { test as setup } from "@playwright/test";
 import { minioadminFile } from "./consts";
+import { pagePort } from "./consts";
 
 setup("authenticate as admin", async ({ page }) => {
   // Perform authentication steps. Replace these actions with your own.
-  await page.goto("http://localhost:5005");
+  await page.goto(pagePort);
   await page.getByPlaceholder("Username").click();
   await page.getByPlaceholder("Username").fill("minioadmin");
   await page.getByPlaceholder("Password").click();

--- a/portal-ui/e2e/buckets.spec.ts
+++ b/portal-ui/e2e/buckets.spec.ts
@@ -16,11 +16,12 @@
 import { expect } from "@playwright/test";
 import { generateUUID, test } from "./fixtures/baseFixture";
 import { minioadminFile } from "./consts";
+import { pagePort } from "./consts";
 
 test.use({ storageState: minioadminFile });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("http://localhost:5005/");
+  await page.goto(pagePort);
 });
 
 test("create a new bucket", async ({ page }) => {

--- a/portal-ui/e2e/consts.ts
+++ b/portal-ui/e2e/consts.ts
@@ -15,3 +15,4 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 export const minioadminFile = "playwright/.auth/admin.json";
+export const pagePort = "http://localhost:9090/buckets";

--- a/portal-ui/e2e/groups.spec.ts
+++ b/portal-ui/e2e/groups.spec.ts
@@ -17,11 +17,12 @@
 import { expect } from "@playwright/test";
 import { generateUUID, test } from "./fixtures/baseFixture";
 import { minioadminFile } from "./consts";
+import { pagePort } from "./consts";
 
 test.use({ storageState: minioadminFile });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("http://localhost:5005/");
+  await page.goto(pagePort);
 });
 
 test("Add a new group", async ({ page }) => {

--- a/portal-ui/e2e/lifecycle.spec.ts
+++ b/portal-ui/e2e/lifecycle.spec.ts
@@ -17,11 +17,12 @@
 import { expect } from "@playwright/test";
 import { test } from "./fixtures/baseFixture";
 import { minioadminFile } from "./consts";
+import { pagePort } from "./consts";
 
 test.use({ storageState: minioadminFile });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("http://localhost:5005/buckets");
+  await page.goto(pagePort);
 });
 
 test("Test if Object Version selector is present in Lifecycle rule modal", async ({

--- a/portal-ui/e2e/login.spec.ts
+++ b/portal-ui/e2e/login.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "@playwright/test";
+import { pagePort } from "./consts";
 
 test("Basic `minioadmin` Login", async ({ page, context }) => {
-  await page.goto("http://localhost:5005");
+  await page.goto(pagePort);
   await page.getByPlaceholder("Username").click();
   await page.getByPlaceholder("Username").fill("minioadmin");
   await page.getByPlaceholder("Password").click();

--- a/portal-ui/e2e/policies.spec.ts
+++ b/portal-ui/e2e/policies.spec.ts
@@ -16,11 +16,12 @@
 import { expect } from "@playwright/test";
 import { generateUUID, test } from "./fixtures/baseFixture";
 import { minioadminFile } from "./consts";
+import { pagePort } from "./consts";
 
 test.use({ storageState: minioadminFile });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("http://localhost:5005/");
+  await page.goto(pagePort);
 });
 
 test("Can create a policy", async ({ page }) => {

--- a/portal-ui/package.json
+++ b/portal-ui/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "start": "PORT=5005 react-scripts start",
     "build": "react-scripts build",
+    "buildistanbulcoverage": "PORT=9090 USE_BABEL_PLUGIN_ISTANBUL=1 react-app-rewired build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "playwright": "PORT=5005 USE_BABEL_PLUGIN_ISTANBUL=1 react-app-rewired start"

--- a/portal-ui/playwright/jobs.yaml
+++ b/portal-ui/playwright/jobs.yaml
@@ -40,8 +40,8 @@ jobs:
         run: |
           make verifiers
 
-  ui-assets:
-    name: "React Code Has No Warnings & Prettified"
+  ui-assets-istanbul-coverage:
+    name: "Assets with Istanbul Plugin for coverage"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -59,12 +59,12 @@ jobs:
           cache: "yarn"
           cache-dependency-path: portal-ui/yarn.lock
       - uses: actions/cache@v3
-        id: assets-cache
-        name: Assets Cache
+        id: assets-cache-istanbul-coverage
+        name: Assets Cache Istanbul Coverage
         with:
           path: |
             ./portal-ui/build/
-          key: ${{ runner.os }}-assets-${{ github.run_id }}
+          key: ${{ runner.os }}-assets-istanbul-coverage-${{ github.run_id }}
       - name: Install Dependencies
         working-directory: ./portal-ui
         continue-on-error: false
@@ -74,7 +74,7 @@ jobs:
         working-directory: ./portal-ui
         continue-on-error: false
         run: |
-          ./check-warnings.sh
+          ./check-warnings-istanbul-coverage.sh
       - name: Check if Files are Prettified
         working-directory: ./portal-ui
         continue-on-error: false
@@ -122,11 +122,11 @@ jobs:
           pip3 install semgrep
           semgrep --config semgrep.yaml $(pwd)/portal-ui --error
 
-  compile-binary:
-    name: Compiles on Go ${{ matrix.go-version }} and ${{ matrix.os }}
+  compile-binary-istanbul-coverage:
+    name: "Compile Console Binary with Istanbul Plugin for Coverage"
     needs:
       - lint-job
-      - ui-assets
+      - ui-assets-istanbul-coverage
       - reuse-golang-dependencies
       - semgrep-static-code-analysis
     runs-on: ${{ matrix.os }}
@@ -145,18 +145,18 @@ jobs:
           cache: true
         id: go
       - uses: actions/cache@v3
-        name: Console Binary Cache
+        name: Console Binary Cache Istanbul Coverage
         with:
           path: |
             ./console
-          key: ${{ runner.os }}-binary-${{ github.run_id }}
+          key: ${{ runner.os }}-binary-istanbul-coverage-${{ github.run_id }}
       - uses: actions/cache@v3
-        id: assets-cache
-        name: Assets Cache
+        id: assets-cache-istanbul-coverage
+        name: Assets Cache Istanbul Coverage
         with:
           path: |
             ./portal-ui/build/
-          key: ${{ runner.os }}-assets-${{ github.run_id }}
+          key: ${{ runner.os }}-assets-istanbul-coverage-${{ github.run_id }}
       - name: Build on ${{ matrix.os }}
         env:
           GO111MODULE: on
@@ -166,7 +166,7 @@ jobs:
 
   playwright:
     needs:
-      - compile-binary
+      - compile-binary-istanbul-coverage
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -193,20 +193,15 @@ jobs:
         run: npx playwright install --with-deps
 
       - uses: actions/cache@v3
-        name: Console Binary Cache
+        name: Console Binary Cache Istanbul Coverage
         with:
           path: |
             ./console
-          key: ${{ runner.os }}-binary-${{ github.run_id }}
+          key: ${{ runner.os }}-binary-istanbul-coverage-${{ github.run_id }}
 
       - name: Start Console, front-end app and initialize users/policies
         run: |
           (./console server) & (make initialize-permissions)
-
-      - name: Start Browser at port 5005
-        run: |
-          echo "yarn playwright"
-          (cd $GITHUB_WORKSPACE/portal-ui; yarn playwright) & (sleep 120) # To start port 5005 with Istanbul Plugin Injected
 
       - name: Run Playwright tests
         run: |


### PR DESCRIPTION
### Objective:

To make playwright run faster by running tests in port 9090 that is already up and running from previous steps. And since console on port 9090 is needed anyway then we can skip 5005 and save time, here a diagram on how this works: https://github.com/cniackz/public/wiki/How-Playwright-Coverage-Works-in-GitHub-On-Console-Repo

1. I need to make sure, we can get coverage: For the coverage, I need to create another build that injects or contains the Istambul puglin for coverage to be retrieved, example:

```
"buildistanbulcoverage": "PORT=9090 USE_BABEL_PLUGIN_ISTANBUL=1 react-app-rewired build",
```

> It should look like:

```sh
npx nyc report
---------------------------------------|---------|----------|---------|---------|-------------------
File                                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------------------------------|---------|----------|---------|---------|-------------------
All files                              |   43.88 |    32.87 |    27.7 |   43.92 |                   
 src                                   |    50.9 |    34.14 |   35.59 |   50.31 |                   
  MainRouter.tsx                       |    62.5 |      100 |      25 |   83.33 | 27                
  ProtectedRoutes.tsx                  |      66 |    51.42 |   53.84 |    65.3 | ...70-106,1[20](https://github.com/minio/console/actions/runs/4519423200/jobs/7961393176?pr=2737#step:8:21),134
```

2. I need to make sure tests can run in 9090 so they re-use the UI running in the compiled binary of console and we save time.

```sh
Running 6 tests using 1 worker
······
  6 passed
```

3. In another PR, I will address the issue or improvement of having an env variable for switching between 5005 and 9090 but for now let's keep as it is for simplicity of this change and then we can improve that.

### Additional information:

* Failure in SSO is not related to this change:

```sh
adding policy to Dillon Harper to be able to login:
mc: <ERROR> Incorrect command. Please use 'mc admin policy create'.
make: *** [Makefile:147: test-sso-integration] Error 1
Error: Process completed with exit code 2.
##[debug]Finishing: Build on 
```

### Testing and comparison:

* With this change we are saving ~2 min per execution:

```
succeeded 4 hours ago in 4m 46s
```

> versus

```
succeeded 2 days ago in 6m 23s
```