### PR TITLE
Kms status endpoints null validation

### DIFF
--- a/web-app/src/screens/Console/KMS/Status.tsx
+++ b/web-app/src/screens/Console/KMS/Status.tsx
@@ -222,7 +222,7 @@ const Status = () => {
                   label={"Key Management Service Endpoints:"}
                   value={
                     <Fragment>
-                      {status.endpoints.map((e: any, i: number) => (
+                      {status.endpoints?.map((e: any, i: number) => (
                         <LabelWithIcon
                           key={i}
                           icon={


### PR DESCRIPTION
If for some reason the kms/status api returns null in endpoints, it was breaking the Encryption Screen so this adds a type check.

Before:
Blank Screen
<img width="934" alt="Screenshot 2024-01-12 at 2 23 41 PM" src="https://github.com/minio/console/assets/11819101/3309cb97-6d99-4242-a82b-0ae63f2e530f">
<img width="637" alt="Screenshot 2024-01-12 at 3 48 58 PM" src="https://github.com/minio/console/assets/11819101/0cd27e10-2534-49b1-853b-2b9d2937afab">

After:
<img width="896" alt="Screenshot 2024-01-12 at 4 02 24 PM" src="https://github.com/minio/console/assets/11819101/6fd44bfa-e851-4310-ac7f-8b58ca107f12">
