### PR TITLE
Use swagger api for IDP configuration details

### DIFF
--- a/api/embedded_spec.go
+++ b/api/embedded_spec.go
@@ -3005,6 +3005,9 @@ func init() {
         }
       },
       "put": {
+        "consumes": [
+          "application/json"
+        ],
         "tags": [
           "idp"
         ],
@@ -12171,6 +12174,9 @@ func init() {
         }
       },
       "put": {
+        "consumes": [
+          "application/json"
+        ],
         "tags": [
           "idp"
         ],

--- a/swagger.yml
+++ b/swagger.yml
@@ -3399,6 +3399,8 @@ paths:
     put:
       summary: Update IDP Configuration
       operationId: UpdateConfiguration
+      consumes:
+        - application/json
       parameters:
         - name: body
           in: body

--- a/web-app/src/api/consoleApi.ts
+++ b/web-app/src/api/consoleApi.ts
@@ -5170,6 +5170,7 @@ export class Api<
         method: "PUT",
         body: body,
         secure: true,
+        type: ContentType.Json,
         format: "json",
         ...params,
       }),


### PR DESCRIPTION
Updates IDPConfigurationDetails.tsx to use swagger api.
Component uses multiple requests there so three were done:
- Fetching info
- Updatating info
- Enabling info

Other changes:
- for some reason the consoleApi.ts file was not including the `JSON` type so I had to add the `consumes` parameter in the swagger yaml.

### Test Steps

Configure your MinIO with an IDP as defined in [here](https://github.com/minio/minio-iam-testing/tree/main):
1. Clone repo https://github.com/minio/minio-iam-testing
2. Run:
```
# To use with Docker:
make docker-run
```
3. Configure the IDP using mc:
```
mc idp openid add myminio \                         
    config_url="http://localhost:5556/dex/.well-known/openid-configuration" \
    client_id="minio-client-app" \
    client_secret="minio-client-app-secret" \
    scopes="openid,groups,email,profile" \
    redirect_uri="http://127.0.0.1:10000/oauth_callback" \
    role_policy="consoleAdmin"
```
4. Go to UI -> Administrator/Identity/OpenID (open id info should be listed as defined above)
5.  Update the role_policy in the UI to `readonly` (click save and it should require you to restart, policy should be updated in the info UI)
6. Try causing errors e.g. defining both role_policy and claim_name (error should be shown as snack bar.)

Screenshots:
<img width="698" alt="Screenshot 2024-01-18 at 2 23 48 PM" src="https://github.com/minio/console/assets/11819101/6d391ad7-b102-48df-bd74-8713bfe2129b">
<img width="699" alt="Screenshot 2024-01-18 at 2 23 57 PM" src="https://github.com/minio/console/assets/11819101/27d33a6d-e247-449a-8f71-de8f8c02e672">


