### PR TITLE
Fixed an issue while deleting objects with similar prefixes

### DIFF
--- a/portal-ui/tests/permissions-7/deleteWithPrefixes.ts
+++ b/portal-ui/tests/permissions-7/deleteWithPrefixes.ts
@@ -1,0 +1,63 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import * as roles from "../utils/roles";
+import { Selector } from "testcafe";
+import * as functions from "../utils/functions";
+import { namedTestBucketBrowseButtonFor } from "../utils/functions";
+
+fixture("Test resources policy").page("http://localhost:9090/");
+
+const bucket1 = "abucket3";
+const test1BucketBrowseButton = namedTestBucketBrowseButtonFor(bucket1);
+export const remainingFile = Selector(
+  ".ReactVirtualized__Table__rowColumn",
+).withText("abcd");
+
+test
+  .before(async (t) => {
+    await functions.setUpNamedBucket(t, bucket1);
+    await functions.setVersionedBucket(t, bucket1);
+    await functions.uploadNamedObjectToBucket(
+      t,
+      bucket1,
+      "abc",
+      "portal-ui/tests/uploads/noextension",
+    );
+    await functions.uploadNamedObjectToBucket(
+      t,
+      bucket1,
+      "abcd",
+      "portal-ui/tests/uploads/noextension",
+    );
+  })(
+    "Files with similar prefixes don't get deleted with all versions",
+    async (t) => {
+      await t
+        .useRole(roles.admin)
+        .navigateTo(`http://localhost:9090/browser`)
+        .click(test1BucketBrowseButton)
+        .click(Selector(".ReactVirtualized__Table__rowColumn").withText("abc"))
+        .click(Selector("#delete-element-click"))
+        .click(Selector("#delete-versions-switch"))
+        .click(Selector("#confirm-ok"))
+        .expect(remainingFile.exists)
+        .ok();
+    },
+  )
+  .after(async (t) => {
+    await functions.cleanUpNamedBucketAndUploads(t, bucket1);
+  });

--- a/portal-ui/tests/uploads/noextension
+++ b/portal-ui/tests/uploads/noextension
@@ -1,0 +1,1 @@
+a demo file


### PR DESCRIPTION
## What does this do?

Fixed an issue while deleting all versions, where if there were two files with similar prefixes but you only wanted to delete one, both files got deleted

## How does it look?

### Before
![beforeff](https://github.com/minio/console/assets/33497058/bd1b1ac7-e671-45a0-a7fb-dc596f1f9ec4)

### After
![afterff](https://github.com/minio/console/assets/33497058/9aed85d9-213b-41ad-b065-e124e3691a75)
