### PR TITLE
audit only the dependencies and exclude dev dependencies in ci for ui

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -241,7 +241,7 @@ jobs:
         working-directory: ./portal-ui
         continue-on-error: false
         run: |
-          yarn audit
+          yarn audit --groups dependencies
 
   all-permissions-1:
     name: Permissions Tests Part 1


### PR DESCRIPTION
audit only the dependencies and exclude dev dependencies in  ci for ui

fix ci failure due to dev dependencies checked for vulnerabilities. 