### PR TITLE
Refactor session to avoid duplicate calls to apis

### DIFF
--- a/portal-ui/src/screens/Console/CommandBar.tsx
+++ b/portal-ui/src/screens/Console/CommandBar.tsx
@@ -152,9 +152,9 @@ const CommandBar = () => {
   }, []);
 
   const initialActions: Action[] = routesAsKbarActions(
-    features,
     buckets,
-    navigate
+    navigate,
+    features
   );
 
   useRegisterActions(initialActions, [buckets, features]);

--- a/portal-ui/src/screens/Console/consoleSlice.ts
+++ b/portal-ui/src/screens/Console/consoleSlice.ts
@@ -15,30 +15,36 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { SessionResponse } from "../../api/consoleApi";
 import { AppState } from "../../store";
-import { SessionResponse } from "api/consoleApi";
+import { fetchSession } from "../../screens/LoginPage/sessionThunk";
+
+export enum SessionCallStates {
+  Idle = "idle",
+  Loading = "loading",
+  Done = "done",
+}
 
 export interface ConsoleState {
   session: SessionResponse;
+  sessionLoadingState: SessionCallStates;
 }
 
 const initialState: ConsoleState = {
-  session: {
-    status: undefined,
-    features: [],
-    distributedMode: false,
-    permissions: {},
-    allowResources: undefined,
-    customStyles: undefined,
-    envConstants: undefined,
-    serverEndPoint: "",
-  },
+  session: {},
+  sessionLoadingState: SessionCallStates.Idle,
 };
 
 export const consoleSlice = createSlice({
   name: "console",
   initialState,
   reducers: {
+    setSessionLoadingState: (
+      state,
+      action: PayloadAction<SessionCallStates>
+    ) => {
+      state.sessionLoadingState = action.payload;
+    },
     saveSessionResponse: (state, action: PayloadAction<SessionResponse>) => {
       state.session = action.payload;
     },
@@ -46,9 +52,19 @@ export const consoleSlice = createSlice({
       state.session = initialState.session;
     },
   },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchSession.pending, (state, action) => {
+        state.sessionLoadingState = SessionCallStates.Loading;
+      })
+      .addCase(fetchSession.fulfilled, (state, action) => {
+        state.sessionLoadingState = SessionCallStates.Done;
+      });
+  },
 });
 
-export const { saveSessionResponse, resetSession } = consoleSlice.actions;
+export const { saveSessionResponse, resetSession, setSessionLoadingState } =
+  consoleSlice.actions;
 export const selSession = (state: AppState) => state.console.session;
 export const selFeatures = (state: AppState) =>
   state.console.session ? state.console.session.features : [];

--- a/portal-ui/src/screens/Console/consoleSlice.ts
+++ b/portal-ui/src/screens/Console/consoleSlice.ts
@@ -18,12 +18,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { SessionResponse } from "../../api/consoleApi";
 import { AppState } from "../../store";
 import { fetchSession } from "../../screens/LoginPage/sessionThunk";
