### PR TITLE
Changed breadcrumbs back button behavior

### DIFF
--- a/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
@@ -169,7 +169,21 @@ const BrowserBreadcrumbs = ({
     if (versionsMode) {
       dispatch(setVersionsModeEnabled({ status: false, objectName: "" }));
     } else {
-      navigate(-1);
+      if (splitPaths.length === 0) {
+        navigate("/browser");
+
+        return;
+      }
+
+      const prevPath = splitPaths.slice(0, -1);
+
+      navigate(
+        `/browser/${bucketName}${
+          prevPath.length > 0
+            ? `/${encodeURLString(`${prevPath.join("/")}/`)}`
+            : ""
+        }`
+      );
     }
   };
 


### PR DESCRIPTION
## What does this do?

Changed the way back button in object browser behaves, now we will be navigating though the paths instead of global navigation

## How does it look?

### Before:
![2023-04-12 14-50-10 2023-04-12 14_51_54](https://user-images.githubusercontent.com/33497058/231582181-6ccaefe4-457e-437c-8b89-14119f39c9a4.gif)

### Now:
![2023-04-12 14-48-14 2023-04-12 14_49_37](https://user-images.githubusercontent.com/33497058/231582235-1d49b443-9673-4fd3-95f6-dab90cf42738.gif)
