### PR TITLE
Update Github jobs to use hardcoded testcafe version

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -383,6 +383,7 @@ jobs:
         run: npm install testcafe@3.0.0
 
       - name: Run TestCafe Tests
+        timeout-minutes: 10
         run: npx testcafe "chrome:headless" portal-ui/tests/permissions-4/ -q --skip-js-errors -c 3
 
   all-permissions-5:
@@ -425,6 +426,7 @@ jobs:
         run: npm install testcafe@3.0.0
 
       - name: Run TestCafe Tests
+        timeout-minutes: 5
         run: npx testcafe "chrome:headless" portal-ui/tests/permissions-5/ -q --skip-js-errors -c 3
 
   all-permissions-6:
@@ -467,6 +469,7 @@ jobs:
         run: npm install testcafe@3.0.0
 
       - name: Run TestCafe Tests
+        timeout-minutes: 5
         run: npx testcafe "chrome:headless" portal-ui/tests/permissions-6/ -q --skip-js-errors -c 3
 
   all-permissions-7:
@@ -508,6 +511,7 @@ jobs:
         run: npm install testcafe@3.0.0
 
       - name: Run TestCafe Tests
+        timeout-minutes: 5
         run: npx testcafe "chrome:headless" portal-ui/tests/permissions-7/ -q --skip-js-errors -c 3
 
   all-permissions-8:
@@ -550,6 +554,7 @@ jobs:
         run: npm install testcafe@3.0.0
 
       - name: Run TestCafe Tests
+        timeout-minutes: 5
         run: npx testcafe "chrome:headless" portal-ui/tests/permissions-8/ -q --skip-js-errors -c 3
 
   all-permissions-9:

--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -238,10 +238,11 @@ jobs:
         run: |
           (./console server) & (make initialize-permissions)
 
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"firefox --headless --no-sandbox" portal-ui/tests/permissions-1/ --skip-js-errors -c 3'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-1/ -q --skip-js-errors -c 3
 
       - name: Clean up users & policies
         run: |
@@ -284,10 +285,11 @@ jobs:
         run: |
           (./console server) & (make initialize-permissions)
 
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"firefox --headless --no-sandbox" portal-ui/tests/permissions-2/ --skip-js-errors -c 3'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-2/ -q --skip-js-errors -c 3
 
       - name: Clean up users & policies
         run: |
@@ -330,10 +332,11 @@ jobs:
         run: |
           (./console server) & (make initialize-permissions)
 
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"firefox --headless --no-sandbox" portal-ui/tests/permissions-3/ --skip-js-errors -c 3'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-3/ -q --skip-js-errors -c 3
 
       - name: Clean up users & policies
         run: |
@@ -375,11 +378,13 @@ jobs:
       - name: Start Console, front-end app and initialize users/policies
         run: |
           (./console server) & (make initialize-permissions)
+
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        timeout-minutes: 10
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"firefox --headless --no-sandbox" portal-ui/tests/permissions-4/ --skip-js-errors'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-4/ -q --skip-js-errors -c 3
+
   all-permissions-5:
     name: Permissions Tests Part 5
     needs:
@@ -415,11 +420,13 @@ jobs:
       - name: Start Console, front-end app and initialize users/policies
         run: |
           (./console server) & (make initialize-permissions)
+
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        timeout-minutes: 5
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"firefox --headless --no-sandbox" portal-ui/tests/permissions-5/ --skip-js-errors'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-5/ -q --skip-js-errors -c 3
+
   all-permissions-6:
     name: Permissions Tests Part 6
     needs:
@@ -455,11 +462,13 @@ jobs:
       - name: Start Console, front-end app and initialize users/policies
         run: |
           (./console server) & (make initialize-permissions)
+
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        timeout-minutes: 5
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"firefox --headless --no-sandbox" portal-ui/tests/permissions-6/ --skip-js-errors'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-6/ -q --skip-js-errors -c 3
+
   all-permissions-7:
     name: Permissions Tests Part 7
     needs:
@@ -495,11 +504,12 @@ jobs:
       - name: Start Console, front-end app and initialize users/policies
         run: |
           (./console server) & (make initialize-permissions)
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        timeout-minutes: 5
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"firefox --headless --no-sandbox" portal-ui/tests/permissions-7/ --skip-js-errors'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-7/ -q --skip-js-errors -c 3
+
   all-permissions-8:
     name: Permissions Tests Part 8
     needs:
