### PR TITLE
Removed extra 'Event Destination' text

### DIFF
--- a/portal-ui/src/screens/Console/EventDestinations/AddEventDestination.tsx
+++ b/portal-ui/src/screens/Console/EventDestinations/AddEventDestination.tsx
@@ -182,10 +182,7 @@ const AddEventDestination = ({
                 {targetElement && (
                   <TargetTitle
                     logoSrc={targetElement.logo}
-                    title={`${
-                      targetElement ? targetElement.targetTitle : ""
-                    } Event
-                        Destination`}
+                    title={targetElement ? targetElement.targetTitle : ""}
                   />
                 )}
               </Grid>


### PR DESCRIPTION
Before:
<img width="913" alt="Screenshot 2023-07-11 at 1 47 45 PM" src="https://github.com/minio/console/assets/65002498/9a7a04ba-e8ee-4a6b-a430-e5f451c963a1">
After:
<img width="913" alt="Screenshot 2023-07-11 at 1 47 32 PM" src="https://github.com/minio/console/assets/65002498/9367983d-32eb-4acd-ba79-c60cf7f26283">
