### PR TITLE
Improve change password  user experience

### DIFF
--- a/portal-ui/src/screens/Console/Account/ChangePasswordModal.tsx
+++ b/portal-ui/src/screens/Console/Account/ChangePasswordModal.tsx
@@ -26,11 +26,16 @@ import {
 import ModalWrapper from "../Common/ModalWrapper/ModalWrapper";
 
 import { modalStyleUtils } from "../Common/FormComponents/common/styleLibrary";
-import { setModalErrorSnackMessage } from "../../../systemSlice";
+import {
+  setModalErrorSnackMessage,
+  setSnackBarMessage,
+} from "../../../systemSlice";
 import { useAppDispatch } from "../../../store";
 import { api } from "api";
 import { AccountChangePasswordRequest } from "api/consoleApi";
 import { errorToHandler } from "api/errors";
+import { useNavigate } from "react-router-dom";
+import WarningMessage from "../Common/WarningMessage/WarningMessage";
 
 interface IChangePasswordProps {
   open: boolean;
@@ -39,6 +44,7 @@ interface IChangePasswordProps {
 
 const ChangePassword = ({ open, closeModal }: IChangePasswordProps) => {
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const [currentPassword, setCurrentPassword] = useState<string>("");
   const [newPassword, setNewPassword] = useState<string>("");
   const [reNewPassword, setReNewPassword] = useState<string>("");
@@ -86,14 +92,26 @@ const ChangePassword = ({ open, closeModal }: IChangePasswordProps) => {
         setNewPassword("");
         setReNewPassword("");
         setCurrentPassword("");
+        dispatch(
+          setSnackBarMessage(
+            "Successfully updated the password. Please login again.",
+          ),
+        );
         closeModal();
+        setTimeout(() => {
+          navigate("/logout");
+        }, 5000); // time around the snackbar closes.
       })
       .catch((err) => {
         setLoading(false);
         setNewPassword("");
         setReNewPassword("");
         setCurrentPassword("");
-        dispatch(setModalErrorSnackMessage(errorToHandler(err)));
+        const errObj = err.err || {
+          message: `Unable to update password. ${err.status} ${err.statusText}`,
+          detailedMessage: "",
+        };
+        dispatch(setModalErrorSnackMessage(errorToHandler(errObj)));
       });
   };
 
@@ -113,6 +131,25 @@ const ChangePassword = ({ open, closeModal }: IChangePasswordProps) => {
         This will change your Console password. Please note your new password
         down, as it will be required to log into Console after this session.
       </div>
+      <WarningMessage
+        title={""}
+        label={
+          <div>
+            <div>
+              If you are looking to change MINIO_ROOT_USER credentials, Please
+              refer to{" "}
+              <a
+                target="_blank"
+                rel="noopener"
+                href="https://min.io/docs/minio/linux/administration/identity-access-management/minio-user-management.html#id4?ref=con"
+              >
+                rotating
+              </a>{" "}
+              credentials .
+            </div>
+          </div>
+        }
+      />
       <form
         noValidate
         autoComplete="off"

--- a/portal-ui/src/screens/Console/Account/ChangePasswordModal.tsx
+++ b/portal-ui/src/screens/Console/Account/ChangePasswordModal.tsx
@@ -27,14 +27,14 @@ import ModalWrapper from "../Common/ModalWrapper/ModalWrapper";
 
 import { modalStyleUtils } from "../Common/FormComponents/common/styleLibrary";
 import {
+  setErrorSnackMessage,
   setModalErrorSnackMessage,
   setSnackBarMessage,
 } from "../../../systemSlice";
 import { useAppDispatch } from "../../../store";
 import { api } from "api";
-import { AccountChangePasswordRequest } from "api/consoleApi";
+import { AccountChangePasswordRequest, ApiError } from "api/consoleApi";
 import { errorToHandler } from "api/errors";
-import { useNavigate } from "react-router-dom";
 import WarningMessage from "../Common/WarningMessage/WarningMessage";
 
 interface IChangePasswordProps {
@@ -44,7 +44,6 @@ interface IChangePasswordProps {
 
 const ChangePassword = ({ open, closeModal }: IChangePasswordProps) => {
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
   const [currentPassword, setCurrentPassword] = useState<string>("");
   const [newPassword, setNewPassword] = useState<string>("");
   const [reNewPassword, setReNewPassword] = useState<string>("");
@@ -92,26 +91,16 @@ const ChangePassword = ({ open, closeModal }: IChangePasswordProps) => {
         setNewPassword("");
         setReNewPassword("");
         setCurrentPassword("");
-        dispatch(
-          setSnackBarMessage(
-            "Successfully updated the password. Please login again.",
-          ),
-        );
+        dispatch(setSnackBarMessage("Successfully updated the password."));
         closeModal();
-        setTimeout(() => {
-          navigate("/logout");
-        }, 5000); // time around the snackbar closes.
       })
-      .catch((err) => {
+      .catch(async (res) => {
         setLoading(false);
         setNewPassword("");
         setReNewPassword("");
         setCurrentPassword("");
-        const errObj = err.err || {
-          message: `Unable to update password. ${err.status} ${err.statusText}`,
-          detailedMessage: "",
-        };
-        dispatch(setModalErrorSnackMessage(errorToHandler(errObj)));
+        const err = (await res.json()) as ApiError;
+        dispatch(setErrorSnackMessage(errorToHandler(err)));
       });
   };
 

--- a/portal-ui/src/screens/Console/Account/ChangeUserPasswordModal.tsx
+++ b/portal-ui/src/screens/Console/Account/ChangeUserPasswordModal.tsx
@@ -24,10 +24,14 @@ import {
   ProgressBar,
 } from "mds";
 import { modalStyleUtils } from "../Common/FormComponents/common/styleLibrary";
-import { setModalErrorSnackMessage } from "../../../systemSlice";
+import {
+  setErrorSnackMessage,
+  setModalErrorSnackMessage,
+  setSnackBarMessage,
+} from "../../../systemSlice";
 import { useAppDispatch } from "../../../store";
 import { api } from "api";
-import { ChangeUserPasswordRequest } from "api/consoleApi";
+import { ApiError, ChangeUserPasswordRequest } from "api/consoleApi";
 import { errorToHandler } from "api/errors";
 import ModalWrapper from "../Common/ModalWrapper/ModalWrapper";
 
@@ -77,13 +81,19 @@ const ChangeUserPassword = ({
         setLoading(false);
         setNewPassword("");
         setReNewPassword("");
+        dispatch(
+          setSnackBarMessage(
+            `Successfully updated the password for the user ${userName}.`,
+          ),
+        );
         closeModal();
       })
-      .catch((err) => {
+      .catch(async (res) => {
         setLoading(false);
         setNewPassword("");
         setReNewPassword("");
-        dispatch(setModalErrorSnackMessage(errorToHandler(err)));
+        const err = (await res.json()) as ApiError;
+        dispatch(setErrorSnackMessage(errorToHandler(err)));
       });
   };
 

--- a/portal-ui/src/screens/Console/Users/UserDetails.tsx
+++ b/portal-ui/src/screens/Console/Users/UserDetails.tsx
@@ -351,6 +351,7 @@ const UserDetails = () => {
                       onClick={changeUserPassword}
                       icon={<PasswordKeyIcon />}
                       variant={"regular"}
+                      disabled={userLoggedIn === userName}
                     />
                   </TooltipWrapper>
                 </Fragment>


### PR DESCRIPTION
improve change password  user experience and add doc reference to rotating credentials for `MINIO_ROOT_USER`.

Fixes https://github.com/minio/console/issues/3053

![image](https://github.com/minio/console/assets/23444145/7167efa2-fad4-4458-8694-9327c2a2643d)
