### PR TITLE
Added Object Version read-only field in Edit Lifecycle Modal

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/EditLifecycleConfiguration.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/EditLifecycleConfiguration.tsx
@@ -310,6 +310,24 @@ const EditLifecycleConfiguration = ({
     }
   };
 
+  let objectVersion = "";
+
+  if (lifecycleRule.expiration) {
+    if (lifecycleRule.expiration.days > 0) {
+      objectVersion = "Current Version";
+    } else if (lifecycleRule.expiration.noncurrent_expiration_days) {
+      objectVersion = "Non-Current Version";
+    }
+  }
+
+  if (lifecycleRule.transition) {
+    if (lifecycleRule.transition.days > 0) {
+      objectVersion = "Current Version";
+    } else if (lifecycleRule.transition.noncurrent_transition_days) {
+      objectVersion = "Non-Current Version";
+    }
+  }
+
   return (
     <ModalWrapper
       onClose={() => {
@@ -329,17 +347,7 @@ const EditLifecycleConfiguration = ({
         <Grid container>
           <Grid item xs={12} className={classes.formScrollable}>
             <Grid container spacing={1}>
-              <Grid item xs={12}>
-                <InputBoxWrapper
-                  id="id"
-                  name="id"
-                  label="Id"
-                  value={lifecycleRule.id}
-                  onChange={() => {}}
-                  disabled
-                />
-              </Grid>
-              <Grid item xs={12}>
+              <Grid item xs={12} sx={{ marginTop: "5px" }}>
                 <FormSwitchWrapper
                   label="Status"
                   indicatorLabels={["Enabled", "Disabled"]}
@@ -350,6 +358,16 @@ const EditLifecycleConfiguration = ({
                   onChange={(e) => {
                     setEnabled(e.target.checked);
                   }}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <InputBoxWrapper
+                  id="id"
+                  name="id"
+                  label="Id"
+                  value={lifecycleRule.id}
+                  onChange={() => {}}
+                  disabled
                 />
               </Grid>
               <Grid item xs={12}>
@@ -364,6 +382,16 @@ const EditLifecycleConfiguration = ({
                   ]}
                   onChange={() => {}}
                   disableOptions
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <InputBoxWrapper
+                  id="object-version"
+                  name="object-version"
+                  label="Object Version"
+                  value={objectVersion}
+                  onChange={() => {}}
+                  disabled
                 />
               </Grid>
               {ilmType === "expiry" && lifecycleRule.expiration?.days && (


### PR DESCRIPTION
## What does this do?

Added Object Version read-only field in Edit Lifecycle Modal

## How does it look?
<img width="796" alt="Screenshot 2023-04-11 at 15 27 31" src="https://user-images.githubusercontent.com/33497058/231292083-4a44a3ed-d5ca-43c0-b50b-223fef70baee.png">
<img width="824" alt="Screenshot 2023-04-11 at 15 27 12" src="https://user-images.githubusercontent.com/33497058/231292092-b6b67845-37fb-492e-a7f0-86344db1d808.png">
<img width="789" alt="Screenshot 2023-04-11 at 15 27 03" src="https://user-images.githubusercontent.com/33497058/231292095-3d7c0b79-1a2b-4fa8-b3c6-20e19f8d2b0b.png">

<img width="801" alt="Screenshot 2023-04-11 at 15 33 11" src="https://user-images.githubusercontent.com/33497058/231293094-4fda55c7-11d1-4355-acad-70810be2dabc.png">
