### PR TITLE
Added CONSOLE_PROMETHEUS_AUTH_TOKEN flag support

### DIFF
--- a/restapi/admin_info.go
+++ b/restapi/admin_info.go
@@ -963,6 +963,12 @@ func unmarshalPrometheus(ctx context.Context, httpClnt *http.Client, endpoint st
 		return true
 	}
 
+	prometheusBearer := getPrometheusAuthToken()
+
+	if prometheusBearer != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", prometheusBearer))
+	}
+
 	resp, err := httpClnt.Do(req)
 	if err != nil {
 		ErrorWithContext(ctx, fmt.Errorf("Unable to fetch labels from prometheus: %w", err))
@@ -992,6 +998,13 @@ func testPrometheusURL(ctx context.Context, url string) bool {
 		ErrorWithContext(ctx, fmt.Errorf("error Building Request: (%v)", err))
 		return false
 	}
+
+	prometheusBearer := getPrometheusAuthToken()
+
+	if prometheusBearer != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", prometheusBearer))
+	}
+
 	response, err := httpClnt.Do(req)
 	if err != nil {
 		ErrorWithContext(ctx, fmt.Errorf("default Prometheus URL not reachable, trying root testing: (%v)", err))

--- a/restapi/config.go
+++ b/restapi/config.go
@@ -247,6 +247,10 @@ func getPrometheusURL() string {
 	return env.Get(PrometheusURL, "")
 }
 
+func getPrometheusAuthToken() string {
+	return env.Get(PrometheusAuthToken, "")
+}
+
 func getPrometheusJobID() string {
 	return env.Get(PrometheusJobID, "minio-job")
 }

--- a/restapi/consts.go
+++ b/restapi/consts.go
@@ -47,6 +47,7 @@ const (
 	ConsoleSecureFeaturePolicy                   = "CONSOLE_SECURE_FEATURE_POLICY"
 	ConsoleSecureExpectCTHeader                  = "CONSOLE_SECURE_EXPECT_CT_HEADER"
 	PrometheusURL                                = "CONSOLE_PROMETHEUS_URL"
+	PrometheusAuthToken                          = "CONSOLE_PROMETHEUS_AUTH_TOKEN"
 	PrometheusJobID                              = "CONSOLE_PROMETHEUS_JOB_ID"
 	PrometheusExtraLabels                        = "CONSOLE_PROMETHEUS_EXTRA_LABELS"
 	ConsoleLogQueryURL                           = "CONSOLE_LOG_QUERY_URL"


### PR DESCRIPTION
## What does this do?

Added CONSOLE_PROMETHEUS_AUTH_TOKEN flag support for setups where prometheus has Bearer token authentication enabled.

NOTE: This PR doesn't support Basic Authentication method described in Prometheus website