### PR TITLE
fix: dateTime usage only available in go1.20

### DIFF
--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [ 1.20.x ]
+        go-version: [ 1.19.x, 1.20.x ]
         os: [ ubuntu-latest ]
     steps:
       - name: Check out code

--- a/restapi/user_objects.go
+++ b/restapi/user_objects.go
@@ -741,7 +741,7 @@ func getMultipleFilesDownloadResponse(session *models.Principal, params objectAp
 		defer resp.Close()
 
 		// indicate it's a download / inline content to the browser, and the size of the object
-		fileName := "selected_files_" + time.Now().UTC().Format(time.DateTime)
+		fileName := "selected_files_" + strings.ReplaceAll(strings.ReplaceAll(time.Now().UTC().Format(time.RFC3339), ":", ""), "-", "")
 
 		rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.zip\"", fileName))
 		rw.Header().Set("Content-Type", "application/zip")


### PR DESCRIPTION
instead use a simpler normalizer for timestamp
to be user friendly without spaces.

For example

```
selected_files_20091110T230000Z.zip
```