### PR TITLE
Fix spelling in file sharing menu

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ShareFile.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ObjectDetails/ShareFile.tsx
@@ -145,7 +145,7 @@ const ShareFile = ({
               return;
             }
 
-            // Version couldn't ve retrieved, we default
+            // Version couldn't be retrieved, we default
             setVersionID("null");
           })
           .catch((error: ErrorResponseHandler) => {
@@ -324,7 +324,7 @@ const ShareFile = ({
         <Fragment>
           <Grid item xs={12} className={classes.shareLinkInfo}>
             To generate a temporary URL, please provide a set of credentials,
-            this link can ve valid up to 7 days.
+            this link can be valid up to 7 days.
             <br />
             <br />
           </Grid>


### PR DESCRIPTION
The file sharing menu for buckets spell 'be' as 've'.
Can be seen here:
![swappy-20230604-180806](https://github.com/minio/console/assets/44610569/22d35805-84c3-4075-98b2-9e6202c2f819)