### PR TITLE
Remove health diagnostic warning

### DIFF
--- a/portal-ui/src/screens/Console/HealthInfo/HealthInfo.tsx
+++ b/portal-ui/src/screens/Console/HealthInfo/HealthInfo.tsx
@@ -23,7 +23,7 @@ import {
 import { AppState, useAppDispatch } from "../../../store";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import { Box, Button, Grid, HelpBox, Loader, WarnIcon } from "mds";
+import { Box, Button, Grid, HelpBox, Loader } from "mds";
 import {
   DiagStatError,
   DiagStatInProgress,
@@ -353,10 +353,8 @@ const HealthInfo = ({ classes }: IHealthInfo) => {
           <Fragment>
             <br />
             <HelpBox
-              title={
-                "During the health diagnostics run, all production traffic will be suspended."
-              }
-              iconComponent={<WarnIcon />}
+              title={""}
+              iconComponent={null}
               help={
                 <Fragment>
                   Cluster Health Report will be uploaded to Subnet, and is


### PR DESCRIPTION
<img width="1235" alt="Screen Shot 2023-04-17 at 15 03 17" src="https://user-images.githubusercontent.com/10521119/232610695-3d940e6d-a835-4069-a7a6-b20571cee372.png">

@bexsoft Should I remove the all helpbox or just the icon and the title? 