### PR TITLE
Show progress bar when loading Usage Info

### DIFF
--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/PrDashboard.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/PrDashboard.tsx
@@ -63,7 +63,9 @@ const styles = (theme: Theme) =>
 
 const PrDashboard = ({ apiPrefix = "admin", usage }: IPrDashboard) => {
   const dispatch = useAppDispatch();
-  const loadingUsage = useSelector((state: AppState) => state.dashboard.loadingUsage);
+  const loadingUsage = useSelector(
+    (state: AppState) => state.dashboard.loadingUsage
+  );
   const zoomOpen = useSelector(
     (state: AppState) => state.dashboard.zoom.openZoom
   );

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/PrDashboard.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/PrDashboard.tsx
@@ -63,6 +63,7 @@ const styles = (theme: Theme) =>
 
 const PrDashboard = ({ apiPrefix = "admin", usage }: IPrDashboard) => {
   const dispatch = useAppDispatch();
+  const loadingUsage = useSelector((state: AppState) => state.dashboard.loadingUsage);
   const zoomOpen = useSelector(
     (state: AppState) => state.dashboard.zoom.openZoom
   );
@@ -237,6 +238,7 @@ const PrDashboard = ({ apiPrefix = "admin", usage }: IPrDashboard) => {
                       onClick={() => {
                         dispatch(getUsageAsync());
                       }}
+                      disabled={loadingUsage}
                       icon={<SyncIcon />}
                       label={"Sync"}
                     />
@@ -328,8 +330,8 @@ const PrDashboard = ({ apiPrefix = "admin", usage }: IPrDashboard) => {
           index={usage?.advancedMetricsStatus === "not configured" ? 0 : 3}
           value={curTab}
         >
-          {!usage && <LinearProgress />}
-          {usage && <BasicDashboard usage={usage} />}
+          {(!usage || loadingUsage) && <LinearProgress />}
+          {usage && !loadingUsage && <BasicDashboard usage={usage} />}
         </TabPanel>
       </Grid>
     </PageLayout>


### PR DESCRIPTION
On Metrics screen there was no visual feedback whenever the `Sync` button was pressed nor it was being disabled.

### How it looks like:
<img width="1148" alt="Screenshot 2023-04-19 at 12 25 25 PM" src="https://user-images.githubusercontent.com/11819101/233187067-a9aaee28-966b-4e8c-aa90-b38216c81626.png">

### After being pressed:
Button is being disabled to avoid making multiple requests while loading screen.

<img width="1089" alt="Screenshot 2023-04-19 at 12 23 21 PM" src="https://user-images.githubusercontent.com/11819101/233187075-3a3c286f-c100-4272-bb8c-ebf851bcaf86.png">
