### PR TITLE
To properly show error in AddAccessRule.tsx

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/AddAccessRule.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/AddAccessRule.tsx
@@ -78,8 +78,8 @@ const AddAccessRule = ({
         dispatch(setSnackBarMessage("Access Rule added successfully"));
         onClose();
       })
-      .catch((err) => {
-        dispatch(setErrorSnackMessage(errorToHandler(err)));
+      .catch((res) => {
+        dispatch(setErrorSnackMessage(errorToHandler(res.error)));
         onClose();
       });
   };


### PR DESCRIPTION
### Objective:

To properly show error in `AddAccessRule.tsx`

### Additional Info:

* This is related to: https://github.com/minio/console/pull/3005

### How and where to test:

> Change the code to simulate the error:

```tsx
  const createProcess = () => {
    api.bucket
      .setAccessRuleWithBucket(bucket, {
        prefix: prefix,
        access: "tester",  // invalid access rule.
      })
```

Administrator > Buckets > Anonymous > Add Access Rule > Save

![Screenshot 2023-08-23 at 5 49 27 PM](https://github.com/minio/console/assets/6667358/b7996697-a3e5-489a-b53c-8e648cda05a5)

### How it should looks:

![Screenshot 2023-08-23 at 5 52 36 PM](https://github.com/minio/console/assets/6667358/d1912201-37e7-4795-af64-31aa7f52a511)
