### PR TITLE
Add HelpTip to clarify Usage calculation

### DIFF
--- a/web-app/src/screens/Console/Buckets/ListBuckets/BucketListItem.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/BucketListItem.tsx
@@ -220,12 +220,7 @@ const BucketListItem = ({
           }
         >
           {bucket.details?.versioning && (
-            <HelpTip
-              content={
-                usageClarifyingContent
-              }
-              placement="top"
-            >
+            <HelpTip content={usageClarifyingContent} placement="top">
               <ReportedUsageIcon />{" "}
             </HelpTip>
           )}

--- a/web-app/src/screens/Console/Buckets/ListBuckets/BucketListItem.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/BucketListItem.tsx
@@ -13,14 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import React, {
-  Fragment,
-  RefObject,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { Fragment, useState } from "react";
 import get from "lodash/get";
 import styled from "styled-components";
 import { Link, useNavigate } from "react-router-dom";

--- a/web-app/src/screens/Console/Buckets/ListBuckets/BucketListItem.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/BucketListItem.tsx
@@ -38,6 +38,7 @@ import {
 } from "../../../../common/SecureComponent/permissions";
 import { hasPermission } from "../../../../common/SecureComponent";
 import { Bucket } from "../../../../api/consoleApi";
+import { usageClarifyingContent } from "screens/Console/Dashboard/BasicDashboard/ReportedUsage";
 
 const BucketItemMain = styled.div(({ theme }) => ({
   border: `${get(theme, "borderColor", "#eaeaea")} 1px solid`,
@@ -221,33 +222,7 @@ const BucketListItem = ({
           {bucket.details?.versioning && (
             <HelpTip
               content={
-                <Fragment>
-                  <div>
-                    <strong> Not what you expected?</strong>
-                    <br />
-                    This Usage value is comparable to{" "}
-                    <strong>mc du --versions</strong> which represents the size
-                    of all object versions that exist in the bucket.
-                    <br />
-                    Running{" "}
-                    <a
-                      target="_blank"
-                      href="https://min.io/docs/minio/linux/reference/minio-mc/mc-du.html"
-                    >
-                      mc du
-                    </a>{" "}
-                    without the <strong>--versions</strong> flag or{" "}
-                    <a
-                      target="_blank"
-                      href="https://man7.org/linux/man-pages/man1/df.1.html"
-                    >
-                      df
-                    </a>{" "}
-                    will provide different values corresponding to the size of
-                    all <strong>current</strong> versions and the physical disk
-                    space occupied respectively.
-                  </div>
-                </Fragment>
+                usageClarifyingContent
               }
               placement="top"
             >

--- a/web-app/src/screens/Console/Dashboard/BasicDashboard/ReportedUsage.tsx
+++ b/web-app/src/screens/Console/Dashboard/BasicDashboard/ReportedUsage.tsx
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React from "react";
+import React, { Fragment } from "react";
 import get from "lodash/get";
 import styled from "styled-components";
-import { Box, Tooltip } from "mds";
+import { Box, HelpTip, Tooltip } from "mds";
 import { Cell, Pie, PieChart } from "recharts";
 
 const ReportedUsageMain = styled.div(({ theme }) => ({
@@ -79,7 +79,38 @@ const ReportedUsage = ({
           <span>Reported Usage</span>
         </div>
 
-        <Tooltip tooltip={`${usageValue} Bytes`}>
+        <HelpTip
+          content={
+            <Fragment>
+              <div>
+                <strong> Not what you expected?</strong>
+                <br />
+                This Usage value is comparable to{" "}
+                <strong>mc du --versions</strong> which represents the size of
+                all object versions that exist in the buckets.
+                <br />
+                Running{" "}
+                <a
+                  target="_blank"
+                  href="https://min.io/docs/minio/linux/reference/minio-mc/mc-du.html"
+                >
+                  mc du
+                </a>{" "}
+                without the <strong>--versions</strong> flag or{" "}
+                <a
+                  target="_blank"
+                  href="https://man7.org/linux/man-pages/man1/df.1.html"
+                >
+                  df
+                </a>{" "}
+                will provide different values corresponding to the size of all{" "}
+                <strong>current</strong> versions and the physical disk space
+                occupied respectively.
+              </div>
+            </Fragment>
+          }
+          placement="left"
+        >
           <label
             className={"unit-value"}
             style={{
@@ -88,8 +119,8 @@ const ReportedUsage = ({
           >
             {total}
           </label>
-        </Tooltip>
-        <label className={"unit-type"}>{unit}</label>
+          <label className={"unit-type"}>{unit}</label>
+        </HelpTip>
       </Box>
 
       <Box>

--- a/web-app/src/screens/Console/Dashboard/BasicDashboard/ReportedUsage.tsx
+++ b/web-app/src/screens/Console/Dashboard/BasicDashboard/ReportedUsage.tsx
@@ -53,6 +53,34 @@ const ReportedUsageMain = styled.div(({ theme }) => ({
     },
   },
 }));
+export const usageClarifyingContent = 
+  <Fragment>
+  <div>
+    <strong> Not what you expected?</strong>
+    <br />
+    This Usage value is comparable to{" "}
+    <strong>mc du --versions</strong> which represents the size of
+    all object versions that exist in the buckets.
+    <br />
+    Running{" "}
+    <a
+      target="_blank"
+      href="https://min.io/docs/minio/linux/reference/minio-mc/mc-du.html"
+    >
+      mc du
+    </a>{" "}
+    without the <strong>--versions</strong> flag or{" "}
+    <a
+      target="_blank"
+      href="https://man7.org/linux/man-pages/man1/df.1.html"
+    >
+      df
+    </a>{" "}
+    will provide different values corresponding to the size of all{" "}
+    <strong>current</strong> versions and the physical disk space
+    occupied respectively.
+  </div>
+</Fragment>
 
 const ReportedUsage = ({
   usageValue,
@@ -63,6 +91,7 @@ const ReportedUsage = ({
   total: number | string;
   unit: string;
 }) => {
+  
   const plotValues = [
     { value: total, color: "#D6D6D6", label: "Free Space" },
     {
@@ -81,33 +110,7 @@ const ReportedUsage = ({
 
         <HelpTip
           content={
-            <Fragment>
-              <div>
-                <strong> Not what you expected?</strong>
-                <br />
-                This Usage value is comparable to{" "}
-                <strong>mc du --versions</strong> which represents the size of
-                all object versions that exist in the buckets.
-                <br />
-                Running{" "}
-                <a
-                  target="_blank"
-                  href="https://min.io/docs/minio/linux/reference/minio-mc/mc-du.html"
-                >
-                  mc du
-                </a>{" "}
-                without the <strong>--versions</strong> flag or{" "}
-                <a
-                  target="_blank"
-                  href="https://man7.org/linux/man-pages/man1/df.1.html"
-                >
-                  df
-                </a>{" "}
-                will provide different values corresponding to the size of all{" "}
-                <strong>current</strong> versions and the physical disk space
-                occupied respectively.
-              </div>
-            </Fragment>
+            usageClarifyingContent
           }
           placement="left"
         >

--- a/web-app/src/screens/Console/Dashboard/BasicDashboard/ReportedUsage.tsx
+++ b/web-app/src/screens/Console/Dashboard/BasicDashboard/ReportedUsage.tsx
@@ -53,34 +53,31 @@ const ReportedUsageMain = styled.div(({ theme }) => ({
     },
   },
 }));
-export const usageClarifyingContent = 
+export const usageClarifyingContent = (
   <Fragment>
-  <div>
-    <strong> Not what you expected?</strong>
-    <br />
-    This Usage value is comparable to{" "}
-    <strong>mc du --versions</strong> which represents the size of
-    all object versions that exist in the buckets.
-    <br />
-    Running{" "}
-    <a
-      target="_blank"
-      href="https://min.io/docs/minio/linux/reference/minio-mc/mc-du.html"
-    >
-      mc du
-    </a>{" "}
-    without the <strong>--versions</strong> flag or{" "}
-    <a
-      target="_blank"
-      href="https://man7.org/linux/man-pages/man1/df.1.html"
-    >
-      df
-    </a>{" "}
-    will provide different values corresponding to the size of all{" "}
-    <strong>current</strong> versions and the physical disk space
-    occupied respectively.
-  </div>
-</Fragment>
+    <div>
+      <strong> Not what you expected?</strong>
+      <br />
+      This Usage value is comparable to <strong>mc du --versions</strong> which
+      represents the size of all object versions that exist in the buckets.
+      <br />
+      Running{" "}
+      <a
+        target="_blank"
+        href="https://min.io/docs/minio/linux/reference/minio-mc/mc-du.html"
+      >
+        mc du
+      </a>{" "}
+      without the <strong>--versions</strong> flag or{" "}
+      <a target="_blank" href="https://man7.org/linux/man-pages/man1/df.1.html">
+        df
+      </a>{" "}
+      will provide different values corresponding to the size of all{" "}
+      <strong>current</strong> versions and the physical disk space occupied
+      respectively.
+    </div>
+  </Fragment>
+);
 
 const ReportedUsage = ({
   usageValue,
@@ -91,7 +88,6 @@ const ReportedUsage = ({
   total: number | string;
   unit: string;
 }) => {
-  
   const plotValues = [
     { value: total, color: "#D6D6D6", label: "Free Space" },
     {
@@ -108,12 +104,7 @@ const ReportedUsage = ({
           <span>Reported Usage</span>
         </div>
 
-        <HelpTip
-          content={
-            usageClarifyingContent
-          }
-          placement="left"
-        >
+        <HelpTip content={usageClarifyingContent} placement="left">
           <label
             className={"unit-value"}
             style={{

--- a/web-app/src/screens/Console/Dashboard/BasicDashboard/ReportedUsage.tsx
+++ b/web-app/src/screens/Console/Dashboard/BasicDashboard/ReportedUsage.tsx
@@ -17,7 +17,7 @@
 import React, { Fragment } from "react";
 import get from "lodash/get";
 import styled from "styled-components";
-import { Box, HelpTip, Tooltip } from "mds";
+import { Box, HelpTip } from "mds";
 import { Cell, Pie, PieChart } from "recharts";
 
 const ReportedUsageMain = styled.div(({ theme }) => ({

--- a/web-app/src/screens/Console/ObjectBrowser/OBBucketList.tsx
+++ b/web-app/src/screens/Console/ObjectBrowser/OBBucketList.tsx
@@ -27,6 +27,7 @@ import {
   ProgressBar,
   RefreshIcon,
   Grid,
+  HelpTip,
 } from "mds";
 import { actionsTray } from "../Common/FormComponents/common/styleLibrary";
 import { SecureComponent } from "../../../common/SecureComponent";
@@ -57,6 +58,7 @@ const OBListBuckets = () => {
 
   const [records, setRecords] = useState<Bucket[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const [clickOverride, setClickOverride] = useState<boolean>(false);
   const [filterBuckets, setFilterBuckets] = useState<string>("");
 
   const features = useSelector(selFeatures);
@@ -102,7 +104,8 @@ const OBListBuckets = () => {
     {
       type: "view",
       onClick: (bucket: Bucket) => {
-        navigate(`${IAM_PAGES.OBJECT_BROWSER_VIEW}/${bucket.name}`);
+        !clickOverride &&
+          navigate(`${IAM_PAGES.OBJECT_BROWSER_VIEW}/${bucket.name}`);
       },
     },
   ];
@@ -213,7 +216,49 @@ const OBListBuckets = () => {
                   {
                     label: "Size",
                     elementKey: "size",
-                    renderFunction: (size: number) => niceBytesInt(size || 0),
+                    renderFunction: (size: number) => (
+                      <div
+                        onMouseEnter={() => setClickOverride(true)}
+                        onMouseLeave={() => setClickOverride(false)}
+                      >
+                        <HelpTip
+                          content={
+                            <Fragment>
+                              <div>
+                                <strong> Not what you expected?</strong>
+                                <br />
+                                This Usage value is comparable to{" "}
+                                <strong>mc du --versions</strong> which
+                                represents the size of all object versions that
+                                exist in the bucket.
+                                <br />
+                                Running{" "}
+                                <a
+                                  target="_blank"
+                                  href="https://min.io/docs/minio/linux/reference/minio-mc/mc-du.html"
+                                >
+                                  mc du
+                                </a>{" "}
+                                without the <strong>--versions</strong> flag or{" "}
+                                <a
+                                  target="_blank"
+                                  href="https://man7.org/linux/man-pages/man1/df.1.html"
+                                >
+                                  df
+                                </a>{" "}
+                                will provide different values corresponding to
+                                the size of all <strong>current</strong>{" "}
+                                versions and the physical disk space occupied
+                                respectively.
+                              </div>
+                            </Fragment>
+                          }
+                          placement="right"
+                        >
+                          {niceBytesInt(size || 0)}
+                        </HelpTip>
+                      </div>
+                    ),
                   },
                   {
                     label: "Access",

--- a/web-app/src/screens/Console/ObjectBrowser/OBBucketList.tsx
+++ b/web-app/src/screens/Console/ObjectBrowser/OBBucketList.tsx
@@ -223,9 +223,7 @@ const OBListBuckets = () => {
                         onMouseLeave={() => setClickOverride(false)}
                       >
                         <HelpTip
-                          content={
-                           usageClarifyingContent
-                          }
+                          content={usageClarifyingContent}
                           placement="right"
                         >
                           {niceBytesInt(size || 0)}

--- a/web-app/src/screens/Console/ObjectBrowser/OBBucketList.tsx
+++ b/web-app/src/screens/Console/ObjectBrowser/OBBucketList.tsx
@@ -51,6 +51,7 @@ import { Bucket } from "../../../api/consoleApi";
 import { api } from "../../../api";
 import { errorToHandler } from "../../../api/errors";
 import HelpMenu from "../HelpMenu";
+import { usageClarifyingContent } from "../Dashboard/BasicDashboard/ReportedUsage";
 
 const OBListBuckets = () => {
   const dispatch = useAppDispatch();
@@ -223,35 +224,7 @@ const OBListBuckets = () => {
                       >
                         <HelpTip
                           content={
-                            <Fragment>
-                              <div>
-                                <strong> Not what you expected?</strong>
-                                <br />
-                                This Usage value is comparable to{" "}
-                                <strong>mc du --versions</strong> which
-                                represents the size of all object versions that
-                                exist in the bucket.
-                                <br />
-                                Running{" "}
-                                <a
-                                  target="_blank"
-                                  href="https://min.io/docs/minio/linux/reference/minio-mc/mc-du.html"
-                                >
-                                  mc du
-                                </a>{" "}
-                                without the <strong>--versions</strong> flag or{" "}
-                                <a
-                                  target="_blank"
-                                  href="https://man7.org/linux/man-pages/man1/df.1.html"
-                                >
-                                  df
-                                </a>{" "}
-                                will provide different values corresponding to
-                                the size of all <strong>current</strong>{" "}
-                                versions and the physical disk space occupied
-                                respectively.
-                              </div>
-                            </Fragment>
+                           usageClarifyingContent
                           }
                           placement="right"
                         >


### PR DESCRIPTION
Displays HelpTip containing explanatory text and document links clarifying the differences between the value shown in Console and other possible measures of usage on Usage values shown on BucketList, OBBucketList and Metrics screens. 

https://github.com/minio/console/assets/65002498/5d5edc39-caad-4233-a9fe-31bf9d86016f


https://github.com/minio/console/assets/65002498/ce6b1915-81cd-47a7-b704-bbd59d480381


https://github.com/minio/console/assets/65002498/4f98c5e8-d4fd-4167-a89c-9a0b27dfbe99

https://github.com/minio/console/issues/2917