-
-export enum SessionCallStates {
-  Idle = "idle",
-  Loading = "loading",
-  Done = "done",
-}
+import { SessionCallStates } from "./consoleSlice.types";
 
 export interface ConsoleState {
   session: SessionResponse;
@@ -32,7 +27,7 @@ export interface ConsoleState {
 
 const initialState: ConsoleState = {
   session: {},
-  sessionLoadingState: SessionCallStates.Idle,
+  sessionLoadingState: SessionCallStates.Initial,
 };
 
 export const consoleSlice = createSlice({

--- a/portal-ui/src/screens/Console/consoleSlice.types.ts
+++ b/portal-ui/src/screens/Console/consoleSlice.types.ts
@@ -1,0 +1,21 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+export enum SessionCallStates {
+  Initial = "initial",
+  Loading = "loading",
+  Done = "done",
+}

--- a/portal-ui/src/screens/Console/kbar-actions.tsx
+++ b/portal-ui/src/screens/Console/kbar-actions.tsx
@@ -21,9 +21,9 @@ import { IAM_PAGES } from "../../common/SecureComponent/permissions";
 import { Bucket } from "../../api/consoleApi";
 
 export const routesAsKbarActions = (
-  features: string[] | undefined,
   buckets: Bucket[],
-  navigate: (url: string) => void
+  navigate: (url: string) => void,
+  features?: string[]
 ) => {
   const initialActions: Action[] = [];
   const allowedMenuItems = validRoutes(features);

--- a/portal-ui/src/screens/LoginPage/Login.tsx
+++ b/portal-ui/src/screens/LoginPage/Login.tsx
@@ -36,7 +36,8 @@ export interface LoginStrategyPayload {
 }
 
 export const getTargetPath = () => {
-  let targetPath = "/";
+  // default to browser view to avoid redirecting first to "/" and then to "/browser" on login
+  let targetPath = "/browser";
   if (
     localStorage.getItem("redirect-path") &&
     localStorage.getItem("redirect-path") !== ""

--- a/portal-ui/src/screens/LoginPage/Login.tsx
+++ b/portal-ui/src/screens/LoginPage/Login.tsx
@@ -36,7 +36,6 @@ export interface LoginStrategyPayload {
 }
 
 export const getTargetPath = () => {
-  // default to browser view to avoid redirecting first to "/" and then to "/browser" on login
   let targetPath = "/browser";
   if (
     localStorage.getItem("redirect-path") &&

--- a/portal-ui/src/screens/LoginPage/sessionThunk.ts
+++ b/portal-ui/src/screens/LoginPage/sessionThunk.ts
@@ -27,8 +27,9 @@ import { errorToHandler } from "api/errors";
 import {
   saveSessionResponse,
   setSessionLoadingState,
-  SessionCallStates,
 } from "../Console/consoleSlice";
+import { SessionCallStates } from "../Console/consoleSlice.types";
+
 import {
   globalSetDistributedSetup,
   setOverrideStyles,
@@ -36,11 +37,13 @@ import {
 } from "../../../src/systemSlice";
 import { getOverrideColorVariants } from "../../utils/stylesUtils";
 import { userLogged } from "../../../src/systemSlice";
+import { AppState } from "../../store";
 
 export const fetchSession = createAsyncThunk(
   "session/fetchSession",
-  async (location: string, { dispatch, rejectWithValue }) => {
-    const pathnameParts = location.split("/");
+  async (_, { getState, dispatch, rejectWithValue }) => {
+    const state = getState() as AppState;
+    const pathnameParts = state.system.locationPath.split("/");
     const screen = pathnameParts.length > 2 ? pathnameParts[1] : "";
 
     return api.session

--- a/portal-ui/src/screens/LoginPage/sessionThunk.ts
+++ b/portal-ui/src/screens/LoginPage/sessionThunk.ts
@@ -1,0 +1,95 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { setErrorSnackMessage } from "../../systemSlice";
+import { api } from "api";
+import {
+  Error,
+  HttpResponse,
+  SessionResponse,
+  ListObjectsResponse,
+} from "api/consoleApi";
+import { errorToHandler } from "api/errors";
+import {
+  saveSessionResponse,
+  setSessionLoadingState,
+  SessionCallStates,
+} from "../Console/consoleSlice";
+import {
+  globalSetDistributedSetup,
+  setOverrideStyles,
+  setAnonymousMode,
+} from "../../../src/systemSlice";
+import { getOverrideColorVariants } from "../../utils/stylesUtils";
+import { userLogged } from "../../../src/systemSlice";
+
+export const fetchSession = createAsyncThunk(
+  "session/fetchSession",
+  async (location: string, { dispatch, rejectWithValue }) => {
+    const pathnameParts = location.split("/");
+    const screen = pathnameParts.length > 2 ? pathnameParts[1] : "";
+
+    return api.session
+      .sessionCheck()
+      .then((res: HttpResponse<SessionResponse, Error>) => {
+        dispatch(userLogged(true));
+        dispatch(saveSessionResponse(res.data));
+        dispatch(globalSetDistributedSetup(res.data.distributedMode || false));
+
+        if (res.data.customStyles && res.data.customStyles !== "") {
+          const overrideColorVariants = getOverrideColorVariants(
+            res.data.customStyles
+          );
+
+          if (overrideColorVariants !== false) {
+            dispatch(setOverrideStyles(overrideColorVariants));
+          }
+        }
+      })
+      .catch(async (res: HttpResponse<SessionResponse, Error>) => {
+        if (screen === "browser") {
+          const bucket = pathnameParts.length >= 3 ? pathnameParts[2] : "";
+          // no bucket, no business
+          if (bucket === "") {
+            return;
+          }
+          // before marking the session as done, let's check if the bucket is publicly accessible (anonymous)
+          api.buckets
+            .listObjects(
+              bucket,
+              { limit: 1 },
+              { headers: { "X-Anonymous": "1" } }
+            )
+            .then(() => {
+              dispatch(setAnonymousMode());
+            })
+            .catch((res: HttpResponse<ListObjectsResponse, Error>) => {
+              dispatch(setErrorSnackMessage(errorToHandler(res.error)));
+            })
+            .finally(() => {
+              // TODO: we probably need a thunk for this api since setting the state here is hacky,
+              // we can use a state to let the ProtectedRoutes know when to render the elements
+              dispatch(setSessionLoadingState(SessionCallStates.Done));
+            });
+        } else {
+          dispatch(setSessionLoadingState(SessionCallStates.Done));
+          dispatch(setErrorSnackMessage(errorToHandler(res.error)));
+        }
+        return rejectWithValue(res.error);
+      });
+  }
+);

--- a/portal-ui/src/store.ts
+++ b/portal-ui/src/store.ts
@@ -23,7 +23,7 @@ import logReducer from "./screens/Console/Logs/logsSlice";
 import healthInfoReducer from "./screens/Console/HealthInfo/healthInfoSlice";
 import watchReducer from "./screens/Console/Watch/watchSlice";
 import consoleReducer from "./screens/Console/consoleSlice";
-import bucketsReducer from "./screens/Console/Buckets/ListBuckets/AddBucket/addBucketsSlice";
+import addBucketsReducer from "./screens/Console/Buckets/ListBuckets/AddBucket/addBucketsSlice";
 import bucketDetailsReducer from "./screens/Console/Buckets/BucketDetails/bucketDetailsSlice";
 import objectBrowserReducer from "./screens/Console/ObjectBrowser/objectBrowserSlice";
 import dashboardReducer from "./screens/Console/Dashboard/dashboardSlice";
@@ -39,7 +39,7 @@ const rootReducer = combineReducers({
   logs: logReducer,
   watch: watchReducer,
   console: consoleReducer,
-  addBucket: bucketsReducer,
+  addBucket: addBucketsReducer,
   bucketDetails: bucketDetailsReducer,
   objectBrowser: objectBrowserReducer,
   healthInfo: healthInfoReducer,

--- a/portal-ui/src/systemSlice.ts
+++ b/portal-ui/src/systemSlice.ts
@@ -29,7 +29,6 @@ export interface SystemState {
   loggedIn: boolean;
   showMarketplace: boolean;
   sidebarOpen: boolean;
-  session: string;
   userName: string;
   serverNeedsRestart: boolean;
   serverIsLoading: boolean;
@@ -51,7 +50,6 @@ const initialState: SystemState = {
   value: 0,
   loggedIn: false,
   showMarketplace: false,
-  session: "",
   userName: "",
   sidebarOpen: initSideBarOpen,
   siteReplicationInfo: { siteName: "", curSite: false, enabled: false },
@@ -155,7 +153,6 @@ export const systemSlice = createSlice({
       state.licenseInfo = action.payload;
     },
     setHelpName: (state, action: PayloadAction<string>) => {
-      console.log("setting helpName: ", action.payload);
       state.helpName = action.payload;
     },
     setHelpTabName: (state, action: PayloadAction<string>) => {

--- a/portal-ui/src/systemSlice.ts
+++ b/portal-ui/src/systemSlice.ts
@@ -44,6 +44,7 @@ export interface SystemState {
   anonymousMode: boolean;
   helpName: string;
   helpTabName: string;
+  locationPath: string;
 }
 
 const initialState: SystemState = {
@@ -74,6 +75,7 @@ const initialState: SystemState = {
   anonymousMode: false,
   helpName: "help",
   helpTabName: "docs",
+  locationPath: "",
 };
 
 export const systemSlice = createSlice({
@@ -169,6 +171,9 @@ export const systemSlice = createSlice({
       state.anonymousMode = true;
       state.loggedIn = true;
     },
+    setLocationPath: (state, action: PayloadAction<string>) => {
+      state.locationPath = action.payload;
+    },
     resetSystem: () => {
       return initialState;
     },
@@ -197,6 +202,7 @@ export const {
   configurationIsLoading,
   setHelpName,
   setHelpTabName,
+  setLocationPath,
 } = systemSlice.actions;
 
 export const selDistSet = (state: AppState) => state.system.distributedSetup;


### PR DESCRIPTION
### Description:
Refactors the way we were calling `/session` api since previous implementaiton was making multiple requests (up to six) which could mean high latency if that requests take time to resolve. Now we call it only once and only at initial load. 

### Changes:
- [x] created Session thunk to control Session API state 
- [x] Create new state in consoleSlice to store the session state (loading, done, etc)
- [x] Updated Loging.tsx to default to `/browser` to avoid redirecting first to `/` and then to `/browser` when logging in.  

Before:
<img width="537" alt="Screenshot 2023-06-12 at 10 50 46 PM" src="https://github.com/minio/console/assets/11819101/d793ea39-9a3e-4e03-bf69-2d8f6f4398fb">

After:
<img width="378" alt="Screenshot 2023-06-12 at 11 05 27 PM" src="https://github.com/minio/console/assets/11819101/262a5e91-1b79-49a2-86e3-e46c37827436">

If navigating between tabs it won't call session api.
<img width="318" alt="Screenshot 2023-06-13 at 1 59 49 PM" src="https://github.com/minio/console/assets/11819101/daecdead-6584-4fdb-84ba-a22ed3ba7ce7">


### Test Steps:
Scenarios:
- With a minio running on port 9000, make assets and then make the binary `make assets && make` then run it on port 9090 like:
```
CONSOLE_ACCESS_KEY=minioconsole
CONSOLE_SECRET_KEY=minioconsole
CONSOLE_MINIO_SERVER=http://localhost:9000
CONSOLE_DEV_MODE=on ./console server
```
- Can login with valid user and the amount of calls to `/session` api are not more than one.
- Navigate between tabs (we should call `/session` only ONCE at initial load of whole page)
- Anonymous access works without issues (create bucket, set anonymous access to it  [path `/`] and try to access to it without loging in). Everything should work just fine.