### PR TITLE
dashboard metrics

### DIFF
--- a/portal-ui/src/screens/Console/Common/FormComponents/DateTimePickerWrapper/DateTimePickerWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/DateTimePickerWrapper/DateTimePickerWrapper.tsx
@@ -316,8 +316,8 @@ const DateTimePickerWrapper = ({
         xs={12}
         className={`${containerCls} ${classNamePrefix}input-field-container`}
         sx={{
-          display: "flex",
-          alignItems: "center",
+          display: "grid",
+          gridAutoColumns: "max-content",
         }}
       >
         {label !== "" && (

--- a/portal-ui/src/screens/Console/Dashboard/Prometheus/utils.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Prometheus/utils.tsx
@@ -736,11 +736,7 @@ export const widgetDetailsToPanel = (
         if (panelItem.customStructure) {
           values = panelItem.customStructure.map((structureItem) => {
             const metricTake = chartBars.find((element: any) => {
-              const metricKeyItem = Object.keys(element.metric);
-
-              const metricName = element.metric[metricKeyItem[0]];
-
-              return metricName === structureItem.originTag;
+              return element.metric.range === structureItem.originTag;
             });
 
             const elements = get(metricTake, "values", []);

--- a/restapi/admin_info.go
+++ b/restapi/admin_info.go
@@ -331,7 +331,7 @@ var widgets = []Metric{
 		},
 		Targets: []Target{
 			{
-				Expr:         `max by (range) (minio_cluster_objects_size_distribution{$__query})`,
+				Expr:         `minio_cluster_objects_size_distribution{$__query}`,
 				LegendFormat: "{{range}}",
 				Step:         300,
 			},

--- a/restapi/admin_info.go
+++ b/restapi/admin_info.go
@@ -471,7 +471,7 @@ var widgets = []Metric{
 		ID:            66,
 		Title:         "Number of Buckets",
 		Type:          "stat",
-		MaxDataPoints: 100,
+		MaxDataPoints: 5,
 		GridPos: GridPos{
 			H: 3,
 			W: 3,
@@ -487,8 +487,9 @@ var widgets = []Metric{
 		},
 		Targets: []Target{
 			{
-				Expr:         `count(count by (bucket) (minio_bucket_usage_total_bytes{$__query}))`,
+				Expr:         `minio_cluster_bucket_total{$__query}`,
 				LegendFormat: "",
+				Step:         100,
 			},
 		},
 	},

--- a/restapi/admin_info.go
+++ b/restapi/admin_info.go
@@ -305,7 +305,7 @@ var widgets = []Metric{
 		},
 		Targets: []Target{
 			{
-				Expr:         `sum(minio_cluster_usage_total_bytes{$__query}) by (instance)`,
+				Expr:         `minio_cluster_usage_total_bytes{$__query}`,
 				LegendFormat: "Used Capacity",
 				InitialTime:  -180,
 				Step:         10,
@@ -599,7 +599,7 @@ var widgets = []Metric{
 		},
 		Targets: []Target{
 			{
-				Expr:         `topk(1, sum(minio_cluster_usage_object_total{$__query}) by (instance))`,
+				Expr:         `minio_cluster_usage_object_total{$__query}`,
 				LegendFormat: "",
 			},
 		},

--- a/restapi/admin_info.go
+++ b/restapi/admin_info.go
@@ -305,7 +305,7 @@ var widgets = []Metric{
 		},
 		Targets: []Target{
 			{
-				Expr:         `sum(minio_bucket_usage_total_bytes{$__query}) by (instance)`,
+				Expr:         `sum(minio_cluster_usage_total_bytes{$__query}) by (instance)`,
 				LegendFormat: "Used Capacity",
 				InitialTime:  -180,
 				Step:         10,
@@ -331,7 +331,7 @@ var widgets = []Metric{
 		},
 		Targets: []Target{
 			{
-				Expr:         `max by (range) (minio_bucket_objects_size_distribution{$__query})`,
+				Expr:         `max by (range) (minio_cluster_objects_size_distribution{$__query})`,
 				LegendFormat: "{{range}}",
 				Step:         300,
 			},
@@ -598,7 +598,7 @@ var widgets = []Metric{
 		},
 		Targets: []Target{
 			{
-				Expr:         `topk(1, sum(minio_bucket_usage_object_total{$__query}) by (instance))`,
+				Expr:         `topk(1, sum(minio_cluster_usage_object_total{$__query}) by (instance))`,
 				LegendFormat: "",
 			},
 		},


### PR DESCRIPTION

![image](https://github.com/minio/console/assets/23444145/8d203517-a097-4370-b382-eb9466ab0aad)

Note: This PR depends on https://github.com/minio/minio/pull/17663


Note: `Buckets`  i.e: Number of Buckets  requires  update to new endpoint may be, as  it is not available at cluster level `minio_cluster_usage_total_bytes` does not publish bucket name.

@harshavardhana 
