### PR TITLE
Removed mui support from PasswordSelector component

### DIFF
--- a/portal-ui/src/screens/Console/Users/AddUsersSlice.tsx
+++ b/portal-ui/src/screens/Console/Users/AddUsersSlice.tsx
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { createUserAsync, resetFormAsync } from "./thunk/AddUsersThunk";
 
@@ -21,7 +22,6 @@ export interface ICreateUser {
   secretKey: string;
   selectedGroups: string[];
   selectedPolicies: string[];
-  showPassword: boolean;
   sendEnabled: boolean;
   addLoading: boolean;
   apinoerror: boolean;
@@ -30,7 +30,6 @@ export interface ICreateUser {
 
 const initialState: ICreateUser = {
   addLoading: false,
-  showPassword: false,
   sendEnabled: false,
   apinoerror: false,
   userName: "",
@@ -60,9 +59,6 @@ export const createUserSlice = createSlice({
     setSelectedPolicies: (state, action: PayloadAction<string[]>) => {
       state.selectedPolicies = action.payload;
     },
-    setShowPassword: (state, action: PayloadAction<boolean>) => {
-      state.showPassword = action.payload;
-    },
     setSendEnabled: (state) => {
       state.sendEnabled = state.userName.trim() !== "";
     },
@@ -77,7 +73,6 @@ export const createUserSlice = createSlice({
         state.selectedGroups = [];
         state.secretKey = "";
         state.selectedPolicies = [];
-        state.showPassword = false;
       })
       .addCase(createUserAsync.pending, (state, action) => {
         state.addLoading = true;
@@ -96,7 +91,6 @@ export const {
   setSelectedGroups,
   setSecretKey,
   setSelectedPolicies,
-  setShowPassword,
   setAddLoading,
   setSendEnabled,
   setApinoerror,

--- a/portal-ui/src/screens/Console/Users/PasswordSelector.tsx
+++ b/portal-ui/src/screens/Console/Users/PasswordSelector.tsx
@@ -16,33 +16,27 @@
 
 import React from "react";
 import { InputBox } from "mds";
-import { setSecretKey, setShowPassword } from "./AddUsersSlice";
+import { setSecretKey } from "./AddUsersSlice";
 import { useSelector } from "react-redux";
 import { AppState, useAppDispatch } from "../../../store";
-import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
-import RemoveRedEyeIcon from "@mui/icons-material/RemoveRedEye";
 
 const PasswordSelector = () => {
   const dispatch = useAppDispatch();
-  const showPassword = useSelector(
-    (state: AppState) => state.createUser.showPassword,
-  );
   const secretKey = useSelector(
     (state: AppState) => state.createUser.secretKey,
   );
+
   return (
     <InputBox
       id="standard-multiline-static"
       name="standard-multiline-static"
+      type="password"
       label="Password"
-      type={showPassword ? "text" : "password"}
       value={secretKey}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         dispatch(setSecretKey(e.target.value));
       }}
       autoComplete="current-password"
-      overlayIcon={showPassword ? <VisibilityOffIcon /> : <RemoveRedEyeIcon />}
-      overlayAction={() => dispatch(setShowPassword(!showPassword))}
     />
   );
 };

--- a/portal-ui/src/screens/Console/Users/SetUserPolicies.tsx
+++ b/portal-ui/src/screens/Console/Users/SetUserPolicies.tsx
@@ -15,19 +15,24 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { useEffect, useState } from "react";
-import { Box, Button, FormLayout, IAMPoliciesIcon, ProgressBar } from "mds";
-
+import {
+  Box,
+  Button,
+  FormLayout,
+  IAMPoliciesIcon,
+  ProgressBar,
+  Grid,
+} from "mds";
 import { useSelector } from "react-redux";
-import Grid from "@mui/material/Grid";
 import { modalStyleUtils } from "../Common/FormComponents/common/styleLibrary";
 import { IPolicyItem } from "../Users/types";
 import { ErrorResponseHandler } from "../../../common/types";
-import ModalWrapper from "../Common/ModalWrapper/ModalWrapper";
-import api from "../../../common/api";
-import PolicySelectors from "../Policies/PolicySelectors";
 import { setModalErrorSnackMessage } from "../../../systemSlice";
 import { AppState, useAppDispatch } from "../../../store";
 import { setSelectedPolicies } from "./AddUsersSlice";
+import ModalWrapper from "../Common/ModalWrapper/ModalWrapper";
+import api from "../../../common/api";
+import PolicySelectors from "../Policies/PolicySelectors";
 
 interface ISetUserPoliciesProps {
   closeModalAndRefresh: () => void;

--- a/portal-ui/src/screens/Console/Users/thunk/AddUsersThunk.tsx
+++ b/portal-ui/src/screens/Console/Users/thunk/AddUsersThunk.tsx
@@ -20,13 +20,12 @@ import {
   setSecretKey,
   setSelectedGroups,
   setSelectedPolicies,
-  setShowPassword,
   setUserName,
 } from "../AddUsersSlice";
 import { AppState } from "../../../../store";
-import api from "../../../../common/api";
 import { ErrorResponseHandler } from "../../../../common/types";
 import { setErrorSnackMessage } from "../../../../systemSlice";
+import api from "../../../../common/api";
 
 export const resetFormAsync = createAsyncThunk(
   "resetForm/resetFormAsync",
@@ -35,7 +34,6 @@ export const resetFormAsync = createAsyncThunk(
     dispatch(setUserName(""));
     dispatch(setSecretKey(""));
     dispatch(setSelectedPolicies([]));
-    dispatch(setShowPassword(false));
   },
 );
 


### PR DESCRIPTION
## What does this do?

Removed mui support from password selector component

## How does it look?


<img width="827" alt="Screenshot 2023-10-06 at 12 21 41 p m" src="https://github.com/minio/console/assets/33497058/bf707c4c-d55d-47e6-8350-a40ab94d71b7">
<img width="778" alt="Screenshot 2023-10-06 at 12 21 37 p m" src="https://github.com/minio/console/assets/33497058/a10e74de-cf00-482c-acb9-e54f17ebb330">
<img width="858" alt="Screenshot 2023-10-06 at 12 21 27 p m" src="https://github.com/minio/console/assets/33497058/39efcb3e-9fe7-49d3-b379-5a477bff5a9b">

