### PR TITLE
update docker file to ubi9 base image

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,17 +1,10 @@
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:8.7 as build
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2 as build
 
 RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs
-RUN  curl -s -q https://raw.githubusercontent.com/minio/kes/master/LICENSE -o LICENSE
-RUN  curl -s -q https://raw.githubusercontent.com/minio/kes/master/CREDITS -o CREDITS
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.7
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.2
 
-# On RHEL the certificate bundle is located at:
-# - /etc/pki/tls/certs/ca-bundle.crt (RHEL 6)
-# - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (RHEL 7)
-COPY --from=build /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
-COPY --from=build LICENSE /LICENSE
-COPY --from=build CREDITS /CREDITS
+ARG TAG
 
 LABEL name="MinIO" \
       vendor="MinIO Inc <dev@min.io>" \
@@ -21,7 +14,14 @@ LABEL name="MinIO" \
       summary="A graphical user interface for MinIO" \
       description="MinIO object storage is fundamentally different. Designed for performance and the S3 API, it is 100% open-source. MinIO is ideal for large, private cloud environments with stringent security requirements and delivers mission-critical availability across a diverse range of workloads."
 
-EXPOSE 9090
+# On RHEL the certificate bundle is located at:
+# - /etc/pki/tls/certs/ca-bundle.crt (RHEL 6)
+# - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (RHEL 7)
+COPY --from=build /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
+COPY LICENSE /LICENSE
+COPY CREDITS /CREDITS
 COPY console /console
+
+EXPOSE 9090
 
 ENTRYPOINT ["/console"]


### PR DESCRIPTION
This commit improves and updates the docker file
to the UBI 9 base image.