### PR TITLE
Added support for Scanner event type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/minio/kes v0.22.3
 	github.com/minio/madmin-go/v3 v3.0.18
 	github.com/minio/mc v0.0.0-20230907224855-9dcef8825fae
-	github.com/minio/minio-go/v7 v7.0.63
+	github.com/minio/minio-go/v7 v7.0.64-0.20230920204636-e783c9ba11b3
 	github.com/minio/selfupdate v0.6.0
 	github.com/minio/websocket v1.6.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/minio/mc v0.0.0-20230907224855-9dcef8825fae h1:LteOWEz6ZnP8hm6AEScDmn
 github.com/minio/mc v0.0.0-20230907224855-9dcef8825fae/go.mod h1:M/RN4OtnloGZLgLd/HicgzoEQdYXYz0taYqZzoBqVrc=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
-github.com/minio/minio-go/v7 v7.0.63 h1:GbZ2oCvaUdgT5640WJOpyDhhDxvknAJU2/T3yurwcbQ=
-github.com/minio/minio-go/v7 v7.0.63/go.mod h1:Q6X7Qjb7WMhvG65qKf4gUgA5XaiSox74kR1uAEjxRS4=
+github.com/minio/minio-go/v7 v7.0.64-0.20230920204636-e783c9ba11b3 h1:0DtfDxg67S/IRcGnIBKgzyjZ0GXyk3jN1Fy5/+8CQlM=
+github.com/minio/minio-go/v7 v7.0.64-0.20230920204636-e783c9ba11b3/go.mod h1:Q6X7Qjb7WMhvG65qKf4gUgA5XaiSox74kR1uAEjxRS4=
 github.com/minio/mux v1.9.0 h1:dWafQFyEfGhJvK6AwLOt83bIG5bxKxKJnKMCi0XAaoA=
 github.com/minio/pkg/v2 v2.0.1 h1:MI3xMGCxoN5EEBRp98uEU5J0LlaF+8fLPtL8oHTHLX0=
 github.com/minio/pkg/v2 v2.0.1/go.mod h1:6xTAr5M9yobpUroXAAaTrGJ9fhOZIqKYOT0I87u2yZ4=

--- a/models/notification_event_type.go
+++ b/models/notification_event_type.go
@@ -61,6 +61,9 @@ const (
 
 	// NotificationEventTypeIlm captures enum value "ilm"
 	NotificationEventTypeIlm NotificationEventType = "ilm"
+
+	// NotificationEventTypeScanner captures enum value "scanner"
+	NotificationEventTypeScanner NotificationEventType = "scanner"
 )
 
 // for schema
@@ -68,7 +71,7 @@ var notificationEventTypeEnum []interface{}
 
 func init() {
 	var res []NotificationEventType
-	if err := json.Unmarshal([]byte(`["put","delete","get","replica","ilm"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["put","delete","get","replica","ilm","scanner"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/portal-ui/src/api/consoleApi.ts
+++ b/portal-ui/src/api/consoleApi.ts
@@ -291,6 +291,7 @@ export enum NotificationEventType {
   Get = "get",
   Replica = "replica",
   Ilm = "ilm",
+  Scanner = "scanner",
 }
 
 export interface NotificationConfig {

--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/AddEvent.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/AddEvent.tsx
@@ -105,6 +105,11 @@ const AddEvent = ({
       value: NotificationEventType.Replica,
     },
     { label: "ILM - Object Transitioned", value: NotificationEventType.Ilm },
+    {
+      label:
+        "SCANNER - Object has too many versions / Prefixes has too many sub-folders",
+      value: NotificationEventType.Scanner,
+    },
   ];
 
   const handleClick = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/BucketEventsPanel.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/BucketEventsPanel.tsx
@@ -96,8 +96,19 @@ const BucketEventsPanel = () => {
     }
   }, [loadingEvents, dispatch, bucketName, displayEvents]);
 
-  const eventsDisplay = (events: string[]) => {
-    return <Fragment>{events.join(", ")}</Fragment>;
+  const eventsDisplay = (events: string[] | null) => {
+    if (!events) {
+      return "other";
+    }
+
+    const cleanEvents = events.reduce((acc: string[], read: string) => {
+      if (!acc.includes(read)) {
+        return [...acc, read];
+      }
+      return acc;
+    }, []);
+
+    return <Fragment>{cleanEvents.join(", ")}</Fragment>;
   };
 
   const confirmDeleteEvent = (evnt: NotificationConfig) => {

--- a/portal-ui/src/screens/Console/Buckets/BucketDetails/DeleteEvent.tsx
+++ b/portal-ui/src/screens/Console/Buckets/BucketDetails/DeleteEvent.tsx
@@ -54,15 +54,22 @@ const DeleteEvent = ({
       return;
     }
 
-    const events = get(bucketEvent, "events", []);
+    const events: string[] = get(bucketEvent, "events", []);
     const prefix = get(bucketEvent, "prefix", "");
     const suffix = get(bucketEvent, "suffix", "");
+
+    const cleanEvents = events.reduce((acc: string[], currVal: string) => {
+      if (!acc.includes(currVal)) {
+        return [...acc, currVal];
+      }
+      return acc;
+    }, []);
 
     invokeDeleteApi(
       "DELETE",
       `/api/v1/buckets/${selectedBucket}/events/${bucketEvent.arn}`,
       {
-        events,
+        events: cleanEvents,
         prefix,
         suffix,
       },

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7445,7 +7445,8 @@ func init() {
         "delete",
         "get",
         "replica",
-        "ilm"
+        "ilm",
+        "scanner"
       ]
     },
     "objectBucketLifecycle": {
@@ -16635,7 +16636,8 @@ func init() {
         "delete",
         "get",
         "replica",
-        "ilm"
+        "ilm",
+        "scanner"
       ]
     },
     "objectBucketLifecycle": {

--- a/restapi/user_buckets_events.go
+++ b/restapi/user_buckets_events.go
@@ -77,6 +77,8 @@ func listBucketEvents(client MinioClient, bucketName string) ([]*models.Notifica
 				eventTypePretty = models.NotificationEventTypeReplica
 			case notification.ObjectTransitionAll:
 				eventTypePretty = models.NotificationEventTypeIlm
+			case notification.ObjectScannerManyVersions, notification.ObjectScannerBigPrefix:
+				eventTypePretty = models.NotificationEventTypeScanner
 			default:
 				continue
 			}

--- a/swagger.yml
+++ b/swagger.yml
@@ -4058,6 +4058,7 @@ definitions:
       - get
       - replica
       - ilm
+      - scanner
   notificationConfig:
     type: object
     required:


### PR DESCRIPTION
fixes #3033 

## What does this do?

Added support for Scanner event type as https://min.io/docs/minio/linux/reference/minio-mc/mc-event-add.html#supported-bucket-events especification

## How does it look?


<img width="1172" alt="Screenshot 2023-09-20 at 18 00 38" src="https://github.com/minio/console/assets/33497058/e16b360c-3247-47f0-8347-514d0acc2bbd">
<img width="1708" alt="Screenshot 2023-09-20 at 18 00 30" src="https://github.com/minio/console/assets/33497058/458fa154-c16a-476f-92ee-6a1e13ab8431">

