### PR TITLE
Fixed an issue with subpaths in resources policies

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/BrowserHandler.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/BrowserHandler.tsx
@@ -214,7 +214,7 @@ const BrowserHandler = () => {
           }
 
           const permitItems = permissionItems(
-            bucketName,
+            response.bucketName || bucketName,
             pathPrefix,
             allowResources || []
           );

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/types.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/types.tsx
@@ -46,6 +46,7 @@ export interface WebsocketResponse {
   request_end?: boolean;
   data?: ObjectResponse[];
   prefix?: string;
+  bucketName?: string;
 }
 
 export interface ObjectResponse {

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
@@ -296,7 +296,7 @@ export const permissionItems = (
     return null;
   }
 
-  const returnElements: BucketObjectItem[] = [];
+  let returnElements: BucketObjectItem[] = [];
 
   // We split current path
   const splitCurrentPath = currentPath.split("/");
@@ -354,6 +354,14 @@ export const permissionItems = (
 
           let pathToRouteElements: string[] = [];
 
+          // We verify if currentPath is contained in the path begin, if is not contained the  user has no access to this subpath
+          const cleanCurrPath = currentPath.replace(/\/$/, "");
+
+          if (!prefixItem.startsWith(cleanCurrPath) && currentPath !== "") {
+            return;
+          }
+
+          // For every split element we iterate and check if we can construct a URL
           splitItems.every((splitElement, index) => {
             if (!splitElement.includes("*") && splitElement !== "") {
               if (splitElement !== splitCurrentPath[index]) {
@@ -379,6 +387,21 @@ export const permissionItems = (
       });
     }
   });
+
+  // We clean duplicated name entries
+  if (returnElements.length > 0) {
+    let clElements: BucketObjectItem[] = [];
+    let keys: string[] = [];
+
+    returnElements.forEach((itm) => {
+      if (!keys.includes(itm.name)) {
+        clElements.push(itm);
+        keys.push(itm.name);
+      }
+    });
+
+    returnElements = clElements;
+  }
 
   return returnElements;
 };

--- a/portal-ui/tests/policies/conditionsPolicy3.json
+++ b/portal-ui/tests/policies/conditionsPolicy3.json
@@ -1,0 +1,36 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowUserToSeeBucketListInTheConsole",
+      "Action": ["s3:ListAllMyBuckets", "s3:GetBucketLocation"],
+      "Effect": "Allow",
+      "Resource": ["arn:aws:s3:::*"]
+    },
+    {
+      "Sid": "AllowRootAndHomeListingOfCompanyBucket",
+      "Action": ["s3:ListBucket"],
+      "Effect": "Allow",
+      "Resource": ["arn:aws:s3:::my-company"],
+      "Condition": {
+        "StringEquals": {
+          "s3:prefix": ["", "home/", "home/User"],
+          "s3:delimiter": ["/"]
+        }
+      }
+    },
+    {
+      "Sid": "AllowListingOfUserFolder",
+      "Action": ["s3:ListBucket"],
+      "Effect": "Allow",
+      "Resource": ["arn:aws:s3:::my-company"],
+      "Condition": { "StringLike": { "s3:prefix": ["home/User/*"] } }
+    },
+    {
+      "Sid": "AllowAllS3ActionsInUserFolder",
+      "Effect": "Allow",
+      "Action": ["s3:*"],
+      "Resource": ["arn:aws:s3:::my-company/home/User/*"]
+    }
+  ]
+}

