### PR TITLE
[WIP] Enabled Dark Mode in Console

### DIFF
--- a/portal-ui/package.json
+++ b/portal-ui/package.json
@@ -10,7 +10,7 @@
     "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.21",
     "luxon": "^3.4.3",
-    "mds": "https://github.com/minio/mds.git#v0.12.1",
+    "mds": "https://github.com/minio/mds.git#v0.12.2",
     "react": "^18.1.0",
     "react-component-export-image": "^1.0.6",
     "react-copy-to-clipboard": "^5.0.2",

--- a/portal-ui/src/StyleHandler.tsx
+++ b/portal-ui/src/StyleHandler.tsx
@@ -42,7 +42,7 @@ const StyleHandler = ({ children }: IStyleHandler) => {
   return (
     <Fragment>
       <GlobalStyles />
-      <ThemeHandler darkMode={!!darkMode} customTheme={thm}>
+      <ThemeHandler darkMode={darkMode} customTheme={thm}>
         {children}
       </ThemeHandler>
     </Fragment>

--- a/portal-ui/src/screens/Console/Common/DarkModeActivator/DarkModeActivator.tsx
+++ b/portal-ui/src/screens/Console/Common/DarkModeActivator/DarkModeActivator.tsx
@@ -1,5 +1,5 @@
 // This file is part of MinIO Console Server
-// Copyright (c) 2021 MinIO, Inc.
+// Copyright (c) 2023 MinIO, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -14,39 +14,35 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { Fragment } from "react";
-import { GlobalStyles, ThemeHandler } from "mds";
-import "react-virtualized/styles.css";
-
-import { generateOverrideTheme } from "./utils/stylesUtils";
-import "./index.css";
+import React from "react";
+import { Button, DarkModeIcon } from "mds";
+import TooltipWrapper from "../TooltipWrapper/TooltipWrapper";
 import { useSelector } from "react-redux";
-import { AppState } from "./store";
+import { AppState, useAppDispatch } from "../../../../store";
+import { setDarkMode } from "../../../../systemSlice";
+import { storeDarkMode } from "../../../../utils/stylesUtils";
 
-interface IStyleHandler {
-  children: React.ReactNode;
-}
+const DarkModeActivator = () => {
+  const dispatch = useAppDispatch();
 
-const StyleHandler = ({ children }: IStyleHandler) => {
-  const colorVariants = useSelector(
-    (state: AppState) => state.system.overrideStyles,
-  );
   const darkMode = useSelector((state: AppState) => state.system.darkMode);
 
-  let thm = undefined;
+  const darkModeActivator = () => {
+    const currentStatus = !!darkMode;
 
-  if (colorVariants) {
-    thm = generateOverrideTheme(colorVariants);
-  }
+    dispatch(setDarkMode(!currentStatus));
+    storeDarkMode(!currentStatus ? "on" : "off");
+  };
 
   return (
-    <Fragment>
-      <GlobalStyles />
-      <ThemeHandler darkMode={!!darkMode} customTheme={thm}>
-        {children}
-      </ThemeHandler>
-    </Fragment>
+    <TooltipWrapper tooltip={`${darkMode ? "Light" : "Dark"} Mode`}>
+      <Button
+        id={"dark-mode-activator"}
+        icon={<DarkModeIcon />}
+        onClick={darkModeActivator}
+      />
+    </TooltipWrapper>
   );
 };
 
-export default StyleHandler;
+export default DarkModeActivator;

--- a/portal-ui/src/screens/Console/Common/PageHeaderWrapper/PageHeaderWrapper.tsx
+++ b/portal-ui/src/screens/Console/Common/PageHeaderWrapper/PageHeaderWrapper.tsx
@@ -17,6 +17,7 @@
 import React, { Fragment } from "react";
 import { PageHeader } from "mds";
 import ObjectManagerButton from "../ObjectManager/ObjectManagerButton";
+import DarkModeActivator from "../DarkModeActivator/DarkModeActivator";
 
 interface IPageHeaderWrapper {
   label: React.ReactNode;
@@ -35,6 +36,7 @@ const PageHeaderWrapper = ({
       actions={
         <Fragment>
           {actions}
+          <DarkModeActivator />
           <ObjectManagerButton />
         </Fragment>
       }

--- a/portal-ui/src/screens/LoginPage/Login.tsx
+++ b/portal-ui/src/screens/LoginPage/Login.tsx
@@ -27,7 +27,8 @@ import StrategyForm from "./StrategyForm";
 import { getLogoVar } from "../../config";
 import { RedirectRule } from "api/consoleApi";
 import { redirectRules } from "./login.utils";
-import { setHelpName } from "../../systemSlice";
+import { setDarkMode, setHelpName } from "../../systemSlice";
+import get from "lodash/get";
 
 export const getTargetPath = () => {
   let targetPath = "/browser";
@@ -59,6 +60,8 @@ const Login = () => {
     (state: AppState) => state.login.backgroundAnimation,
   );
 
+  const darkMode = useSelector((state: AppState) => state.system.darkMode);
+
   useEffect(() => {
     if (navigateTo !== "") {
       dispatch(resetForm());
@@ -71,6 +74,15 @@ const Login = () => {
       dispatch(getFetchConfigurationAsync());
     }
   }, [loadingFetchConfiguration, dispatch]);
+
+  useEffect(() => {
+    if (darkMode === null) {
+      const systemDarkMode = window.matchMedia("(prefers-color-scheme: dark)");
+      const darkModeFromSystem = get(systemDarkMode, "matches", false);
+
+      dispatch(setDarkMode(darkModeFromSystem));
+    }
+  }, [darkMode, dispatch]);
 
   let loginComponent;
 

--- a/portal-ui/src/screens/LoginPage/Login.tsx
+++ b/portal-ui/src/screens/LoginPage/Login.tsx
@@ -27,8 +27,7 @@ import StrategyForm from "./StrategyForm";
 import { getLogoVar } from "../../config";
 import { RedirectRule } from "api/consoleApi";
 import { redirectRules } from "./login.utils";
-import { setDarkMode, setHelpName } from "../../systemSlice";
-import get from "lodash/get";
+import { setHelpName } from "../../systemSlice";
 
 export const getTargetPath = () => {
   let targetPath = "/browser";
@@ -74,15 +73,6 @@ const Login = () => {
       dispatch(getFetchConfigurationAsync());
     }
   }, [loadingFetchConfiguration, dispatch]);
-
-  useEffect(() => {
-    if (darkMode === null) {
-      const systemDarkMode = window.matchMedia("(prefers-color-scheme: dark)");
-      const darkModeFromSystem = get(systemDarkMode, "matches", false);
-
-      dispatch(setDarkMode(darkModeFromSystem));
-    }
-  }, [darkMode, dispatch]);
 
   let loginComponent;
 

--- a/portal-ui/src/screens/LoginPage/loginThunks.ts
+++ b/portal-ui/src/screens/LoginPage/loginThunks.ts
@@ -16,12 +16,17 @@
 
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { AppState } from "../../store";
-import { setErrorSnackMessage, userLogged } from "../../systemSlice";
+import {
+  setDarkMode,
+  setErrorSnackMessage,
+  userLogged,
+} from "../../systemSlice";
 import { setNavigateTo } from "./loginSlice";
 import { getTargetPath } from "./Login";
 import { api } from "api";
 import { ApiError, LoginRequest } from "api/consoleApi";
 import { errorToHandler } from "api/errors";
+import { isDarkModeOn } from "../../utils/stylesUtils";
 
 export const doLoginAsync = createAsyncThunk(
   "login/doLoginAsync",
@@ -47,10 +52,13 @@ export const doLoginAsync = createAsyncThunk(
     return api.login
       .login(payload)
       .then((res) => {
+        const darkModeEnabled = isDarkModeOn(); // If null, then we set the dark mode as disabled per requirement. If configuration al ready set, then we establish this configuration
+
         // We set the state in redux
         dispatch(userLogged(true));
         localStorage.setItem("userLoggedIn", accessKey);
         dispatch(setNavigateTo(getTargetPath()));
+        dispatch(setDarkMode(!!darkModeEnabled));
       })
       .catch(async (res) => {
         const err = (await res.json()) as ApiError;

--- a/portal-ui/src/systemSlice.ts
+++ b/portal-ui/src/systemSlice.ts
@@ -46,7 +46,7 @@ export interface SystemState {
   helpName: string;
   helpTabName: string;
   locationPath: string;
-  darkMode: boolean | null;
+  darkMode: boolean;
 }
 
 const initialState: SystemState = {

--- a/portal-ui/src/systemSlice.ts
+++ b/portal-ui/src/systemSlice.ts
@@ -18,6 +18,7 @@ import { snackBarMessage, SRInfoStateType } from "./types";
 import { ErrorResponseHandler, IEmbeddedCustomStyles } from "./common/types";
 import { AppState } from "./store";
 import { SubnetInfo } from "./screens/Console/License/types";
+import { isDarkModeOn } from "./utils/stylesUtils";
 
 // determine whether we have the sidebar state stored on localstorage
 const initSideBarOpen = localStorage.getItem("sidebarOpen")
@@ -45,6 +46,7 @@ export interface SystemState {
   helpName: string;
   helpTabName: string;
   locationPath: string;
+  darkMode: boolean | null;
 }
 
 const initialState: SystemState = {
@@ -76,6 +78,7 @@ const initialState: SystemState = {
   helpName: "help",
   helpTabName: "docs",
   locationPath: "",
+  darkMode: isDarkModeOn(),
 };
 
 export const systemSlice = createSlice({
@@ -174,6 +177,9 @@ export const systemSlice = createSlice({
     setLocationPath: (state, action: PayloadAction<string>) => {
       state.locationPath = action.payload;
     },
+    setDarkMode: (state, action: PayloadAction<boolean>) => {
+      state.darkMode = action.payload;
+    },
     resetSystem: () => {
       return initialState;
     },
@@ -203,6 +209,7 @@ export const {
   setHelpName,
   setHelpTabName,
   setLocationPath,
+  setDarkMode,
 } = systemSlice.actions;
 
 export const selDistSet = (state: AppState) => state.system.distributedSetup;

--- a/portal-ui/src/utils/stylesUtils.ts
+++ b/portal-ui/src/utils/stylesUtils.ts
@@ -279,3 +279,17 @@ export const generateOverrideTheme = (overrideVars: IEmbeddedCustomStyles) => {
 
   return retVal;
 };
+
+export const isDarkModeOn = () => {
+  const darkMode = localStorage.getItem("dark-mode");
+
+  if (!darkMode) {
+    return null;
+  }
+
+  return darkMode === "on";
+};
+
+export const storeDarkMode = (mode: "on" | "off") => {
+  localStorage.setItem("dark-mode", mode);
+};

--- a/portal-ui/src/utils/stylesUtils.ts
+++ b/portal-ui/src/utils/stylesUtils.ts
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { IEmbeddedCustomStyles } from "../common/types";
+import get from "lodash/get";
 
 export const getOverrideColorVariants: (
   customStyles: string,
@@ -284,7 +285,8 @@ export const isDarkModeOn = () => {
   const darkMode = localStorage.getItem("dark-mode");
 
   if (!darkMode) {
-    return null;
+    const systemDarkMode = window.matchMedia("(prefers-color-scheme: dark)");
+    return get(systemDarkMode, "matches", false);
   }
 
   return darkMode === "on";

--- a/portal-ui/yarn.lock
+++ b/portal-ui/yarn.lock
@@ -8038,9 +8038,9 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-"mds@https://github.com/minio/mds.git#v0.12.1":
-  version "0.12.1"
-  resolved "https://github.com/minio/mds.git#4c4b18d022eed7c120a044709e677b25bc4500d7"
+"mds@https://github.com/minio/mds.git#v0.12.2":
+  version "0.12.2"
+  resolved "https://github.com/minio/mds.git#82b14ea9544079a24db31e5cff477e3fc56c4e39"
   dependencies:
     "@types/styled-components" "^5.1.30"
     "@uiw/react-textarea-code-editor" "^2.1.9"


### PR DESCRIPTION
fixes #2429 

## What does this do?

- Dark mode for login page will be tied to system settings when no configuration is set
- Dark mode will be stored in Application storage once set
- If Set system will automatically set the Dark Mode configuration

## How does it look?

<img width="1805" alt="Screenshot 2023-11-14 at 1 51 44 p m" src="https://github.com/minio/console/assets/33497058/e36ffc48-6b46-4437-9416-6ff31ae55544">
<img width="1815" alt="Screenshot 2023-11-14 at 1 50 02 p m" src="https://github.com/minio/console/assets/33497058/e178e8c6-3d7c-4527-b51e-b45404e69fda">
<img width="1815" alt="Screenshot 2023-11-14 at 1 49 48 p m" src="https://github.com/minio/console/assets/33497058/501e4644-3c1b-4514-b491-6f65c77ce3d5">
<img width="1808" alt="Screenshot 2023-11-14 at 1 49 35 p m" src="https://github.com/minio/console/assets/33497058/fece55d1-2d60-4c9e-85ec-66b8a4d466b1">
<img width="1819" alt="Screenshot 2023-11-14 at 1 49 27 p m" src="https://github.com/minio/console/assets/33497058/95294af1-2a8f-4888-8844-1ff0919bc38e">
<img width="1813" alt="Screenshot 2023-11-14 at 1 49 19 p m" src="https://github.com/minio/console/assets/33497058/2db9a100-e0f0-4e67-862b-b1c9a48a46de">
