### PR TITLE
Change Loading Logic for Metrics Page

### DIFF
--- a/portal-ui/src/screens/Console/Dashboard/Dashboard.tsx
+++ b/portal-ui/src/screens/Console/Dashboard/Dashboard.tsx
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Fragment, useEffect, useState } from "react";
-import { Grid, ProgressBar } from "mds";
 import { useSelector } from "react-redux";
 import { AppState, useAppDispatch } from "../../../store";
 import { getUsageAsync } from "./dashboardThunks";
@@ -27,7 +26,7 @@ import HelpMenu from "../HelpMenu";
 
 const Dashboard = () => {
   const dispatch = useAppDispatch();
-  const [loading, setLoading] = useState<boolean>(true);
+  const [iniLoad, setIniLoad] = useState<boolean>(false);
 
   const usage = useSelector((state: AppState) => state.dashboard.usage);
   const features = useSelector(selFeatures);
@@ -40,31 +39,22 @@ const Dashboard = () => {
   }
 
   useEffect(() => {
-    if (loading) {
-      setLoading(false);
+    if (!iniLoad) {
+      setIniLoad(true);
       dispatch(getUsageAsync());
     }
-  }, [loading, dispatch]);
+  }, [iniLoad, dispatch]);
 
   useEffect(() => {
     dispatch(setHelpName("metrics"));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [dispatch]);
 
   return (
     <Fragment>
       {!hideMenu && (
         <PageHeaderWrapper label="Metrics" actions={<HelpMenu />} />
       )}
-      {loading ? (
-        <Grid container>
-          <Grid item xs={12}>
-            <ProgressBar />
-          </Grid>
-        </Grid>
-      ) : (
-        <PrDashboard usage={usage} />
-      )}
+      <PrDashboard usage={usage} />
     </Fragment>
   );
 };

--- a/portal-ui/src/screens/Console/Dashboard/dashboardSlice.ts
+++ b/portal-ui/src/screens/Console/Dashboard/dashboardSlice.ts
@@ -23,17 +23,17 @@ import { AdminInfoResponse } from "api/consoleApi";
 export interface DashboardState {
   zoom: zoomState;
   usage: AdminInfoResponse | null;
-  loadingUsage: boolean;
+  status: "idle" | "loading" | "failed";
   widgetLoadVersion: number;
 }
 
 const initialState: DashboardState = {
+  status: "idle",
   zoom: {
     openZoom: false,
     widgetRender: null,
   },
   usage: null,
-  loadingUsage: true,
   widgetLoadVersion: 0,
 };
 export const dashboardSlice = createSlice({
@@ -55,13 +55,13 @@ export const dashboardSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(getUsageAsync.pending, (state) => {
-        state.loadingUsage = true;
+        state.status = "loading";
       })
       .addCase(getUsageAsync.rejected, (state) => {
-        state.loadingUsage = false;
+        state.status = "failed";
       })
       .addCase(getUsageAsync.fulfilled, (state, action) => {
-        state.loadingUsage = false;
+        state.status = "idle";
         state.usage = action.payload;
       });
   },

--- a/portal-ui/src/store.ts
+++ b/portal-ui/src/store.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { useDispatch } from "react-redux";
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 
 import systemReducer from "./systemSlice";
@@ -69,6 +69,8 @@ if (process.env.NODE_ENV !== "production" && module.hot) {
 export type AppState = ReturnType<typeof rootReducer>;
 
 export type AppDispatch = typeof store.dispatch;
+export type RootState = ReturnType<typeof store.getState>;
 export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 export default store;


### PR DESCRIPTION
We have an ongoing problem where we display an error for the dashboard page every time we load it directly via browser url or hit refresh on that page. 

This fixes it by introducing a third loading state so that the internal functions know when to properly perform their own checks.

Also sets the order of the tabs to always start with Info