### PR TITLE
fix console dashboard node io prometheus metric WChar and RChar

### DIFF
--- a/restapi/admin_info.go
+++ b/restapi/admin_info.go
@@ -837,8 +837,8 @@ var widgets = []Metric{
 			},
 
 			{
-				Expr:         `rate(minio_node_io_rchar_bytes{$__query}[$__rate_interval])`,
-				LegendFormat: "Node RChar [{{server}}]",
+				Expr:         `rate(minio_node_io_wchar_bytes{$__query}[$__rate_interval])`,
+				LegendFormat: "Node WChar [{{server}}]",
 			},
 		},
 	},


### PR DESCRIPTION
Fixes https://github.com/minio/console/issues/2667

Fix duplicate series  in Node IO chart to show WChar and RChar series shown in console Prometheus dashboard.


<details>
<summary> Metrics in Prometheus/Grafana</summary>


Grafana:

![image](https://github.com/minio/console/assets/23444145/49bbb76c-d629-472f-9318-f6f2b9e3c772)

</details>