### PR TITLE
Restored ENV var display support in Console Configuration pages.

### DIFF
--- a/portal-ui/src/screens/Console/Configurations/types.ts
+++ b/portal-ui/src/screens/Console/Configurations/types.ts
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { SelectorTypes } from "../../../common/types";
+import { EnvOverride } from "../../../api/consoleApi";
 
 export type KVFieldType =
   | "string"
@@ -51,15 +52,10 @@ export interface IConfigurationElement {
   url?: string;
 }
 
-export interface IEnvOverride {
-  name: string;
-  value: string;
-}
-
 export interface IElementValue {
   key: string;
   value: string;
-  env_override?: IEnvOverride;
+  env_override?: EnvOverride;
 }
 
 export interface IConfigurationSys {

--- a/portal-ui/src/screens/Console/Configurations/utils.tsx
+++ b/portal-ui/src/screens/Console/Configurations/utils.tsx
@@ -429,8 +429,8 @@ export const overrideFields = (formFields: IElementValue[]): IOverrideEnv => {
     // it has override values, we construct the value
     if (envItem.env_override) {
       const value: OverrideValue = {
-        value: envItem.env_override.value,
-        overrideEnv: envItem.env_override.name,
+        value: envItem.env_override.value || "",
+        overrideEnv: envItem.env_override.name || "",
       };
 
       overrideReturn = { ...overrideReturn, [envItem.key]: value };

--- a/portal-ui/src/screens/Console/EventDestinations/CustomForms/EditConfiguration.tsx
+++ b/portal-ui/src/screens/Console/EventDestinations/CustomForms/EditConfiguration.tsx
@@ -91,7 +91,7 @@ const EditConfiguration = ({
 
             const fieldsConfig: KVField[] = fieldsConfigurations[configId];
 
-            const keyVals = fieldsConfig.map((field) => {
+            const keyVals: IElementValue[] = fieldsConfig.map((field) => {
               const includedValue = values.find(
                 (element: ConfigurationKV) => element.key === field.name,
               );
@@ -102,6 +102,7 @@ const EditConfiguration = ({
                 value: field.customValueProcess
                   ? field.customValueProcess(customValue)
                   : customValue,
+                env_override: includedValue?.env_override,
               };
             });
 


### PR DESCRIPTION
fixes #3111
fixes https://github.com/minio/minio/discussions/18328

## What does this do?

Fixed an issue with override ENV vars display in Console's Configuration page.

## How does it look?


<img width="1552" alt="Screenshot 2023-10-30 at 1 36 32 p m" src="https://github.com/minio/console/assets/33497058/94ea9818-ef31-4392-b052-9a80faa4f53c">
<img width="1558" alt="Screenshot 2023-10-30 at 1 34 50 p m" src="https://github.com/minio/console/assets/33497058/a26565c6-943a-4222-bf9c-7f1b3451202f">
<img width="1565" alt="Screenshot 2023-10-30 at 1 34 42 p m" src="https://github.com/minio/console/assets/33497058/4900514e-1a7c-4305-a49f-224bc03b1299">
