### PR TITLE
Replaced MenuDropdown components with mds variables

### DIFF
--- a/portal-ui/package.json
+++ b/portal-ui/package.json
@@ -17,7 +17,7 @@
     "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.21",
     "luxon": "^3.4.3",
-    "mds": "https://github.com/minio/mds.git#v0.10.1",
+    "mds": "https://github.com/minio/mds.git#v0.11.0",
     "react": "^18.1.0",
     "react-component-export-image": "^1.0.6",
     "react-copy-to-clipboard": "^5.0.2",

--- a/portal-ui/src/screens/Console/Common/FormComponents/InputUnitMenu/InputUnitMenu.tsx
+++ b/portal-ui/src/screens/Console/Common/FormComponents/InputUnitMenu/InputUnitMenu.tsx
@@ -15,14 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Fragment } from "react";
-import { Theme } from "@mui/material/styles";
-import createStyles from "@mui/styles/createStyles";
-import withStyles from "@mui/styles/withStyles";
-import { SelectorType } from "mds";
-import { Menu, MenuItem } from "@mui/material";
+import { DropdownSelector, SelectorType } from "mds";
+import styled from "styled-components";
+import get from "lodash/get";
 
 interface IInputUnitBox {
-  classes: any;
   id: string;
   unitSelected: string;
   unitsList: SelectorType[];
@@ -30,19 +27,15 @@ interface IInputUnitBox {
   onUnitChange?: (newValue: string) => void;
 }
 
-const styles = (theme: Theme) =>
-  createStyles({
-    buttonTrigger: {
-      border: "#F0F2F2 1px solid",
-      borderRadius: 3,
-      color: "#838383",
-      backgroundColor: "#fff",
-      fontSize: 12,
-    },
-  });
+const UnitMenuButton = styled.button(({ theme }) => ({
+  border: `1px solid ${get(theme, "borderColor", "#E2E2E2")}`,
+  borderRadius: 3,
+  color: get(theme, "secondaryText", "#5B5C5C"),
+  backgroundColor: get(theme, "boxBackground", "#FBFAFA"),
+  fontSize: 12,
+}));
 
 const InputUnitMenu = ({
-  classes,
   id,
   unitSelected,
   unitsList,
@@ -63,46 +56,31 @@ const InputUnitMenu = ({
 
   return (
     <Fragment>
-      <button
+      <UnitMenuButton
         id={`${id}-button`}
         aria-controls={`${id}-menu`}
         aria-haspopup="true"
         aria-expanded={open ? "true" : undefined}
         onClick={handleClick}
-        className={classes.buttonTrigger}
         disabled={disabled}
         type={"button"}
       >
         {unitSelected}
-      </button>
-      <Menu
-        id={`${id}-menu`}
-        aria-labelledby={`${id}-button`}
-        anchorEl={anchorEl}
-        open={open}
-        onClose={() => {
+      </UnitMenuButton>
+      <DropdownSelector
+        id={"upload-main-menu"}
+        options={unitsList}
+        selectedOption={""}
+        onSelect={(value) => handleClose(value)}
+        hideTriggerAction={() => {
           handleClose("");
         }}
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "center",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "center",
-        }}
-      >
-        {unitsList.map((unit) => (
-          <MenuItem
-            onClick={() => handleClose(unit.value)}
-            key={`itemUnit-${unit.value}-${unit.label}`}
-          >
-            {unit.label}
-          </MenuItem>
-        ))}
-      </Menu>
+        open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={"end"}
+      />
     </Fragment>
   );
 };
 
-export default withStyles(styles)(InputUnitMenu);
+export default InputUnitMenu;

--- a/portal-ui/src/screens/Console/Dashboard/DownloadWidgetDataButton.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/DownloadWidgetDataButton.tsx
@@ -15,9 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Fragment } from "react";
-import { Box, Menu, MenuItem } from "@mui/material";
-import ListItemText from "@mui/material/ListItemText";
-import { DownloadIcon } from "mds";
+import { Box, DownloadIcon, DropdownSelector } from "mds";
 import { exportComponentAsPNG } from "react-component-export-image";
 import { ErrorResponseHandler } from "../../../common/types";
 import { useAppDispatch } from "../../../../src/store";
@@ -104,11 +102,19 @@ const DownloadWidgetDataButton = ({
     }
   };
 
+  const handleSelectedOption = (selectOption: string) => {
+    if (selectOption === "csv") {
+      downloadAsCSV();
+    } else if (selectOption === "png") {
+      downloadAsPNG();
+    }
+  };
+
   return (
     <Fragment>
       <Box
-        justifyItems={"center"}
         sx={{
+          justifyItems: "center",
           "& .download-icon": {
             backgroundColor: "transparent",
             border: 0,
@@ -126,33 +132,24 @@ const DownloadWidgetDataButton = ({
           },
         }}
       >
-        <button onClick={handleClick} className={"download-icon"}>
+        <button className={"download-icon"} onClick={handleClick}>
           <DownloadIcon />
         </button>
-        <Menu
-          id={`download-widget-main-menu`}
-          aria-labelledby={`download-widget-main`}
-          anchorEl={anchorEl}
-          open={openDownloadMenu}
-          onClose={() => {
+        <DropdownSelector
+          id={"download-widget-main-menu"}
+          options={[
+            { label: "Download as CSV", value: "csv" },
+            { label: "Download as PNG", value: "png" },
+          ]}
+          selectedOption={""}
+          onSelect={(value) => handleSelectedOption(value)}
+          hideTriggerAction={() => {
             handleCloseDownload();
           }}
-        >
-          <MenuItem
-            onClick={() => {
-              downloadAsCSV();
-            }}
-          >
-            <ListItemText>Download as CSV</ListItemText>
-          </MenuItem>
-          <MenuItem
-            onClick={() => {
-              downloadAsPNG();
-            }}
-          >
-            <ListItemText>Download as PNG</ListItemText>
-          </MenuItem>
-        </Menu>
+          open={openDownloadMenu}
+          anchorEl={anchorEl}
+          anchorOrigin={"end"}
+        />
       </Box>
     </Fragment>
   );

--- a/portal-ui/src/screens/LoginPage/StrategyForm.tsx
+++ b/portal-ui/src/screens/LoginPage/StrategyForm.tsx
@@ -152,6 +152,7 @@ const StrategyForm = ({ redirectRules }: { redirectRules: RedirectRule[] }) => {
                 }}
                 open={ssoOptionsOpen}
                 anchorEl={anchorEl}
+                useAnchorWidth={true}
               />
             )}
           </Box>

--- a/portal-ui/src/utils/stylesUtils.ts
+++ b/portal-ui/src/utils/stylesUtils.ts
@@ -42,6 +42,7 @@ export const generateOverrideTheme = (overrideVars: IEmbeddedCustomStyles) => {
       loaderColor: overrideVars.loaderColor,
       boxBackground: overrideVars.boxBackground,
       mutedText: "#9c9c9c",
+      secondaryText: "#9c9c9c",
       buttons: {
         regular: {
           enabled: {

--- a/portal-ui/tests/permissions-B/bucketWritePrefixOnly.ts
+++ b/portal-ui/tests/permissions-B/bucketWritePrefixOnly.ts
@@ -31,11 +31,9 @@ test
         .useRole(roles.bucketWritePrefixOnly)
         .navigateTo("http://localhost:9090/browser/testcafe")
         .click(uploadButton)
-        .expect(Selector("li").withText("Upload File").hasClass("Mui-disabled"))
+        .expect(Selector("li").withText("Upload File").hasClass("disabled"))
         .ok()
-        .expect(
-          Selector("li").withText("Upload Folder").hasClass("Mui-disabled"),
-        )
+        .expect(Selector("li").withText("Upload Folder").hasClass("disabled"))
         .notOk();
     },
   )
@@ -50,11 +48,9 @@ test
         .useRole(roles.bucketWritePrefixOnly)
         .navigateTo("http://localhost:9090/browser/testcafe/d3JpdGU=")
         .click(uploadButton)
-        .expect(Selector("li").withText("Upload File").hasClass("Mui-disabled"))
+        .expect(Selector("li").withText("Upload File").hasClass("disabled"))
         .notOk()
-        .expect(
-          Selector("li").withText("Upload Folder").hasClass("Mui-disabled"),
-        )
+        .expect(Selector("li").withText("Upload Folder").hasClass("disabled"))
         .notOk();
     },
   )

--- a/portal-ui/yarn.lock
+++ b/portal-ui/yarn.lock
@@ -8412,9 +8412,9 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-"mds@https://github.com/minio/mds.git#v0.10.1":
-  version "0.10.1"
-  resolved "https://github.com/minio/mds.git#83a5533ce8331cc57613308c1aaf6c4b40196c1c"
+"mds@https://github.com/minio/mds.git#v0.11.0":
+  version "0.11.0"
+  resolved "https://github.com/minio/mds.git#f8f53f26977ee21d6de5c11915f34fb12a2a01ab"
   dependencies:
     "@types/styled-components" "^5.1.28"
     "@uiw/react-textarea-code-editor" "^2.1.9"


### PR DESCRIPTION
## What does this do?

- Replaced menu dropdown in Files Button
- Input Unit Menu dropdown replacement
- Migrated Download Widget dropdown
- Updated mds to v0.11.0

## How does it look?
<img width="307" alt="Screenshot 2023-10-30 at 2 07 47 p m" src="https://github.com/minio/console/assets/33497058/6dfad374-1d08-4b97-88ea-95bf943dc8b5">
<img width="852" alt="Screenshot 2023-10-30 at 2 07 38 p m" src="https://github.com/minio/console/assets/33497058/f442b224-4bf4-4b6f-a77b-b983ccd3fffb">
<img width="295" alt="Screenshot 2023-10-30 at 2 08 00 p m" src="https://github.com/minio/console/assets/33497058/01047a65-2bd6-41ed-b590-94a16afe679d">
