### PR TITLE
Upgrade go version in git workflows to 1.21.1

### DIFF
--- a/.github/workflows/vulncheck.yaml
+++ b/.github/workflows/vulncheck.yaml
@@ -1,3 +1,5 @@
+# @format
+
 name: Vulnerability Check
 on:
   pull_request:
@@ -20,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.0
+          go-version: 1.21.1
           check-latest: true
       - name: Get official govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -34,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.21.0 ]
-        os: [ ubuntu-latest ]
+        go-version: [1.21.1]
+        os: [ubuntu-latest]
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
Upgrading to solve recent vulnerabilities found in crypto package
https://pkg.go.dev/vuln/GO-2023-2044