### PR TITLE
fix to prevent extra metadata call when listing at a bucket level

### DIFF
--- a/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/portal-ui/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -311,9 +311,9 @@ const ListObjects = () => {
 
   const fetchMetadata = useCallback(() => {
     const objectName = selectedObjects[0];
+    const encodedPath = encodeURLString(objectName);
 
-    if (!isMetaDataLoaded) {
-      const encodedPath = encodeURLString(objectName);
+    if (!isMetaDataLoaded && encodedPath) {
       api.buckets
         .getObjectMetadata(bucketName, {
           prefix: encodedPath,


### PR DESCRIPTION
fix to prevent extra metadata call when listing at a bucket level

The prefix is mandatory at the api level because it is only for an object (selected in UI). 

So prevent the unnecessary call when no object is selected in UI. 