### PR TITLE
Fix oauth2Config.Exchange error reporting

### DIFF
--- a/pkg/auth/idp/oauth2/provider.go
+++ b/pkg/auth/idp/oauth2/provider.go
@@ -326,10 +326,10 @@ func (client *Provider) VerifyIdentity(ctx context.Context, code, state, roleARN
 		if err != nil {
 			return nil, err
 		}
-		client.RefreshToken = oauth2Token.RefreshToken
 		if !oauth2Token.Valid() {
 			return nil, errors.New("invalid token")
 		}
+		client.RefreshToken = oauth2Token.RefreshToken
 
 		expiration := token.GetConsoleSTSDuration()
 		if exp := getIDPTokenExpiration(); exp > 0 {

--- a/pkg/auth/idp/oauth2/provider.go
+++ b/pkg/auth/idp/oauth2/provider.go
@@ -323,10 +323,10 @@ func (client *Provider) VerifyIdentity(ctx context.Context, code, state, roleARN
 	getWebTokenExpiry := func() (*credentials.WebIdentityToken, error) {
 		customCtx := context.WithValue(ctx, oauth2.HTTPClient, client.provHTTPClient)
 		oauth2Token, err := client.oauth2Config.Exchange(customCtx, code)
-		client.RefreshToken = oauth2Token.RefreshToken
 		if err != nil {
 			return nil, err
 		}
+		client.RefreshToken = oauth2Token.RefreshToken
 		if !oauth2Token.Valid() {
 			return nil, errors.New("invalid token")
 		}


### PR DESCRIPTION
This fixes the reporting of OIDC /token endpoint problems (been there, took me two days to figure out).
client.RefreshToken is a silent dead-end if oauth2Config.Exchange fails, so the error reporting should come first.