### PR TITLE
fix loading of objects at a path when url is shared opened elsewhere

### DIFF
--- a/portal-ui/src/common/utils.ts
+++ b/portal-ui/src/common/utils.ts
@@ -434,12 +434,27 @@ export const representationNumber = (number: number | undefined) => {
   return `${returnValue}${unit}`;
 };
 
+/** Ref https://developer.mozilla.org/en-US/docs/Glossary/Base64 */
+
+const base64ToBytes = (base64: any): Uint8Array => {
+  const binString: any = atob(base64);
+  // @ts-ignore
+  return Uint8Array.from(binString, (m) => m.codePointAt(0));
+};
+
+const bytesToBase64 = (bytes: any) => {
+  const binString = Array.from(bytes, (x: any) => String.fromCodePoint(x)).join(
+    ""
+  );
+  return btoa(binString);
+};
+
 export const encodeURLString = (name: string | null) => {
   if (!name) {
     return "";
   }
   try {
-    return btoa(unescape(encodeURIComponent(name)));
+    return bytesToBase64(new TextEncoder().encode(name));
   } catch (err) {
     return "";
   }
@@ -447,7 +462,7 @@ export const encodeURLString = (name: string | null) => {
 
 export const decodeURLString = (text: string) => {
   try {
-    return decodeURIComponent(escape(window.atob(text)));
+    return new TextDecoder().decode(base64ToBytes(text));
   } catch (err) {
     return text;
   }

--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/BrowserHandler.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/BrowserHandler.tsx
@@ -292,18 +292,6 @@ const BrowserHandler = () => {
   );
 
   useEffect(() => {
-    // when a bucket param changes, (i.e /browser/:bucketName),  re-init e.g with KBar, this should not apply for resources prefixes.
-    const permitItems = permissionItems(bucketName, "", allowResources || []);
-
-    if (bucketName && (!permitItems || permitItems.length === 0)) {
-      dispatch(resetMessages());
-      dispatch(setLoadingRecords(true));
-      dispatch(setLoadingObjects(true));
-      initWSRequest("", new Date());
-    }
-  }, [bucketName, dispatch, initWSRequest, allowResources]);
-
-  useEffect(() => {
     return () => {
       const request: WebsocketRequest = {
         mode: "cancel",
@@ -479,6 +467,18 @@ const BrowserHandler = () => {
       }
     }
   }, [bucketName, loadingLocking, dispatch, displayListObjects]);
+
+  useEffect(() => {
+    // when a bucket param changes, (i.e /browser/:bucketName),  re-init e.g with KBar, this should not apply for resources prefixes.
+    const permitItems = permissionItems(bucketName, "", allowResources || []);
+
+    if (bucketName && (!permitItems || permitItems.length === 0)) {
+      dispatch(resetMessages());
+      dispatch(setLoadingRecords(true));
+      dispatch(setLoadingObjects(true));
+      initWSRequest("", new Date());
+    }
+  }, [bucketName, dispatch, initWSRequest, allowResources]);
 
   return (
     <Fragment>


### PR DESCRIPTION
Fixes https://github.com/minio/console/issues/2942

When a path is shared and opened in a new browser instance, only the top level was loaded.

with this fix, the shared path would load as expected.
