### PR TITLE
Updated OpenID UX

### DIFF
--- a/portal-ui/src/screens/Console/EventDestinations/WebhookSettings/EditWebhookEndpoint.tsx
+++ b/portal-ui/src/screens/Console/EventDestinations/WebhookSettings/EditWebhookEndpoint.tsx
@@ -218,7 +218,9 @@ const EditEndpointModal = ({
                     <Tooltip
                       tooltip={
                         overrideValues.enable
-                          ? `This value is set from the ${overrideValues.enable.overrideEnv} environment variable`
+                          ? `This value is set from the ${
+                              overrideValues.enable?.overrideEnv || "N/A"
+                            } environment variable`
                           : ""
                       }
                       placement={"left"}
@@ -245,7 +247,9 @@ const EditEndpointModal = ({
                     <Tooltip
                       tooltip={
                         overrideValues.enable
-                          ? `This value is set from the ${overrideValues.endpoint.overrideEnv} environment variable`
+                          ? `This value is set from the ${
+                              overrideValues.endpoint?.overrideEnv || "N/A"
+                            } environment variable`
                           : ""
                       }
                       placement={"left"}
@@ -272,7 +276,9 @@ const EditEndpointModal = ({
                     <Tooltip
                       tooltip={
                         overrideValues.enable
-                          ? `This value is set from the ${overrideValues.auth_token.overrideEnv} environment variable`
+                          ? `This value is set from the ${
+                              overrideValues.auth_token?.overrideEnv || "N/A"
+                            } environment variable`
                           : ""
                       }
                       placement={"left"}

--- a/portal-ui/src/screens/Console/IDP/utils.tsx
+++ b/portal-ui/src/screens/Console/IDP/utils.tsx
@@ -59,6 +59,7 @@ export const openIDFormFields = {
     placeholder:
       "https://identity-provider-url/.well-known/openid-configuration",
     type: "text",
+    editOnly: false,
   },
   client_id: {
     required: true,
@@ -69,6 +70,7 @@ export const openIDFormFields = {
     tooltip: "Identity provider Client ID",
     placeholder: "Enter Client ID",
     type: "text",
+    editOnly: false,
   },
   client_secret: {
     required: true,
@@ -79,6 +81,7 @@ export const openIDFormFields = {
     tooltip: "Identity provider Client Secret",
     placeholder: "Enter Client Secret",
     type: "password",
+    editOnly: true,
   },
   claim_name: {
     required: false,
@@ -87,6 +90,7 @@ export const openIDFormFields = {
     placeholder: "Enter Claim Name",
     type: "text",
     hasError: (s: string, editMode: boolean) => "",
+    editOnly: false,
   },
   display_name: {
     required: false,
@@ -95,6 +99,7 @@ export const openIDFormFields = {
     placeholder: "Enter Display Name",
     type: "text",
     hasError: (s: string, editMode: boolean) => "",
+    editOnly: false,
   },
   claim_prefix: {
     required: false,
@@ -103,6 +108,7 @@ export const openIDFormFields = {
     placeholder: "Enter Claim Prefix",
     type: "text",
     hasError: (s: string, editMode: boolean) => "",
+    editOnly: false,
   },
   scopes: {
     required: false,
@@ -111,6 +117,7 @@ export const openIDFormFields = {
     placeholder: "openid,profile,email",
     type: "text",
     hasError: (s: string, editMode: boolean) => "",
+    editOnly: false,
   },
   redirect_uri: {
     required: false,
@@ -119,6 +126,7 @@ export const openIDFormFields = {
     placeholder: "https://console-endpoint-url/oauth_callback",
     type: "text",
     hasError: (s: string, editMode: boolean) => "",
+    editOnly: false,
   },
   role_policy: {
     required: false,
@@ -127,6 +135,7 @@ export const openIDFormFields = {
     placeholder: "readonly",
     type: "text",
     hasError: (s: string, editMode: boolean) => "",
+    editOnly: false,
   },
   claim_userinfo: {
     required: false,
@@ -135,6 +144,7 @@ export const openIDFormFields = {
     placeholder: "Claim User Info",
     type: "toggle",
     hasError: (s: string, editMode: boolean) => "",
+    editOnly: false,
   },
   redirect_uri_dynamic: {
     required: false,
@@ -143,6 +153,7 @@ export const openIDFormFields = {
     placeholder: "Redirect URI Dynamic",
     type: "toggle",
     hasError: (s: string, editMode: boolean) => "",
+    editOnly: false,
   },
 };
 

--- a/portal-ui/src/screens/LoginPage/Login.tsx
+++ b/portal-ui/src/screens/LoginPage/Login.tsx
@@ -29,12 +29,6 @@ import { RedirectRule } from "api/consoleApi";
 import { redirectRules } from "./login.utils";
 import { setHelpName } from "../../systemSlice";
 
-export interface LoginStrategyPayload {
-  accessKey: string;
-  secretKey: string;
-  sts?: string;
-}
-
 export const getTargetPath = () => {
   let targetPath = "/browser";
   if (

--- a/restapi/admin_idp.go
+++ b/restapi/admin_idp.go
@@ -198,6 +198,7 @@ func getIDPConfiguration(ctx context.Context, idpType, name string, client Minio
 	if err != nil {
 		return nil, err
 	}
+
 	return &models.IdpServerConfiguration{
 		Name: config.Name,
 		Type: config.Type,


### PR DESCRIPTION
fixes #2936

## What does this do?

- Display ENV variables set in configuration
- Removed Password empty placeholders
- Added notification to re-enter password when modifying OpenID configuration

## How does it look?

<img width="1159" alt="Screenshot 2023-09-18 at 18 56 50" src="https://github.com/minio/console/assets/33497058/61586074-217b-406f-a86c-46a55bc62ff5">
<img width="478" alt="Screenshot 2023-09-18 at 18 56 43" src="https://github.com/minio/console/assets/33497058/13acdb70-9734-4e67-8a4d-ad8d3b408013">
<img width="467" alt="Screenshot 2023-09-18 at 18 56 31" src="https://github.com/minio/console/assets/33497058/a7f874a3-1db8-4a56-8da0-15cbb9ec6c45">
<img width="613" alt="Screenshot 2023-09-18 at 18 56 28" src="https://github.com/minio/console/assets/33497058/4f8767b9-1a0d-4ce5-9d4d-6078ee7f082c">
<img width="1956" alt="Screenshot 2023-09-18 at 18 56 26" src="https://github.com/minio/console/assets/33497058/af855132-a0e1-43bb-ae56-8288339dd9fb">
