### PR TITLE
truncate prefixes above the selected level to make the download layout flat

### DIFF
--- a/restapi/user_objects.go
+++ b/restapi/user_objects.go
@@ -722,7 +722,10 @@ func getMultipleFilesDownloadResponse(session *models.Principal, params objectAp
 					continue
 				}
 
-				f, err := addToZip(dObj, objectData.LastModified)
+				prefixes := strings.Split(dObj, "/")
+				// truncate upper level prefixes to make the download as flat at the current level.
+				objectName := prefixes[len(prefixes)-1]
+				f, err := addToZip(objectName, objectData.LastModified)
 				if err != nil {
 					// Ignore errors, move to next
 					continue


### PR DESCRIPTION
truncate prefixes above the selected level to make the download layout flat

Since objects are selected at nested level, we could ignore the top level prefixes when zip is created to make the layout flat.