### PR TITLE
Fix yaml vulnerability

### DIFF
--- a/portal-ui/package.json
+++ b/portal-ui/package.json
@@ -94,6 +94,7 @@
   },
   "resolutions": {
     "nth-check": "^2.0.1",
+    "yaml": "^2.2.2",
     "postcss": "^8.2.13",
     "react-scripts/**/node-forge": "^1.3.0",
     "react-scripts/**/async": "^2.6.4",

--- a/portal-ui/yarn.lock
+++ b/portal-ui/yarn.lock
@@ -12810,10 +12810,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2, yaml@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
+  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
 yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
Bump yaml package version to 2.2.2  to address unhandled exception [CVE-2023-2251](https://nvd.nist.gov/vuln/detail/CVE-2023-2251)

More details on https://github.com/advisories/GHSA-f9xv-q969-pqx4