--- a/portal-ui/tests/scripts/cleanup-env.sh
+++ b/portal-ui/tests/scripts/cleanup-env.sh
@@ -30,6 +30,7 @@ remove_users() {
   mc admin user remove minio prefix-policy-ui-crash-$TIMESTAMP
   mc admin user remove minio conditions-$TIMESTAMP
   mc admin user remove minio conditions-2-$TIMESTAMP
+  mc admin user remove minio conditions-3-$TIMESTAMP
 }
 
 remove_policies() {
@@ -54,6 +55,7 @@ remove_policies() {
   mc admin policy remove minio fix-prefix-policy-ui-crash-$TIMESTAMP
   mc admin policy remove minio conditions-policy-$TIMESTAMP
   mc admin policy remove minio conditions-policy-2-$TIMESTAMP
+  mc admin policy remove minio conditions-policy-3-$TIMESTAMP
 }
 
 __init__() {

--- a/portal-ui/tests/scripts/common.sh
+++ b/portal-ui/tests/scripts/common.sh
@@ -48,6 +48,7 @@ create_policies() {
   mc admin policy create minio delete-object-with-prefix-$TIMESTAMP portal-ui/tests/policies/deleteObjectWithPrefix.json
   mc admin policy create minio conditions-policy-$TIMESTAMP portal-ui/tests/policies/conditionsPolicy.json
   mc admin policy create minio conditions-policy-2-$TIMESTAMP portal-ui/tests/policies/conditionsPolicy2.json
+  mc admin policy create minio conditions-policy-3-$TIMESTAMP portal-ui/tests/policies/conditionsPolicy3.json
 }
 
 create_users() {
@@ -77,6 +78,7 @@ create_users() {
   mc admin user add minio delete-object-with-prefix-$TIMESTAMP deleteobjectwithprefix1234
   mc admin user add minio conditions-$TIMESTAMP conditions1234
   mc admin user add minio conditions-2-$TIMESTAMP conditions1234
+  mc admin user add minio conditions-3-$TIMESTAMP conditions1234
 }
 
 create_buckets() {
@@ -111,4 +113,5 @@ assign_policies() {
   mc admin policy attach minio delete-object-with-prefix-$TIMESTAMP --user delete-object-with-prefix-$TIMESTAMP
   mc admin policy attach minio conditions-policy-$TIMESTAMP --user conditions-$TIMESTAMP
   mc admin policy attach minio conditions-policy-2-$TIMESTAMP --user conditions-2-$TIMESTAMP
+  mc admin policy attach minio conditions-policy-3-$TIMESTAMP --user conditions-3-$TIMESTAMP
 }

--- a/portal-ui/tests/scripts/permissions.sh
+++ b/portal-ui/tests/scripts/permissions.sh
@@ -38,6 +38,7 @@ remove_users() {
   mc admin user remove minio delete-object-with-prefix-"$TIMESTAMP"
   mc admin user remove minio conditions-"$TIMESTAMP"
   mc admin user remove minio conditions-2-"$TIMESTAMP"
+  mc admin user remove minio conditions-3-"$TIMESTAMP"
 }
 
 remove_policies() {
@@ -63,6 +64,7 @@ remove_policies() {
   mc admin policy remove minio delete-object-with-prefix-"$TIMESTAMP"
   mc admin policy remove conditions-policy-"$TIMESTAMP"
   mc admin policy remove conditions-policy-2-"$TIMESTAMP"
+  mc admin policy remove conditions-policy-3-"$TIMESTAMP"
 }
 
 remove_buckets() {

--- a/portal-ui/tests/utils/roles.ts
+++ b/portal-ui/tests/utils/roles.ts
@@ -272,3 +272,14 @@ export const conditions2 = Role(
   },
   { preserveUrl: true }
 );
+
+export const conditions3 = Role(
+  loginUrl,
+  async (t) => {
+    await t
+      .typeText("#accessKey", "conditions-3-" + unixTimestamp)
+      .typeText("#secretKey", "conditions1234")
+      .click(submitButton);
+  },
+  { preserveUrl: true }
+);

--- a/restapi/admin_objects.go
+++ b/restapi/admin_objects.go
@@ -44,6 +44,7 @@ type WSResponse struct {
 	Error      string           `json:"error,omitempty"`
 	RequestEnd bool             `json:"request_end,omitempty"`
 	Prefix     string           `json:"prefix,omitempty"`
+	BucketName string           `json:"bucketName,omitempty"`
 	Data       []ObjectResponse `json:"data,omitempty"`
 }
 

--- a/restapi/ws_objects.go
+++ b/restapi/ws_objects.go
@@ -104,9 +104,10 @@ func (wsc *wsMinioClient) objectManager(session *models.Principal) {
 							}
 							if lsObj.Err != nil {
 								writeChannel <- WSResponse{
-									RequestID: messageRequest.RequestID,
-									Error:     lsObj.Err.Error(),
-									Prefix:    messageRequest.Prefix,
+									RequestID:  messageRequest.RequestID,
+									Error:      lsObj.Err.Error(),
+									Prefix:     messageRequest.Prefix,
+									BucketName: messageRequest.BucketName,
 								}
 
 								continue
@@ -177,9 +178,10 @@ func (wsc *wsMinioClient) objectManager(session *models.Principal) {
 						for lsObj := range startRewindListing(ctx, mcS3C, objectRqConfigs) {
 							if lsObj.Err != nil {
 								writeChannel <- WSResponse{
-									RequestID: messageRequest.RequestID,
-									Error:     lsObj.Err.String(),
-									Prefix:    messageRequest.Prefix,
+									RequestID:  messageRequest.RequestID,
+									Error:      lsObj.Err.String(),
+									Prefix:     messageRequest.Prefix,
+									BucketName: messageRequest.BucketName,
 								}
 
 								continue


### PR DESCRIPTION
fixes #2835 

## What does this do?

Fixes an issue where resources policies can return incorrect items in subpaths

## How to test

1. In console create a policy with this content and assign it to a user
```json
{
 "Version":"2012-10-17",
 "Statement": [
   {
     "Sid": "AllowUserToSeeBucketListInTheConsole",
     "Action": ["s3:ListAllMyBuckets", "s3:GetBucketLocation"],
     "Effect": "Allow",
     "Resource": ["arn:aws:s3:::*"]
   },
  {
     "Sid": "AllowRootAndHomeListingOfCompanyBucket",
     "Action": ["s3:ListBucket"],
     "Effect": "Allow",
     "Resource": ["arn:aws:s3:::my-company"],
     "Condition":{"StringEquals":{"s3:prefix":["","home/", "home/David"],"s3:delimiter":["/"]}}
    },
   {
     "Sid": "AllowListingOfUserFolder",
     "Action": ["s3:ListBucket"],
     "Effect": "Allow",
     "Resource": ["arn:aws:s3:::my-company"],
     "Condition":{"StringLike":{"s3:prefix":["home/David/*"]}}
   },
   {
     "Sid": "AllowAllS3ActionsInUserFolder",
     "Effect": "Allow",
     "Action": ["s3:*"],
     "Resource": ["arn:aws:s3:::my-company/home/David/*"]
   }
 ]
}
```
2. In your local MinIO instance, create a bucket called `my-company` and create a home folder inside it
3. Inside the home folder, create some folders, one of the must be called `David`. Add files to them
4. Login as the user with the assigned policy and navigate to `home/David` inside `my-company` bucket. Files must be seen
5. Try to navigate to a different folder inside `home`, an Access Denied error must be seen.

## How does it look?

![2023-06-06 17-17-39 2023-06-06 17_20_08 (1)](https://github.com/minio/console/assets/33497058/70c14b73-887b-4419-a4fd-4a65ebeebc1e)
