### PR TITLE
Fix BucketNamingRules button click

### DIFF
--- a/web-app/src/screens/Console/Buckets/ListBuckets/AddBucket/BucketNamingRules.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/AddBucket/BucketNamingRules.tsx
@@ -61,6 +61,7 @@ const BucketNamingRules = ({ errorList }: { errorList: boolean[] }) => {
     <Fragment>
       <ExpandOptionsButton
         id={"toggle-naming-rules"}
+        type="button"
         open={showNamingRules}
         label={`${showNamingRules ? "Hide" : "View"} Bucket Naming Rules`}
         onClick={() => {


### PR DESCRIPTION
On create bucket panel, if I click "View Bucket Naming Rules", the form is submitted.
This PR should fix that.