### PR TITLE
Fix subpath button

### DIFF
--- a/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useState } from "react";
 import { useSelector } from "react-redux";
 import CopyToClipboard from "react-copy-to-clipboard";
 import createStyles from "@mui/styles/createStyles";

--- a/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
+++ b/portal-ui/src/screens/Console/ObjectBrowser/BrowserBreadcrumbs.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { Fragment, useState } from "react";
+import React, { Fragment, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import CopyToClipboard from "react-copy-to-clipboard";
 import createStyles from "@mui/styles/createStyles";
@@ -100,7 +100,7 @@ const BrowserBreadcrumbs = ({
   const splitPaths = paths.split("/").filter((path) => path !== "");
   const lastBreadcrumbsIndex = splitPaths.length - 1;
 
-  const pathToCheckPerms = paths || bucketName;
+  const pathToCheckPerms = bucketName + paths || bucketName;
   const sessionGrantWildCards = getSessionGrantsWildCard(
     sessionGrants,
     pathToCheckPerms,


### PR DESCRIPTION
Bucket name was missing from the path passed to check bucket permissions 
<img width="873" alt="Screenshot 2023-08-02 at 1 35 27 PM" src="https://github.com/minio/console/assets/65002498/02a8a373-9d8b-4365-bada-36bfca12d4dd">

fixes https://github.com/minio/console/issues/2951