### PR TITLE
Fix regression on login path when using redirect url

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -200,6 +200,55 @@ jobs:
         run: |
           make console
 
+  test-nginx-subpath:
+    name: Test Subpath with Nginx
+    needs:
+      - compile-binary
+    runs-on: [ubuntu-latest]
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        go-version: [1.21.x]
+        os: [ubuntu-latest]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NVMRC }}
+      - name: Install MinIO JS
+        working-directory: ./
+        continue-on-error: false
+        run: |
+          yarn add minio
+
+      - uses: actions/cache@v3
+        name: Console Binary Cache
+        with:
+          path: |
+            ./console
+          key: ${{ runner.os }}-binary-${{ github.run_id }}
+
+      - name: clean-previous-containers-if-any
+        run: |
+          docker stop minio || true;
+          docker container prune -f || true;
+
+      - name: Start Console, MinIO and Nginx
+        run: |
+          (CONSOLE_SUBPATH=/console/subpath ./console server ) & (make test-initialize-minio-nginx)
+
+      - name: Install TestCafe
+        run: npm install testcafe@3.0.0
+
+      - name: Run TestCafe Tests
+        run: npx testcafe "chrome:headless" portal-ui/tests/subpath-nginx/ -q --skip-js-errors -c 3
+
+      - name: Clean up docker
+        if: always()
+        run: |
+          make cleanup-minio-nginx
+
   all-permissions-1:
     name: Permissions Tests Part 1
     needs:

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,30 @@ cleanup-permissions:
 	@(env bash $(PWD)/portal-ui/tests/scripts/cleanup-env.sh)
 	@(docker stop minio)
 
+initialize-docker-network:
+	@(docker network create test-network)
+
+test-start-docker-minio-w-redirect-url: initialize-docker-network
+	@(docker run \
+    -e MINIO_BROWSER_REDIRECT_URL='http://localhost:8000/console/subpath/' \
+    -e MINIO_SERVER_URL='http://localhost:9000' \
+    -v /data1 -v /data2 -v /data3 -v /data4 \
+    -d --network host --name minio --rm\
+    quay.io/minio/minio:latest server /data{1...4}) 
+
+test-start-docker-nginx-w-subpath:
+	@(docker run \
+	--network host \
+	-d --rm \
+	--add-host=host.docker.internal:host-gateway \
+	-v ./portal-ui/tests/subpath-nginx/nginx.conf:/etc/nginx/nginx.conf \
+	--name test-nginx nginx)
+
+test-initialize-minio-nginx: test-start-docker-minio-w-redirect-url test-start-docker-nginx-w-subpath
+
+cleanup-minio-nginx:
+	@(docker stop minio test-nginx & docker rm test-nginx & docker network rm test-network)
+
 test:
 	@echo "execute test and get coverage"
 	@(cd restapi && mkdir coverage && GO111MODULE=on go test -test.v -coverprofile=coverage/coverage.out)

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ test-start-docker-nginx-w-subpath:
 test-initialize-minio-nginx: test-start-docker-minio-w-redirect-url test-start-docker-nginx-w-subpath
 
 cleanup-minio-nginx:
-	@(docker stop minio test-nginx & docker rm test-nginx & docker network rm test-network)
+	@(docker stop minio test-nginx & docker network rm test-network)
 
 test:
 	@echo "execute test and get coverage"

--- a/portal-ui/src/api/index.ts
+++ b/portal-ui/src/api/index.ts
@@ -25,7 +25,7 @@ api.request = async <T = any, E = any>({
     cancelToken,
     ...params,
   });
-  return internalResp.catch((e) => CommonAPIValidation(e));
+  return internalResp.then((e) => CommonAPIValidation(e));
 };
 
 export function CommonAPIValidation<D, E>(
@@ -37,5 +37,5 @@ export function CommonAPIValidation<D, E>(
       document.location = "/login";
     }
   }
-  throw res;
+  return res;
 }

--- a/portal-ui/tests/subpath-nginx/nginx.conf
+++ b/portal-ui/tests/subpath-nginx/nginx.conf
@@ -1,0 +1,22 @@
+events { worker_connections 1024; }
+http {
+    server {
+        listen 8000;
+        location /console/subpath/ {
+            rewrite   ^/console/subpath/(.*) /$1 break;
+            proxy_pass http://host.docker.internal:9090;
+            
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # This allows WebSocket connections
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+}

--- a/portal-ui/tests/subpath-nginx/test-unauthenticated-user.ts
+++ b/portal-ui/tests/subpath-nginx/test-unauthenticated-user.ts
@@ -1,0 +1,28 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import * as elements from "../utils/elements";
+
+// Using subpath defined in `MINIO_BROWSER_REDIRECT_URL`
+const appBaseUrl = "http://localhost:8000/console/subpath";
+let rootUrl = `${appBaseUrl}/`;
+
+fixture("Tests using subpath").page(appBaseUrl);
+
+test("RootUrl redirects to Login Page", async (t) => {
+  const loginButtonExists = elements.loginButton.exists;
+  await t.navigateTo(rootUrl).expect(loginButtonExists).ok().wait(2000);
+});

--- a/portal-ui/tests/utils/elements.ts
+++ b/portal-ui/tests/utils/elements.ts
@@ -191,3 +191,7 @@ export const locationEmpty = Selector("div").withAttribute(
   "id",
   "empty-results",
 );
+//----------------------------------------------------
+// Login Window
+//----------------------------------------------------
+export const loginButton = Selector("button").withAttribute("id", "do-login");


### PR DESCRIPTION
Fixes: https://github.com/minio/console/issues/3036

We changed the way of handling the errors in here https://github.com/minio/console/pull/3005 which caused a regression on the login path when using `MINIO_BROWSER_REDIRECT_URL` env variable.

### Test Steps
Please follow same steps as  https://github.com/minio/console/pull/2818
Note: Use correct command as explained in the comments like:
```
make build && CI=true MINIO_BROWSER_REDIRECT_URL=http://localhost:8000/console/subpath/ MINIO_SERVER_URL=http://localhost:9000 ./minio server --console-address ":9090" ~/Data
```

Go to http://localhost:8000/console/subpath/

It should redirect you to `http://localhost:8000/console/subpath/login` before it was redirecting to `http://localhost:8000/login`.

Other test:
- Login and then go to a different pat such as browser or access keys
- Delete the local storage for the page
- refresh the site, it should redirect you again to `http://localhost:8000/console/subpath/login`