@@ -535,11 +545,13 @@ jobs:
       - name: Start Console, front-end app and initialize users/policies
         run: |
           (./console server) & (make initialize-permissions)
+
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        timeout-minutes: 5
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"chrome --headless --no-sandbox" portal-ui/tests/permissions-8/ --skip-js-errors'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-8/ -q --skip-js-errors -c 3
+
   all-permissions-9:
     name: Permissions Tests Part 9
     needs:
@@ -576,10 +588,11 @@ jobs:
         run: |
           (./console server) & (make initialize-permissions)
 
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"firefox --headless --no-sandbox" portal-ui/tests/permissions-9/ --skip-js-errors -c 3'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-9/ -q --skip-js-errors -c 3
 
       - name: Clean up users & policies
         run: |
@@ -621,10 +634,11 @@ jobs:
         run: |
           (./console server) & (make initialize-permissions)
 
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"firefox --headless --no-sandbox" portal-ui/tests/permissions-A/ --skip-js-errors -c 3'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-A/ -q --skip-js-errors -c 3
 
       - name: Clean up users & policies
         run: |
@@ -666,10 +680,11 @@ jobs:
         run: |
           (./console server) & (make initialize-permissions)
 
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
       - name: Run TestCafe Tests
-        uses: DevExpress/testcafe-action@latest
-        with:
-          args: '"firefox --headless --no-sandbox" portal-ui/tests/permissions-B/ --skip-js-errors -c 3'
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-B/ -q --skip-js-errors -c 3
 
       - name: Clean up users & policies
         run: |

--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -384,7 +384,7 @@ jobs:
 
       - name: Run TestCafe Tests
         timeout-minutes: 10
-        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-4/ -q --skip-js-errors -c 3
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-4/ --skip-js-errors
 
   all-permissions-5:
     name: Permissions Tests Part 5
@@ -427,7 +427,7 @@ jobs:
 
       - name: Run TestCafe Tests
         timeout-minutes: 5
-        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-5/ -q --skip-js-errors -c 3
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-5/ --skip-js-errors
 
   all-permissions-6:
     name: Permissions Tests Part 6
@@ -470,7 +470,7 @@ jobs:
 
       - name: Run TestCafe Tests
         timeout-minutes: 5
-        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-6/ -q --skip-js-errors -c 3
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-6/ --skip-js-errors
 
   all-permissions-7:
     name: Permissions Tests Part 7
@@ -512,7 +512,7 @@ jobs:
 
       - name: Run TestCafe Tests
         timeout-minutes: 5
-        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-7/ -q --skip-js-errors -c 3
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-7/ --skip-js-errors
 
   all-permissions-8:
     name: Permissions Tests Part 8
@@ -555,7 +555,7 @@ jobs:
 
       - name: Run TestCafe Tests
         timeout-minutes: 5
-        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-8/ -q --skip-js-errors -c 3
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-8/ --skip-js-errors
 
   all-permissions-9:
     name: Permissions Tests Part 9
@@ -597,7 +597,7 @@ jobs:
         run: npm install testcafe@3.0.0
 
       - name: Run TestCafe Tests
-        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-9/ -q --skip-js-errors -c 3
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-9/ --skip-js-errors -c 3
 
       - name: Clean up users & policies
         run: |
@@ -643,7 +643,7 @@ jobs:
         run: npm install testcafe@3.0.0
 
       - name: Run TestCafe Tests
-        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-A/ -q --skip-js-errors -c 3
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-A/ --skip-js-errors -c 3
 
       - name: Clean up users & policies
         run: |
@@ -689,7 +689,7 @@ jobs:
         run: npm install testcafe@3.0.0
 
       - name: Run TestCafe Tests
-        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-B/ -q --skip-js-errors -c 3
+        run: npx testcafe "chrome:headless" portal-ui/tests/permissions-B/ --skip-js-errors -c 3
 
       - name: Clean up users & policies
         run: |


### PR DESCRIPTION
Updated jobs to use raw command for testcafe instead of using github-action since that one uses latest version of testcafe which has a known [issue](https://github.com/DevExpress/testcafe/issues/7898) for headless chrome which seems to have been introduced in v3.1.0.