### PR TITLE
add support for preview based on content type

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -60,7 +60,7 @@ import {
 } from "../../../../Common/FormComponents/common/styleLibrary";
 import { Badge } from "@mui/material";
 import BrowserBreadcrumbs from "../../../../ObjectBrowser/BrowserBreadcrumbs";
-import { extensionPreview } from "../utils";
+import { AllowedPreviews, previewObjectType } from "../utils";
 import { ErrorResponseHandler } from "../../../../../../common/types";
 
 import { AppState, useAppDispatch } from "../../../../../../store";
@@ -301,6 +301,9 @@ const ListObjects = () => {
   const [canPreviewFile, setCanPreviewFile] = useState<boolean>(false);
   const [quota, setQuota] = useState<BucketQuota | null>(null);
 
+  const [metaData, setMetaData] = useState<any>(null);
+  const [isMetaDataLoaded, setIsMetaDataLoaded] = useState(false);
+
   const isVersioningApplied = isVersionedMode(versioningConfig.status);
   const bucketName = params.bucketName || "";
 
@@ -365,6 +368,37 @@ const ListObjects = () => {
     (state: AppState) => state.objectBrowser.selectedObjects
   );
 
+  const fetchMetadata = useCallback(() => {
+    const objectName = selectedObjects[0];
+
+    if (!isMetaDataLoaded) {
+      const encodedPath = encodeURLString(objectName);
+      api.buckets
+        .getObjectMetadata(bucketName, {
+          prefix: encodedPath,
+        })
+        .then((res) => {
+          let metadata = get(res.data, "objectMetadata", {});
+          setIsMetaDataLoaded(true);
+          setMetaData(metadata);
+        })
+        .catch((err) => {
+          console.error(
+            "Error Getting Metadata Status: ",
+            err,
+            err?.detailedError
+          );
+          setIsMetaDataLoaded(true);
+        });
+    }
+  }, [bucketName, selectedObjects, isMetaDataLoaded]);
+
+  useEffect(() => {
+    if (bucketName && selectedObjects.length === 1) {
+      fetchMetadata();
+    }
+  }, [bucketName, selectedObjects, fetchMetadata]);
+
   useEffect(() => {
     dispatch(setSearchObjects(""));
     dispatch(setLoadingObjects(true));
@@ -392,8 +426,9 @@ const ListObjects = () => {
   useEffect(() => {
     if (selectedObjects.length === 1) {
       const objectName = selectedObjects[0];
+      let objectType: AllowedPreviews = previewObjectType(metaData, objectName);
 
-      if (extensionPreview(objectName) !== "none" && canDownload) {
+      if (objectType !== "none") {
         setCanPreviewFile(true);
       } else {
         setCanPreviewFile(false);
@@ -408,7 +443,7 @@ const ListObjects = () => {
       setCanShareFile(false);
       setCanPreviewFile(false);
     }
-  }, [selectedObjects, canDownload]);
+  }, [selectedObjects, canDownload, metaData]);
 
   useEffect(() => {
     if (!quota && !anonymousMode) {

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -428,7 +428,7 @@ const ListObjects = () => {
       const objectName = selectedObjects[0];
       let objectType: AllowedPreviews = previewObjectType(metaData, objectName);
 
-      if (objectType !== "none") {
+      if (objectType !== "none" && canDownload) {
         setCanPreviewFile(true);
       } else {
         setCanPreviewFile(false);

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ObjectDetailPanel.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ObjectDetailPanel.tsx
@@ -44,7 +44,7 @@ import {
   spacingUtils,
   textStyleUtils,
 } from "../../../../Common/FormComponents/common/styleLibrary";
-import { extensionPreview } from "../utils";
+import { AllowedPreviews, previewObjectType } from "../utils";
 
 import {
   decodeURLString,
@@ -395,6 +395,8 @@ const ObjectDetailPanel = ({
     [IAM_SCOPES.S3_DELETE_OBJECT]
   );
 
+  let objectType: AllowedPreviews = previewObjectType(metaData, currentItem);
+
   const multiActionButtons = [
     {
       action: () => {
@@ -431,8 +433,7 @@ const ObjectDetailPanel = ({
       label: "Preview",
       disabled:
         !!actualInfo.is_delete_marker ||
-        extensionPreview(currentItem) === "none" ||
-        !canGetObject,
+        (objectType === "none" && !canGetObject),
       icon: <PreviewIcon />,
       tooltip: canGetObject
         ? "Preview this File"

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/types.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/types.tsx
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { BucketObject } from "api/consoleApi";
-import { IFileInfo } from "../ObjectDetails/types";
 
 export interface BucketObjectItem {
   name: string;

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/types.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/types.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { BucketObject } from "api/consoleApi";
+import { IFileInfo } from "../ObjectDetails/types";
 
 export interface BucketObjectItem {
   name: string;

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
@@ -200,10 +200,30 @@ class DownloadHelper {
   }
 }
 
+export type AllowedPreviews = "image" | "text" | "audio" | "video" | "none";
+export const contentTypePreview = (contentType: string): AllowedPreviews => {
+  if (contentType) {
+    const mimeObjectType = (contentType || "").toLowerCase();
+
+    if (mimeObjectType.includes("image")) {
+      return "image";
+    }
+    if (mimeObjectType.includes("text")) {
+      return "text";
+    }
+    if (mimeObjectType.includes("audio")) {
+      return "audio";
+    }
+    if (mimeObjectType.includes("video")) {
+      return "video";
+    }
+  }
+
+  return "none";
+};
+
 // Review file extension by name & returns the type of preview browser that can be used
-export const extensionPreview = (
-  fileName: string
-): "image" | "text" | "audio" | "video" | "none" => {
+export const extensionPreview = (fileName: string): AllowedPreviews => {
   const imageExtensions = [
     "jif",
     "jfif",
@@ -262,6 +282,30 @@ export const extensionPreview = (
   return "none";
 };
 
+export const previewObjectType = (
+  metaData: Record<any, any>,
+  objectName: string
+) => {
+  const metaContentType = (
+    (metaData && metaData["Content-Type"]) ||
+    ""
+  ).toString();
+
+  const extensionType = extensionPreview(objectName || "");
+  const contentType = contentTypePreview(metaContentType);
+
+  let objectType: AllowedPreviews = extensionType;
+
+  if (extensionType === contentType) {
+    objectType = extensionType;
+  } else if (extensionType === "none" && contentType !== "none") {
+    objectType = contentType;
+  } else if (contentType === "none" && extensionType !== "none") {
+    objectType = extensionType;
+  }
+
+  return objectType;
+};
 export const sortListObjects = (fieldSort: string) => {
   switch (fieldSort) {
     case "name":

--- a/portal-ui/src/screens/Console/ObjectBrowser/utils.ts
+++ b/portal-ui/src/screens/Console/ObjectBrowser/utils.ts
@@ -39,10 +39,9 @@ export const downloadObject = (
     `${bucketName}-${object.name}-${new Date().getTime()}-${Math.random()}`
   );
 
-  if (
-    object.name?.length ||
-    (0 > 200 && getClientOS().toLowerCase().includes("win"))
-  ) {
+  const isWinOs = getClientOS().toLowerCase().includes("win");
+
+  if ((object.name?.length || 0) > 200 && isWinOs) {
     dispatch(setLongFileOpen(true));
     return;
   }


### PR DESCRIPTION
add support for preview based on content type

Fixes https://github.com/minio/console/issues/2919

it adds functionality on top of extension based file preview. so the existing functionalities should be un affected.