### PR TITLE
improve playwright tests with refactoring and clean up

### DIFF
--- a/portal-ui/e2e/auth.setup.ts
+++ b/portal-ui/e2e/auth.setup.ts
@@ -14,16 +14,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { test as setup } from "@playwright/test";
-import { minioadminFile } from "./consts";
-import { pagePort } from "./consts";
+import { adminAccessKey, adminSecretKey, minioadminFile } from "./consts";
+import { BUCKET_LIST_PAGE } from "./consts";
 
 setup("authenticate as admin", async ({ page }) => {
   // Perform authentication steps. Replace these actions with your own.
-  await page.goto(pagePort);
+  await page.goto(BUCKET_LIST_PAGE);
   await page.getByPlaceholder("Username").click();
-  await page.getByPlaceholder("Username").fill("minioadmin");
+  await page.getByPlaceholder("Username").fill(adminAccessKey);
   await page.getByPlaceholder("Password").click();
-  await page.getByPlaceholder("Password").fill("minioadmin");
+  await page.getByPlaceholder("Password").fill(adminSecretKey);
   await page.getByRole("button", { name: "Login" }).click();
 
   // we need to give the browser time to store the cookies

--- a/portal-ui/e2e/buckets.spec.ts
+++ b/portal-ui/e2e/buckets.spec.ts
@@ -16,12 +16,12 @@
 import { expect } from "@playwright/test";
 import { generateUUID, test } from "./fixtures/baseFixture";
 import { minioadminFile } from "./consts";
-import { pagePort } from "./consts";
+import { BUCKET_LIST_PAGE } from "./consts";
 
 test.use({ storageState: minioadminFile });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto(pagePort);
+  await page.goto(BUCKET_LIST_PAGE);
 });
 
 test("create a new bucket", async ({ page }) => {
@@ -34,6 +34,13 @@ test("create a new bucket", async ({ page }) => {
   await page.getByLabel("Bucket Name*").fill(bucketName);
   await page.getByRole("button", { name: "Create Bucket" }).click();
   await expect(page.locator(`#manageBucket-${bucketName}`)).toBeTruthy();
+  const bucketLocatorEl = `#manageBucket-${bucketName}`;
+  await page.locator(bucketLocatorEl).click();
+  await page.locator("#delete-bucket-button").click();
+  //confirm modal
+  await page.locator("#confirm-ok").click();
+  const listItemsCount = await page.locator(bucketLocatorEl).count();
+  await expect(listItemsCount).toEqual(0);
 });
 
 test("invalid bucket name", async ({ page }) => {

--- a/portal-ui/e2e/consts.ts
+++ b/portal-ui/e2e/consts.ts
@@ -15,4 +15,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 export const minioadminFile = "playwright/.auth/admin.json";
-export const pagePort = "http://localhost:9090/buckets";
+
+export const SERVER_ENDPOINT = "http://localhost:9090";
+export const BUCKET_LIST_PAGE = `${SERVER_ENDPOINT}/buckets`;
+
+export const adminAccessKey = "minioadmin";
+export const adminSecretKey = "minioadmin";

--- a/portal-ui/e2e/groups.spec.ts
+++ b/portal-ui/e2e/groups.spec.ts
@@ -17,12 +17,12 @@
 import { expect } from "@playwright/test";
 import { generateUUID, test } from "./fixtures/baseFixture";
 import { minioadminFile } from "./consts";
-import { pagePort } from "./consts";
+import { BUCKET_LIST_PAGE } from "./consts";
 
 test.use({ storageState: minioadminFile });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto(pagePort);
+  await page.goto(BUCKET_LIST_PAGE);
 });
 
 test("Add a new group", async ({ page }) => {

--- a/portal-ui/e2e/login.spec.ts
+++ b/portal-ui/e2e/login.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from "@playwright/test";
-import { pagePort } from "./consts";
+import { adminAccessKey, adminSecretKey, BUCKET_LIST_PAGE } from "./consts";
 
 test("Basic `minioadmin` Login", async ({ page, context }) => {
-  await page.goto(pagePort);
+  await page.goto(BUCKET_LIST_PAGE);
   await page.getByPlaceholder("Username").click();
-  await page.getByPlaceholder("Username").fill("minioadmin");
+  await page.getByPlaceholder("Username").fill(adminAccessKey);
   await page.getByPlaceholder("Password").click();
-  await page.getByPlaceholder("Password").fill("minioadmin");
+  await page.getByPlaceholder("Password").fill(adminSecretKey);
   await page.getByRole("button", { name: "Login" }).click();
   await context.storageState({ path: "storage/minioadmin.json" });
   await expect(page.getByRole("main").getByText("Object Browser")).toBeTruthy();

--- a/portal-ui/e2e/policies.spec.ts
+++ b/portal-ui/e2e/policies.spec.ts
@@ -16,16 +16,16 @@
 import { expect } from "@playwright/test";
 import { generateUUID, test } from "./fixtures/baseFixture";
 import { minioadminFile } from "./consts";
-import { pagePort } from "./consts";
+import { BUCKET_LIST_PAGE } from "./consts";
 
 test.use({ storageState: minioadminFile });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto(pagePort);
+  await page.goto(BUCKET_LIST_PAGE);
 });
 
 test("Can create a policy", async ({ page }) => {
-  await page.getByRole("link", { name: "Policies Policies" }).click();
+  await page.getByRole("link", { name: "Policies" }).click();
   await page.getByRole("button", { name: "Create Policy" }).click();
   await page.getByLabel("Policy Name").click();
 

--- a/portal-ui/e2e/pom/BucketSummaryPage.tsx
+++ b/portal-ui/e2e/pom/BucketSummaryPage.tsx
@@ -1,0 +1,46 @@
+import { Page, Locator } from "@playwright/test";
+
+export class BucketSummaryPage {
+  page: Page;
+  bucketName: string;
+
+  /* Locators */
+  deleteBucketBtn: Locator | undefined;
+
+  constructor(page: Page, bucketName: string) {
+    this.page = page;
+    this.bucketName = bucketName;
+
+    this.initLocators();
+  }
+  getLocator(selector: string): Locator {
+    const page = this.page;
+    const locator: Locator = page.locator(`${selector}`);
+    return locator;
+  }
+
+  initLocators() {
+    this.deleteBucketBtn = this.getLocator("#delete-bucket-button");
+  }
+
+  async loadPage() {
+    await this.clickOnTab(`Summary`);
+  }
+
+  async clickOnTab(tabName: string) {
+    const page = this.page;
+    await page.getByRole("tab", { name: tabName }).click();
+
+    // await page.goto(`${BUCKET_LIST_PAGE}/${this.bucketName}/admin/${tabName}`);
+  }
+
+  async confirmDeleteBucket() {
+    await this.getLocator("#delete-bucket-button").click();
+    await this.getLocator("#confirm-ok").click();
+  }
+
+  async getObjectVersionOption() {
+    await this.page.getByRole("button", { name: "Add Lifecycle Rule" }).click();
+    return this.getLocator("#object_version");
+  }
+}

--- a/portal-ui/e2e/pom/BucketsListPage.tsx
+++ b/portal-ui/e2e/pom/BucketsListPage.tsx
@@ -1,0 +1,56 @@
+import { Page, Locator } from "@playwright/test";
+import { BUCKET_LIST_PAGE } from "../consts";
+
+export class BucketsListPage {
+  page: Page;
+
+  /* Locators */
+
+  createBucketBtn: Locator | undefined;
+  refreshBucketsBtn: Locator | undefined;
+  setReplicationBtn: Locator | undefined;
+
+  bucketListItemPrefix = "#manageBucket-";
+
+  constructor(page: Page) {
+    this.page = page;
+    this.initLocators();
+  }
+  getLocator(selector: string): Locator {
+    const page = this.page;
+    const locator: Locator = page.locator(`${selector}`);
+    return locator;
+  }
+
+  initLocators() {
+    this.createBucketBtn = this.getLocator("#create-bucket");
+    this.refreshBucketsBtn = this.getLocator("#refresh-buckets");
+    this.setReplicationBtn = this.getLocator("#set-replication");
+  }
+
+  locateBucket(bucketName: string): Locator {
+    const bucketRow = this.getLocator(
+      `${this.bucketListItemPrefix}${bucketName}`
+    );
+    return bucketRow;
+  }
+
+  async clickOnBucketRow(bucketName: string) {
+    const bucketRow = this.locateBucket(bucketName);
+    await bucketRow.click();
+  }
+  async goToCreateBucket() {
+    await this.createBucketBtn?.click();
+  }
+
+  async isBucketExist(bucketName: string) {
+    const existBukCount = await this.locateBucket(bucketName).count();
+
+    return existBukCount;
+  }
+
+  async loadPage() {
+    const page = this.page;
+    await page.goto(BUCKET_LIST_PAGE);
+  }
+}

--- a/portal-ui/e2e/pom/CreateBucketPage.tsx
+++ b/portal-ui/e2e/pom/CreateBucketPage.tsx
@@ -1,0 +1,114 @@
+import { Page, Locator } from "@playwright/test";
+import { BUCKET_LIST_PAGE } from "../consts";
+
+export class CreateBucketPage {
+  page: Page;
+
+  /* Locators */
+
+  submitBtn: Locator | undefined;
+  clearBtn: Locator | undefined;
+  bucketNameInput: Locator | undefined;
+  versioningToggle: Locator | undefined;
+  lockingToggle: Locator | undefined;
+  quotaToggle: Locator | undefined;
+  bucketNamingRules: Locator | undefined;
+
+  bucketRetentionToggle: Locator | undefined;
+  quotaSizeInput: Locator | undefined;
+  retentionModeRadio: Locator | undefined;
+  retentionValidity: Locator | undefined;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.initLocators();
+  }
+  getLocator(selector: string): Locator {
+    const page = this.page;
+    const locator: Locator = page.locator(`${selector}`);
+    return locator;
+  }
+
+  initLocators() {
+    this.submitBtn = this.getLocator("#create-bucket");
+    this.clearBtn = this.getLocator("#clear");
+    this.versioningToggle = this.getLocator("#versioned");
+    this.lockingToggle = this.getLocator("#locking");
+    this.quotaToggle = this.getLocator("#bucket_quota");
+    this.bucketNamingRules = this.getLocator("#toggle-naming-rules");
+    this.bucketNameInput = this.getLocator("#bucket-name");
+  }
+
+  //Lazy/Conditional selectors Note: These respective methods must be called before using them.
+  onVersioningToggleOn() {
+    this.bucketRetentionToggle = this.getLocator("#bucket_retention");
+  }
+
+  onBucketQuotaToggleOn() {
+    this.quotaSizeInput = this.getLocator("#quota_size");
+  }
+
+  onRetentionToggleOn() {
+    this.retentionModeRadio = this.getLocator("#retention_mode");
+    this.retentionValidity = this.getLocator("#retention_validity");
+  }
+
+  loadPage() {
+    const page = this.page;
+    page.goto(BUCKET_LIST_PAGE);
+  }
+
+  async fillBucketName(bucketName: string) {
+    await this.bucketNameInput?.click();
+    await this.bucketNameInput?.fill(bucketName);
+  }
+
+  async toggleBucketNamingRules() {
+    await this.bucketNamingRules?.click();
+  }
+
+  async toggleVersioning() {
+    await this.versioningToggle?.check();
+    this.onVersioningToggleOn();
+    //expect to be on
+  }
+
+  async toggleObjectLocking() {
+    await this.lockingToggle?.click();
+    this.onVersioningToggleOn();
+    this.onRetentionToggleOn();
+  }
+
+  async toggleBucketQuota() {
+    await this.quotaToggle?.click();
+    this.onBucketQuotaToggleOn();
+  }
+
+  async toggleRetention() {
+    await this.bucketRetentionToggle?.click();
+  }
+
+  async submitForm() {
+    await this.submitBtn?.click();
+  }
+
+  //Convenience Methods for easy testing
+
+  //create a bucket without any features like versioning, locking, quota etc.
+  async createBucket(bucketName: string) {
+    await this.fillBucketName(bucketName);
+    await this.submitForm();
+  }
+
+  //create a bucket with versioning feature
+  async createVersionedBucket(bucketName: string) {
+    await this.fillBucketName(bucketName);
+    await this.toggleVersioning();
+    await this.submitForm();
+  }
+  //create a bucket with locking feature
+
+  async goToCreateBucket() {
+    await this.submitBtn?.click();
+  }
+}


### PR DESCRIPTION
improve playwright tests with refactoring and clean up

Currently  running the test locally multiple times requires manual clean up ( removal of bucket once test verification step is done)

This PR adds clean up functionality and also the steps based tests.

to run/test locally,
```
# Terminal 1 Start MinIO
CI=true  MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin minio server /tmp/site1{1...4}  --address ":9000" --console-address ":9001"


# Terminal ( start console server)
make install 
CONSOLE_MINIO_SERVER=http://localhost:9000 ./console server

# Terminal 3 ( run playwright tests)
cd portal-ui
npx playwright test

# To debug a specific test file via visual runner
npx playwright test lifecycle.spec.ts --ui

```