### PR TITLE
Display error snack bar on raw policy edit error

### DIFF
--- a/portal-ui/src/screens/Console/Policies/PolicyDetails.tsx
+++ b/portal-ui/src/screens/Console/Policies/PolicyDetails.tsx
@@ -197,9 +197,17 @@ const PolicyDetails = ({ classes }: IPolicyDetailsProps) => {
           dispatch(setSnackBarMessage("Policy successfully updated"));
           refreshPolicyDetails();
         })
-        .catch((err: ErrorResponseHandler) => {
+        .catch((err: HttpResponse<Policy, Error>) => {
           setAddLoading(false);
-          dispatch(setErrorSnackMessage(err));
+          dispatch(
+            setErrorSnackMessage({
+              errorMessage: "There was an error updating the Policy ",
+              detailedError:
+                "There was an error updating the Policy: " +
+                (err.error.detailedMessage || "") +
+                ". Please check Policy syntax.",
+            })
+          );
         });
     } else {
       setAddLoading(false);


### PR DESCRIPTION
## What does this do?

Display error message if edit policy endpoint throws an error

## How does it look?

<img width="1728" alt="Screenshot 2023-05-29 at 17 36 22" src="https://github.com/minio/console/assets/33497058/99025bfb-8a7c-4355-9cf5-87e7d4eeb5e2">
