### PR TITLE
Fixed multiselection of items after deleting one service account

### DIFF
--- a/portal-ui/src/screens/Console/Account/Account.tsx
+++ b/portal-ui/src/screens/Console/Account/Account.tsx
@@ -110,6 +110,7 @@ const Account = () => {
     setDeleteOpen(false);
 
     if (refresh) {
+      setSelectedSAs([]);
       fetchRecords();
     }
   };


### PR DESCRIPTION
## What does this do?

Fixed an issue with service accounts multi selection where counter behaves inconsistently after deleting an item

## How does it look?

### Before
![2023-05-26 15-22-57 2023-05-26 15_24_23](https://github.com/minio/console/assets/33497058/e8b62f74-0e8c-41f0-9a09-d688fc234f5e)

### After
![2023-05-26 15-24-53 2023-05-26 15_25_54](https://github.com/minio/console/assets/33497058/b51973a4-ed02-4e58-8dfa-de8490a35f25)
