### PR TITLE
Fix download of folders

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
@@ -112,7 +112,9 @@ class DownloadHelper {
     let isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     if (isSafari) {
       this.toastCallback();
-      this.downloadSafari();
+      this.downloadByBrowser();
+    } else if (!this.fileSize) {
+      this.downloadByBrowser();
     } else {
       this.download({
         url: this.path,
@@ -187,7 +189,7 @@ class DownloadHelper {
     }
   }
 
-  downloadSafari() {
+  downloadByBrowser() {
     const link = document.createElement("a");
     link.href = this.path;
     document.body.appendChild(link);


### PR DESCRIPTION
Fixes: https://github.com/minio/console/issues/2890

Folders don't have a size attribute when they are retrieved from minio, i believe this is for design so new way to download in chunks won't work in this case, for the moment i'll let the browser handle the download as we do it for safari and later i'll check minio code if there is a way to send the size for folders to console