### PR TITLE
preserve white space in breadcrumb disply and navigation

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/IconWithLabel.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/IconWithLabel.tsx
@@ -24,7 +24,7 @@ const styles = (theme: Theme) =>
       },
     },
     fileNameText: {
-      whiteSpace: "nowrap",
+      whiteSpace: "pre",
       overflow: "hidden",
       textOverflow: "ellipsis",
     },

--- a/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
@@ -22,7 +22,7 @@ import makeStyles from "@mui/styles/makeStyles";
 import { Theme } from "@mui/material/styles";
 import { Link, useNavigate } from "react-router-dom";
 import { objectBrowserCommon } from "../Common/FormComponents/common/styleLibrary";
-import { encodeURLString } from "../../../common/utils";
+import { encodeURLString, safeDecodeURIComponent } from "../../../common/utils";
 import { Button, CopyIcon, NewPathIcon, Tooltip, Breadcrumbs } from "mds";
 import { hasPermission } from "../../../common/SecureComponent";
 import {
@@ -127,9 +127,14 @@ const BrowserBreadcrumbs = ({
       <Fragment key={`breadcrumbs-${index.toString()}`}>
         <span className={classes.slashSpacingStyle}>/</span>
         {index === lastBreadcrumbsIndex ? (
-          <span style={{ cursor: "default" }}>{objectItem}</span>
+          <span style={{ cursor: "default", whiteSpace: "pre" }}>
+            {safeDecodeURIComponent(objectItem) /*Only for display*/}
+          </span>
         ) : (
           <Link
+            style={{
+              whiteSpace: "pre",
+            }}
             to={route}
             onClick={() => {
               dispatch(
@@ -137,7 +142,11 @@ const BrowserBreadcrumbs = ({
               );
             }}
           >
-            {objectItem}
+            {
+              safeDecodeURIComponent(
+                objectItem
+              ) /*Only for display to preserve */
+            }
           </Link>
         )}
       </Fragment>
@@ -210,6 +219,9 @@ const BrowserBreadcrumbs = ({
           />
         )}
         <Breadcrumbs
+          sx={{
+            whiteSpace: "pre",
+          }}
           goBackFunction={goBackFunction}
           additionalOptions={
             <Fragment>


### PR DESCRIPTION
Fixes https://github.com/minio/console/issues/1543
preserve white space while display in ui. objects, folder, breadcrumb


![image](https://github.com/minio/console/assets/23444145/8a71bf7e-d94d-4677-9498-99de25a70779)


![image](https://github.com/minio/console/assets/23444145/5e88baf5-39d9-4bb8-8799-2ff9dfb3bb15)
