### PR TITLE
add encoded filename as part of upload url

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -127,6 +127,8 @@ import ListObjectsTable from "./ListObjectsTable";
 import FilterObjectsSB from "../../../../ObjectBrowser/FilterObjectsSB";
 import AddAccessRule from "../../../BucketDetails/AddAccessRule";
 
+import sanitize from "sanitize-filename";
+
 const DeleteMultipleObjects = withSuspense(
   React.lazy(() => import("./DeleteMultipleObjects")),
 );
@@ -546,12 +548,16 @@ const ListObjects = () => {
               );
             }
 
+            const sanitizedFileName = sanitize(fileName);
+
             if (encodedPath !== "") {
               uploadUrl = `${uploadUrl}?prefix=${encodedPath}${encodeURLString(
-                fileName,
+                sanitizedFileName,
               )}`;
             } else {
-              uploadUrl = `${uploadUrl}?prefix=${encodeURLString(fileName)}`;
+              uploadUrl = `${uploadUrl}?prefix=${encodeURLString(
+                sanitizedFileName,
+              )}`;
             }
 
             const identity = encodeURLString(

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -547,7 +547,12 @@ const ListObjects = () => {
             }
 
             if (encodedPath !== "") {
-              uploadUrl = `${uploadUrl}?prefix=${encodedPath}`;
+              uploadUrl = `${uploadUrl}?prefix=${encodedPath}&fileName=${encodeURLString(
+                fileName,
+              )}`;
+            } else {
+              // if passed as prefix it would be treated as folder in backend
+              uploadUrl = `${uploadUrl}?fileName=${encodeURLString(fileName)}`;
             }
 
             const identity = encodeURLString(

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -127,8 +127,6 @@ import ListObjectsTable from "./ListObjectsTable";
 import FilterObjectsSB from "../../../../ObjectBrowser/FilterObjectsSB";
 import AddAccessRule from "../../../BucketDetails/AddAccessRule";
 
-import sanitize from "sanitize-filename";
-
 const DeleteMultipleObjects = withSuspense(
   React.lazy(() => import("./DeleteMultipleObjects")),
 );
@@ -524,6 +522,8 @@ const ListObjects = () => {
               relativeFolderPath = fileWebkitRelativePath;
             }
 
+            let prefixPath = "";
+
             if (path !== "" || relativeFolderPath !== "") {
               const finalFolderPath = relativeFolderPath
                 .split("/")
@@ -532,33 +532,29 @@ const ListObjects = () => {
 
               const pathClean = path.endsWith("/") ? path.slice(0, -1) : path;
 
-              encodedPath = encodeURLString(
-                `${pathClean}${
-                  !pathClean.endsWith("/") &&
-                  finalFolderPath !== "" &&
-                  !finalFolderPath.startsWith("/")
-                    ? "/"
-                    : ""
-                }${finalFolderPath}${
-                  !finalFolderPath.endsWith("/") ||
-                  (finalFolderPath.trim() === "" && !path.endsWith("/"))
-                    ? "/"
-                    : ""
-                }`,
-              );
+              prefixPath = `${pathClean}${
+                !pathClean.endsWith("/") &&
+                finalFolderPath !== "" &&
+                !finalFolderPath.startsWith("/")
+                  ? "/"
+                  : ""
+              }${finalFolderPath}${
+                !finalFolderPath.endsWith("/") ||
+                (finalFolderPath.trim() === "" && !path.endsWith("/"))
+                  ? "/"
+                  : ""
+              }`;
             }
 
-            const sanitizedFileName = sanitize(fileName);
-
-            if (encodedPath !== "") {
-              uploadUrl = `${uploadUrl}?prefix=${encodedPath}${encodeURLString(
-                sanitizedFileName,
+            if (prefixPath !== "") {
+              uploadUrl = `${uploadUrl}?prefix=${encodeURLString(
+                prefixPath + fileName,
               )}`;
             } else {
-              uploadUrl = `${uploadUrl}?prefix=${encodeURLString(
-                sanitizedFileName,
-              )}`;
+              uploadUrl = `${uploadUrl}?prefix=${encodeURLString(fileName)}`;
             }
+
+            encodedPath = encodeURLString(prefixPath);
 
             const identity = encodeURLString(
               `${bucketName}-${encodedPath}-${new Date().getTime()}-${Math.random()}`,

--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -547,12 +547,11 @@ const ListObjects = () => {
             }
 
             if (encodedPath !== "") {
-              uploadUrl = `${uploadUrl}?prefix=${encodedPath}&fileName=${encodeURLString(
+              uploadUrl = `${uploadUrl}?prefix=${encodedPath}${encodeURLString(
                 fileName,
               )}`;
             } else {
-              // if passed as prefix it would be treated as folder in backend
-              uploadUrl = `${uploadUrl}?fileName=${encodeURLString(fileName)}`;
+              uploadUrl = `${uploadUrl}?prefix=${encodeURLString(fileName)}`;
             }
 
             const identity = encodeURLString(

--- a/restapi/user_objects.go
+++ b/restapi/user_objects.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -1030,8 +1029,8 @@ func uploadFiles(ctx context.Context, client MinioClient, params objectApi.PostB
 		if contentType == "" {
 			contentType = mimedb.TypeByExtension(filepath.Ext(p.FileName()))
 		}
-
-		_, err = client.putObject(ctx, params.BucketName, path.Join(prefix, path.Clean(p.FileName())), p, size, minio.PutObjectOptions{
+		objectName := prefix // prefix will have complete object path e.g: /test-prefix/test-object.txt
+		_, err = client.putObject(ctx, params.BucketName, objectName, p, size, minio.PutObjectOptions{
 			ContentType:      contentType,
 			DisableMultipart: true, // Do not upload as multipart stream for console uploader.
 		})


### PR DESCRIPTION
pass encoded file name also as part of the url.
- Upload a single/multiole files
- Upload a folder
- Drag and drop
- upload under a prefix

the file name is part of `prefix=`  parameter. parameter added for tooling support.

e.g:
```
http://localhost:5005/api/v1/buckets/test-bucket/objects/upload?prefix=dGVzdC1wcmVmaXgvMS5kb2M=
http://localhost:5005/api/v1/buckets/test-bucket/objects/upload?prefix=MS5wbmc=

```