### PR TITLE
Fixed issue while getting locking status of a bucket

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/BrowserHandler.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/BrowserHandler.tsx
@@ -317,6 +317,7 @@ const BrowserHandler = () => {
       dispatch(
         setSimplePathHandler(decodedIPaths === "" ? "/" : decodedIPaths)
       );
+      dispatch(setLoadingLocking(true));
     } else {
       dispatch(setLoadingObjectInfo(true));
       dispatch(setObjectDetailsView(true));

--- a/portal-ui/src/screens/Console/ObjectBrowser/objectBrowserSlice.ts
+++ b/portal-ui/src/screens/Console/ObjectBrowser/objectBrowserSlice.ts
@@ -61,7 +61,7 @@ const initialState: ObjectBrowserState = {
   loadingVersioning: true,
   versionInfo: {},
   lockingEnabled: false,
-  loadingLocking: false,
+  loadingLocking: true,
   selectedObjects: [],
   downloadRenameModal: null,
   selectedPreview: null,


### PR DESCRIPTION
## What does this do?

Fixes an issue where Locking status was not loaded in object browser, this issue disabled Legal Hold & Retention options for every object in the bucket

## How does it look?

<img width="1045" alt="Screenshot 2023-04-25 at 19 05 28" src="https://user-images.githubusercontent.com/33497058/234440597-2e613e19-f227-4365-9799-89fb407cb20f.png">
<img width="1036" alt="Screenshot 2023-04-25 at 19 05 19" src="https://user-images.githubusercontent.com/33497058/234440601-c0e1f164-0b0f-4253-9163-0c0b60daefed.png">
