### PR TITLE
Ignore server file from swagger-gen make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ swagger-console:
 	@swagger generate server -A console --main-package=management --server-package=restapi --exclude-main -P models.Principal -f ./swagger.yml -r NOTICE
 	@echo "Generating typescript api"
 	@npx swagger-typescript-api -p ./swagger.yml -o ./portal-ui/src/api -n consoleApi.ts
+	@git restore restapi/server.go
 
 
 assets:


### PR DESCRIPTION
Since we are using a custom server `custom-server.go`. Running swagger-gen was overriding the ignore flag in `server.go`.
Issue was showing like:
```
restapi/server.go:48:2: schemeHTTP redeclared in this block
        restapi/custom-server.go:46:2: other declaration of schemeHTTP
restapi/server.go:49:2: schemeHTTPS redeclared in this block
        restapi/custom-server.go:47:2: other declaration of schemeHTTPS
        ....
```

Note: swagger-go doesn't have a flag to not build the server.

Test like:
`make swagger-gen && make`.
It should build the binary successfully. 
