### PR TITLE
fix share option should not be enabled for a prefix

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -359,6 +359,8 @@ const ListObjects = () => {
   useEffect(() => {
     if (selectedObjects.length === 1) {
       const objectName = selectedObjects[0];
+      const isPrefix = objectName.endsWith("/");
+
       let objectType: AllowedPreviews = previewObjectType(metaData, objectName);
 
       if (objectType !== "none" && canDownload) {
@@ -367,7 +369,7 @@ const ListObjects = () => {
         setCanPreviewFile(false);
       }
 
-      if (objectName.endsWith("/") || canDownload) {
+      if (canDownload && !isPrefix) {
         setCanShareFile(true);
       } else {
         setCanShareFile(false);


### PR DESCRIPTION
Share option should not be available at a prefix level in console. 

How does it look: 
![Fix](https://github.com/minio/console/assets/23444145/eb1fcfda-e415-409b-b1b4-cb015358dd1c)
