### PR TITLE
Added Disable login animation anv variable

### DIFF
--- a/models/login_details.go
+++ b/models/login_details.go
@@ -38,6 +38,9 @@ import (
 // swagger:model loginDetails
 type LoginDetails struct {
 
+	// animated login
+	AnimatedLogin bool `json:"animatedLogin,omitempty"`
+
 	// is direct p v
 	IsDirectPV bool `json:"isDirectPV,omitempty"`
 

--- a/portal-ui/src/api/consoleApi.ts
+++ b/portal-ui/src/api/consoleApi.ts
@@ -468,6 +468,7 @@ export interface LoginDetails {
   redirectRules?: RedirectRule[];
   isDirectPV?: boolean;
   isK8S?: boolean;
+  animatedLogin?: boolean;
 }
 
 export interface LoginOauth2AuthRequest {

--- a/portal-ui/src/screens/LoginPage/LoginPage.tsx
+++ b/portal-ui/src/screens/LoginPage/LoginPage.tsx
@@ -266,6 +266,10 @@ const Login = () => {
 
   const isK8S = useSelector((state: AppState) => state.login.isK8S);
 
+  const backgroundAnimation = useSelector(
+    (state: AppState) => state.login.backgroundAnimation
+  );
+
   useEffect(() => {
     if (navigateTo !== "") {
       dispatch(resetForm());
@@ -393,6 +397,7 @@ const Login = () => {
             .
           </span>
         }
+        backgroundAnimation={backgroundAnimation}
       />
     </Fragment>
   );

--- a/portal-ui/src/screens/LoginPage/loginSlice.ts
+++ b/portal-ui/src/screens/LoginPage/loginSlice.ts
@@ -27,6 +27,7 @@ export interface LoginState {
   secretKey: string;
   sts: string;
   useSTS: boolean;
+  backgroundAnimation: boolean;
 
   loginStrategy: ILoginDetails;
 
@@ -56,6 +57,7 @@ const initialState: LoginState = {
   loadingVersion: true,
   isDirectPV: false,
   isK8S: false,
+  backgroundAnimation: false,
 
   navigateTo: "",
 };
@@ -107,6 +109,7 @@ export const loginSlice = createSlice({
           state.loginStrategy = action.payload;
           state.isDirectPV = !!action.payload.isDirectPV;
           state.isK8S = !!action.payload.isK8S;
+          state.backgroundAnimation = !!action.payload.animatedLogin;
         }
       })
       .addCase(doLoginAsync.pending, (state, action) => {

--- a/portal-ui/src/screens/LoginPage/types.ts
+++ b/portal-ui/src/screens/LoginPage/types.ts
@@ -19,6 +19,7 @@ export interface ILoginDetails {
   redirectRules: redirectRule[];
   isDirectPV?: boolean;
   isK8S?: boolean;
+  animatedLogin?: boolean;
 }
 
 export interface redirectRule {

--- a/restapi/config.go
+++ b/restapi/config.go
@@ -276,3 +276,7 @@ func getMaxConcurrentDownloadsLimit() int64 {
 func getConsoleDevMode() bool {
 	return strings.ToLower(env.Get(ConsoleDevMode, "off")) == "on"
 }
+
+func getConsoleAnimatedLogin() bool {
+	return strings.ToLower(env.Get(ConsoleAnimatedLogin, "on")) == "on"
+}

--- a/restapi/consts.go
+++ b/restapi/consts.go
@@ -54,6 +54,7 @@ const (
 	ConsoleMaxConcurrentUploads                  = "CONSOLE_MAX_CONCURRENT_UPLOADS"
 	ConsoleMaxConcurrentDownloads                = "CONSOLE_MAX_CONCURRENT_DOWNLOADS"
 	ConsoleDevMode                               = "CONSOLE_DEV_MODE"
+	ConsoleAnimatedLogin                         = "CONSOLE_ANIMATED_LOGIN"
 	LogSearchQueryAuthToken                      = "LOGSEARCH_QUERY_AUTH_TOKEN"
 	SlashSeparator                               = "/"
 )

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7026,6 +7026,9 @@ func init() {
     "loginDetails": {
       "type": "object",
       "properties": {
+        "animatedLogin": {
+          "type": "boolean"
+        },
         "isDirectPV": {
           "type": "boolean"
         },
@@ -16157,6 +16160,9 @@ func init() {
     "loginDetails": {
       "type": "object",
       "properties": {
+        "animatedLogin": {
+          "type": "boolean"
+        },
         "isDirectPV": {
           "type": "boolean"
         },

--- a/restapi/user_login.go
+++ b/restapi/user_login.go
@@ -216,6 +216,7 @@ func getLoginDetailsResponse(params authApi.LoginDetailParams, openIDProviders o
 		LoginStrategy: loginStrategy,
 		RedirectRules: redirectRules,
 		IsK8S:         isKubernetes(),
+		AnimatedLogin: getConsoleAnimatedLogin(),
 	}
 	return loginDetails, nil
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -4355,6 +4355,8 @@ definitions:
         type: boolean
       isK8S:
         type: boolean
+      animatedLogin:
+        type: boolean
   loginOauth2AuthRequest:
     type: object
     required:


### PR DESCRIPTION
## What does this do?

Added an env variable to disable animation in Console. For this to work we need to make another change in MinIO repo to support this behavior from MinIO's binary

## How to test

1. Do `make assets build` in console's root folder
2. Set the following env variables: 
```bash
CONSOLE_ACCESS_KEY=<your_root_access_key>
CONSOLE_SECRET_KEY=<your_root_secret_key>
CONSOLE_MINIO_SERVER=<your_minio_server_url>
CONSOLE_ANIMATED_LOGIN=off
```
3. Start console by running `./console server`
4. Open your web browser and open `http://localhost:9090/login`

To test animated background just delete the env variable or set it to `on`