### PR TITLE
Removing white spaces from provided values

### DIFF
--- a/portal-ui/src/screens/Console/EventDestinations/ConfTargetGeneric.tsx
+++ b/portal-ui/src/screens/Console/EventDestinations/ConfTargetGeneric.tsx
@@ -98,6 +98,7 @@ const ConfTargetGeneric = ({
 
   const setValueElement = (key: string, value: string, index: number) => {
     const valuesDup = [...valueHolder];
+    value = value.trim();
     valuesDup[index] = { key, value };
 
     setValueHolder(valuesDup);


### PR DESCRIPTION
To fix: https://github.com/minio/console/issues/2755

### Explanation:

All I am doing is to trim the spaces introduced by the user so that we avoid an invalid configuration:

```
API: SYSTEM()
Time: 14:05:47 UTC 06/30/2023
DeploymentID: ad79aacc-3ffb-4726-9ff3-6cc7ca58b27a
Error: Invalid site configuration: region ' us-west-rack-2' is invalid, expected simple characters such as [us-east-1, myregion...] (*fmt.wrapError)
       7: internal/logger/logger.go:258:logger.LogIf()
       6: cmd/config-current.go:493:cmd.lookupConfigs()
       5: cmd/config.go:218:cmd.initConfig()
       4: cmd/config.go:189:cmd.(*ConfigSys).Init()
       3: cmd/server-main.go:452:cmd.initConfigSubsystem()
       2: cmd/server-main.go:423:cmd.initServerConfig()
       1: cmd/server-main.go:662:cmd.serverMain()
```

I think this can be generic as in non of our configurations we need leading or trailing spaces to work, so trim seems to be the solution here.