### PR TITLE
Fix Subpath behavior

### DIFF
--- a/portal-ui/src/api/index.ts
+++ b/portal-ui/src/api/index.ts
@@ -1,6 +1,7 @@
 import { Api, HttpResponse, Error, FullRequestParams } from "./consoleApi";
 
 export let api = new Api();
+api.baseUrl = `${new URL(document.baseURI).pathname}api/v1`;
 const internalRequestFunc = api.request;
 api.request = async <T = any, E = any>({
   body,

--- a/restapi/ws_handle.go
+++ b/restapi/ws_handle.go
@@ -148,8 +148,11 @@ func serveWS(w http.ResponseWriter, req *http.Request) {
 		errorsApi.ServeError(w, req, errorsApi.New(http.StatusUnauthorized, err.Error()))
 		return
 	}
-	// Development mode validation
-	if getConsoleDevMode() {
+
+	// If we are using a subpath we are most likely behind a reverse proxy so we most likely
+	// can't validate the proper Origin since we don't know the source domain, so we are going
+	// to allow the connection to be upgraded in this case.
+	if getSubPath() != "/" || getConsoleDevMode() {
 		upgrader.CheckOrigin = func(r *http.Request) bool {
 			return true
 		}


### PR DESCRIPTION
Fixes subpath behavior for `Console`

# How to Test this PR

## Vanilla nginx

Assuming we are exposing the console under `http://localhost:8000/console/subpath/`

1. Make assets via `make assets` and build MinIO with this branch of console
2. Start MinIO for a given Subpath
```bash
CI=true;MINIO_BROWSER_REDIRECT_URL=http://localhost:8000/console/subpath/;MINIO_SERVER_URL=http://localhost:9000 minio --console-address ":9090"
```
3. Start `nginx` with the following configuraiton
```
events { worker_connections 1024; }

http {

server {
    listen 8000;

    location /console/subpath/ {
        rewrite   ^/console/subpath/(.*) /$1 break;
        proxy_pass http://localhost:9090;
        
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "Upgrade";
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
        
        # This allows WebSocket connections
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
    }
}

}
```
with the command
```
nginx -c /PATH/TO/nginx.conf -g "daemon off;"
```
4. Visit http://localhost:8000/console/subpath/ on a browser
<img width="1519" alt="Screenshot 2023-05-17 at 12 10 45 PM" src="https://github.com/minio/console/assets/18384552/68108546-78c2-427b-bade-6cc3e61c23c2">

## In Kubernetes with nginx ingress

1. Create a Tenant with the the address for console under a subpath:
```yaml
  features:
    domains:
      console: https://ns-1.minio-x1/console/subpath/
      minio:
        - https://ns-1.minio-x1
```
Full Tenant Example:
```yaml
apiVersion: minio.min.io/v2
kind: Tenant
metadata:
  name: subpath-tenant
  namespace: ns-1
spec:
  configuration:
    name: subpath-tenant-env-configuration
  credsSecret:
    name: subpath-tenant-secret
  exposeServices:
    console: true
    minio: true
  features:
    domains:
      console: https://ns-1.minio-x1/console/subpath/
      minio:
        - https://ns-1.minio-x1
  image: miniodev/minio:subpath
  imagePullSecret: { }
  mountPath: /export
  pools:
    - affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            - labelSelector:
                matchExpressions:
                  - key: v1.min.io/tenant
                    operator: In
                    values:
                      - subpath-tenant
                  - key: v1.min.io/pool
                    operator: In
                    values:
                      - pool-0
              topologyKey: kubernetes.io/hostname
      name: pool-0
      resources: { }
      runtimeClassName: ""
      servers: 4
      volumeClaimTemplate:
        metadata:
          name: data
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: "68719476736"
          storageClassName: standard
      volumesPerServer: 4
  requestAutoCert: true
  users:
    - name: subpath-tenant-user-0
```

<img width="1519" alt="Screenshot 2023-05-17 at 12 13 23 PM" src="https://github.com/minio/console/assets/18384552/67e892c0-90c9-470c-804c-3e7989bfcefd">

2. Create an ingress controller with the subpath
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ns-1-ingress
  namespace: ns-1
  labels:
    app: console
  annotations:
    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
    nginx.ingress.kubernetes.io/rewrite-target: /$1
    nginx.ingress.kubernetes.io/proxy-body-size: 5120g
spec:
  rules:
    - host: ns-1.minio-x1
      http:
        paths:
          - pathType: Prefix
            path: "/console/subpath/(.*)"
            backend:
              service:
                name: subpath-tenant-console
                port:
                  number: 9443
          - pathType: Prefix
            path: "/"
            backend:
              service:
                name: minio
                port:
                  number: 443
```

3. visit https://ns-1.minio-x1/console/subpath/
<img width="1519" alt="Screenshot 2023-05-17 at 12 14 58 PM" src="https://github.com/minio/console/assets/18384552/df0f6512-5af4-44fd-a1e4-c919a2674e8c">


In all cases:
- Assets will load
- API calls will work
- Websockets will work


Fixes https://github.com/minio/console/issues/1908
Fixes https://github.com/minio/console/issues/2045
Fixes https://github.com/minio/console/issues/2149
Fixes https://github.com/minio/console/issues/2188
Fixes https://github.com/minio/console/issues/2483
Fixes https://github.com/minio/console/issues/2766
Fixes https://github.com/minio/console/issues/2774
Fixes https://github.com/minio/console/issues/2775