### PR TITLE
fix: handle crash in error handling of access keys page

### DIFF
--- a/portal-ui/src/screens/Console/Account/Account.tsx
+++ b/portal-ui/src/screens/Console/Account/Account.tsx
@@ -47,7 +47,7 @@ import { errorToHandler } from "api/errors";
 import HelpMenu from "../HelpMenu";
 import { ACCOUNT_TABLE_COLUMNS } from "./AccountUtils";
 import { useAppDispatch } from "store";
-import { ApiError, ServiceAccounts } from "api/consoleApi";
+import { ServiceAccounts } from "api/consoleApi";
 import {
   setErrorSnackMessage,
   setHelpName,
@@ -104,9 +104,12 @@ const Account = () => {
           const sortedRows = res.data.sort(usersSort);
           setRecords(sortedRows);
         })
-        .catch(async (res) => {
-          const err = (await res.json()) as ApiError;
-          dispatch(setErrorSnackMessage(errorToHandler(err)));
+        .catch((res) => {
+          dispatch(
+            setErrorSnackMessage(
+              errorToHandler(res?.error || "Error retrieving access keys"),
+            ),
+          );
           setLoading(false);
         });
     }

--- a/portal-ui/src/screens/Console/Account/AddServiceAccountScreen.tsx
+++ b/portal-ui/src/screens/Console/Account/AddServiceAccountScreen.tsx
@@ -35,7 +35,7 @@ import { IAM_PAGES } from "../../../common/SecureComponent/permissions";
 import { setErrorSnackMessage, setHelpName } from "../../../systemSlice";
 import { api } from "api";
 import { errorToHandler } from "api/errors";
-import { ApiError, ContentType } from "api/consoleApi";
+import { ContentType } from "api/consoleApi";
 import CodeMirrorWrapper from "../Common/FormComponents/CodeMirrorWrapper/CodeMirrorWrapper";
 import AddServiceAccountHelpBox from "./AddServiceAccountHelpBox";
 import CredentialsPrompt from "../Common/CredentialsPrompt/CredentialsPrompt";
@@ -83,10 +83,9 @@ const AddServiceAccount = () => {
           });
         })
 
-        .catch(async (res) => {
+        .catch((res) => {
           setAddSending(false);
-          const err = (await res.json()) as ApiError;
-          dispatch(setErrorSnackMessage(errorToHandler(err)));
+          dispatch(setErrorSnackMessage(errorToHandler(res.error)));
         });
     }
   }, [addSending, setAddSending, dispatch, policyJSON, accessKey, secretKey]);


### PR DESCRIPTION
The current response handler in UI crashes on any error from the back end.

This can be replicated easily by configuring LDAP  and trying to create "Access Key" or simulating an error scenario from backend.

<details>
Error with latest MinIO:

![image](https://github.com/minio/console/assets/23444145/d441c06e-78a2-43be-b1b2-6b0e396a3b9b)

Replicate this in dev
![Console_SA-Error](https://github.com/minio/console/assets/23444145/0d4e5de3-4dd0-4ffe-b08c-a518c7a99116)

Fix:
![image](https://github.com/minio/console/assets/23444145/aa191325-df00-4342-b0da-8fecce542184)

</details>
