### PR TITLE
AuditLogs page fixes

### DIFF
--- a/portal-ui/src/api/consoleApi.ts
+++ b/portal-ui/src/api/consoleApi.ts
@@ -4567,6 +4567,7 @@ export class Api<
         /** @default "timeDesc" */
         order?: "timeDesc" | "timeAsc";
         timeStart?: string;
+        timeEnd?: string;
       },
       params: RequestParams = {},
     ) =>

--- a/portal-ui/src/screens/Console/Logs/LogSearch/LogsSearchMain.tsx
+++ b/portal-ui/src/screens/Console/Logs/LogSearch/LogsSearchMain.tsx
@@ -119,9 +119,9 @@ const LogsSearchMain = () => {
             queryParams !== "" ? `${queryParams}` : ""
           }&pageSize=100&pageNo=${nextPage}&order=${
             sortOrder === "DESC" ? "timeDesc" : "timeAsc"
-          }${timeStart !== null ? `&timeStart=${timeStart.toISO()}` : ""}${
-            timeEnd !== null ? `&timeEnd=${timeEnd.toISO()}` : ""
-          }`,
+          }${
+            timeStart !== null ? `&timeStart=${timeStart.toUTC().toISO()}` : ""
+          }${timeEnd !== null ? `&timeEnd=${timeEnd.toUTC().toISO()}` : ""}`,
         )
         .then((res: ISearchResponse) => {
           const fetchedResults = res.results || [];

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -3878,6 +3878,11 @@ func init() {
             "type": "string",
             "name": "timeStart",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "name": "timeEnd",
+            "in": "query"
           }
         ],
         "responses": {
@@ -12919,6 +12924,11 @@ func init() {
           {
             "type": "string",
             "name": "timeStart",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "name": "timeEnd",
             "in": "query"
           }
         ],

--- a/restapi/operations/logging/log_search_parameters.go
+++ b/restapi/operations/logging/log_search_parameters.go
@@ -86,6 +86,10 @@ type LogSearchParams struct {
 	/*
 	  In: query
 	*/
+	TimeEnd *string
+	/*
+	  In: query
+	*/
 	TimeStart *string
 }
 
@@ -117,6 +121,11 @@ func (o *LogSearchParams) BindRequest(r *http.Request, route *middleware.Matched
 
 	qPageSize, qhkPageSize, _ := qs.GetOK("pageSize")
 	if err := o.bindPageSize(qPageSize, qhkPageSize, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qTimeEnd, qhkTimeEnd, _ := qs.GetOK("timeEnd")
+	if err := o.bindTimeEnd(qTimeEnd, qhkTimeEnd, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -229,6 +238,24 @@ func (o *LogSearchParams) bindPageSize(rawData []string, hasKey bool, formats st
 		return errors.InvalidType("pageSize", "query", "int32", raw)
 	}
 	o.PageSize = &value
+
+	return nil
+}
+
+// bindTimeEnd binds and validates parameter TimeEnd from query.
+func (o *LogSearchParams) bindTimeEnd(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.TimeEnd = &raw
 
 	return nil
 }

--- a/restapi/operations/logging/log_search_urlbuilder.go
+++ b/restapi/operations/logging/log_search_urlbuilder.go
@@ -36,6 +36,7 @@ type LogSearchURL struct {
 	Order     *string
 	PageNo    *int32
 	PageSize  *int32
+	TimeEnd   *string
 	TimeStart *string
 
 	_basePath string
@@ -108,6 +109,14 @@ func (o *LogSearchURL) Build() (*url.URL, error) {
 	}
 	if pageSizeQ != "" {
 		qs.Set("pageSize", pageSizeQ)
+	}
+
+	var timeEndQ string
+	if o.TimeEnd != nil {
+		timeEndQ = *o.TimeEnd
+	}
+	if timeEndQ != "" {
+		qs.Set("timeEnd", timeEndQ)
 	}
 
 	var timeStartQ string

--- a/restapi/user_log_search.go
+++ b/restapi/user_log_search.go
@@ -80,6 +80,12 @@ func getLogSearchResponse(session *models.Principal, params logApi.LogSearchPara
 	if params.TimeStart != nil && *params.TimeStart != "" {
 		endpoint = fmt.Sprintf("%s&timeStart=%s", endpoint, *params.TimeStart)
 	}
+
+	// timeEnd
+	if params.TimeEnd != nil && *params.TimeEnd != "" {
+		endpoint = fmt.Sprintf("%s&timeEnd=%s", endpoint, *params.TimeEnd)
+	}
+
 	// page size and page number
 	endpoint = fmt.Sprintf("%s&pageSize=%d", endpoint, *params.PageSize)
 	endpoint = fmt.Sprintf("%s&pageNo=%d", endpoint, *params.PageNo)

--- a/swagger.yml
+++ b/swagger.yml
@@ -2943,6 +2943,9 @@ paths:
         - name: timeStart
           in: query
           type: string
+        - name: timeEnd
+          in: query
+          type: string
       responses:
         200:
           description: A successful response.


### PR DESCRIPTION
## What does this do?

- Added support to endDate
- Converted dates to UTC as required by AuditLogs API

## How does it look?

![2023-09-21 18-25-42 2023-09-21 18_27_48](https://github.com/minio/console/assets/33497058/5776eeac-54a7-49ed-9e29-76a14fcc1795)

## How to test

- Configure AuditLogs as mentioned in https://min.io/docs/minio/windows/operations/monitoring/minio-logging.html
- Go into Monitoring > Audit
- Start doing queries to AuditLog page
