### PR TITLE
Improvements to LDAP Configuration page

### DIFF
--- a/portal-ui/src/screens/Console/IDP/utils.tsx
+++ b/portal-ui/src/screens/Console/IDP/utils.tsx
@@ -156,6 +156,7 @@ export const ldapFormFields = {
     tooltip: "Disable SSL certificate verification ",
     placeholder: "myldapserver.com:636",
     type: "toggle",
+    editOnly: false,
   },
   server_addr: {
     required: true,
@@ -166,6 +167,7 @@ export const ldapFormFields = {
     tooltip: 'AD/LDAP server address e.g. "myldapserver.com:636"',
     placeholder: "myldapserver.com:636",
     type: "text",
+    editOnly: false,
   },
   lookup_bind_dn: {
     required: true,
@@ -177,6 +179,7 @@ export const ldapFormFields = {
       "DN (Distinguished Name) for LDAP read-only service account used to perform DN and group lookups",
     placeholder: "cn=admin,dc=min,dc=io",
     type: "text",
+    editOnly: false,
   },
   lookup_bind_password: {
     required: true,
@@ -188,6 +191,7 @@ export const ldapFormFields = {
       "Password for LDAP read-only service account used to perform DN and group lookups",
     placeholder: "admin",
     type: "password",
+    editOnly: true,
   },
   user_dn_search_base_dn: {
     required: true,
@@ -198,6 +202,7 @@ export const ldapFormFields = {
     tooltip: "",
     placeholder: "DC=example,DC=net",
     type: "text",
+    editOnly: false,
   },
   user_dn_search_filter: {
     required: true,
@@ -208,6 +213,7 @@ export const ldapFormFields = {
     tooltip: "",
     placeholder: "(sAMAcountName=%s)",
     type: "text",
+    editOnly: false,
   },
   group_search_base_dn: {
     required: false,
@@ -216,6 +222,7 @@ export const ldapFormFields = {
     tooltip: "",
     placeholder: "ou=swengg,dc=min,dc=io",
     type: "text",
+    editOnly: false,
   },
   group_search_filter: {
     required: false,
@@ -224,5 +231,6 @@ export const ldapFormFields = {
     tooltip: "",
     placeholder: "(&(objectclass=groupofnames)(member=%d))",
     type: "text",
+    editOnly: false,
   },
 };


### PR DESCRIPTION
fixes #3028 

## What does this do?

- Fixed LDAP Enabled / Disabled calculation
- Removed Password Label from main page to avoid confusion
- Added Re-enter password notice to edit configurations page as this is required for security purposes
- Display LDAP ENV variables in case of configured

## How does it look?

<img width="1710" alt="Screenshot 2023-09-13 at 17 31 09" src="https://github.com/minio/console/assets/33497058/096bb2fa-c48f-4cb6-a728-0544f749dbc1">
<img width="1586" alt="Screenshot 2023-09-13 at 17 26 54" src="https://github.com/minio/console/assets/33497058/2a5cfee5-db09-4853-a949-cd9d1cd8a918">
<img width="1572" alt="Screenshot 2023-09-13 at 17 21 06" src="https://github.com/minio/console/assets/33497058/79a6d3da-18af-4e1b-b1ad-d2f81f934374">
<img width="1578" alt="Screenshot 2023-09-13 at 17 18 54" src="https://github.com/minio/console/assets/33497058/da646f08-c0b1-479b-91f1-02ba61de7f62">
<img width="1587" alt="Screenshot 2023-09-13 at 17 17 59" src="https://github.com/minio/console/assets/33497058/bfed91dc-a352-4a51-ba0f-1a5484aba173">
<img width="1331" alt="Screenshot 2023-09-13 at 17 17 33" src="https://github.com/minio/console/assets/33497058/3835e766-eecd-4e24-aca7-0ac7a70d24ed">
<img width="1371" alt="Screenshot 2023-09-13 at 17 17 30" src="https://github.com/minio/console/assets/33497058/164119fd-3368-41df-abc1-7b9aa3242595">
<img width="1582" alt="Screenshot 2023-09-13 at 17 17 27" src="https://github.com/minio/console/assets/33497058/5b0124f8-75f7-49aa-b88a-421c977b6a53">
