### PR TITLE
Hide Lookup Bind Password from the Console UI

### DIFF
--- a/portal-ui/src/screens/Console/IDP/LDAP/IDPLDAPConfigurationDetails.tsx
+++ b/portal-ui/src/screens/Console/IDP/LDAP/IDPLDAPConfigurationDetails.tsx
@@ -49,10 +49,16 @@ import TabSelector from "../../Common/TabSelector/TabSelector";
 const enabledConfigLDAP = [
   "server_addr",
   "lookup_bind_dn",
-  "lookup_bind_password",
   "user_dn_search_base_dn",
   "user_dn_search_filter",
 ];
+
+const getFieldValue = (key: string, value: string) => {
+  if (key === "lookup_bind_password") {
+    return value ? "********" : "";
+  }
+  return value ? value : "";
+};
 
 const IDPLDAPConfigurationDetails = () => {
   const dispatch = useAppDispatch();
@@ -405,7 +411,7 @@ const IDPLDAPConfigurationDetails = () => {
                           <LabelValuePair
                             key={key}
                             label={value.label}
-                            value={fields[key] ? fields[key] : ""}
+                            value={getFieldValue(key, fields[key])}
                           />
                         ))}
                       </Fragment>


### PR DESCRIPTION
### Objective:

To hide `Lookup Bind Password` from the Console UI as suggested by one of our customers.

### How it looks:

<img width="1840" alt="Screenshot 2023-06-03 at 7 12 23 AM" src="https://github.com/minio/console/assets/6667358/b48b2d9a-8ace-4e6d-9cb3-53ad8b6c56a9">

### Testing:

1. Tested that LDAP can be configured
2. Tested that LDAP can be used for access
3. Tested that Password is entered but never shown in the UI.