### PR TITLE
Replace RIGHT-TO-LEFT OVERRIDE unicode

### DIFF
--- a/portal-ui/src/common/utils.ts
+++ b/portal-ui/src/common/utils.ts
@@ -712,3 +712,9 @@ export const getRandomString = function (length = 16): string {
   }
   return retval;
 };
+
+// replaces bad unicode characters
+export const replaceUnicodeChar = (inputString: string): string => {
+  let unicodeChar = "\u202E";
+  return inputString.split(unicodeChar).join("<�202e>");
+};

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/IconWithLabel.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/IconWithLabel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import createStyles from "@mui/styles/createStyles";
 import withStyles from "@mui/styles/withStyles";
 import { Theme } from "@mui/material/styles";
+import { replaceUnicodeChar } from "../../../../../../common/utils";
 
 interface IIconWithLabel {
   classes: any;
@@ -34,7 +35,7 @@ const IconWithLabel = ({ classes, icon, strings }: IIconWithLabel) => {
     <div className={classes.fileName}>
       {icon}
       <span className={classes.fileNameText}>
-        {strings[strings.length - 1]}
+        {replaceUnicodeChar(strings[strings.length - 1])}
       </span>
     </div>
   );


### PR DESCRIPTION
To avoid actors trying to have us display file names with a different extension by leveraging the `RIGHT-TO-LEFT OVERRIDE` unicode character, we will replace it with an obvious expansion to make it obvious the character is there

<img width="1415" alt="Screenshot 2023-05-22 at 8 46 12 PM" src="https://github.com/minio/console/assets/18384552/0750315e-2e5b-4d72-bf5d-1fd0b7e79842">
