### PR TITLE
Adjusting the threshold of the coverage

### DIFF
--- a/.github/workflows/jobs.yaml
+++ b/.github/workflows/jobs.yaml
@@ -1169,7 +1169,7 @@ jobs:
           go tool cover -func=all.out | grep total > tmp2
           result=`cat tmp2 | awk 'END {print $3}'`
           result=${result%\%}
-          threshold=71.3
+          threshold=65.0
           echo "Result:"
           echo "$result%"
           if (( $(echo "$result >= $threshold" |bc -l) )); then


### PR DESCRIPTION
### Objective:

To adjust the coverage threshold

### Reason:

After the introduction of pkg tests back to the CI/CD pipeline (https://github.com/minio/console/pull/3171), we observed a decreased value, hence we need to re-adjust accordingly:

```
Result:
65.9%
It is smaller than threshold (71.3%) value, failed!
```