### PR TITLE
Return proper progress on download error

### DIFF
--- a/web-app/src/screens/Console/Common/ProgressBarWrapper/ProgressBarWrapper.tsx
+++ b/web-app/src/screens/Console/Common/ProgressBarWrapper/ProgressBarWrapper.tsx
@@ -73,7 +73,7 @@ const ProgressBarWrapper = ({
   const propsComponent: ProgressBarProps = {
     variant:
       indeterminate && !ready && !cancelled ? "indeterminate" : "determinate",
-    value: ready ? 100 : value,
+    value: ready && !error ? 100 : value,
     color: color,
     notificationLabel: notificationLabel || "",
   };


### PR DESCRIPTION
If an error occurred during download, we were showing 100% download progress which is not correct.

Before:
<img width="348" alt="Screenshot 2024-01-22 at 1 24 17 PM" src="https://github.com/minio/console/assets/11819101/4f170339-31ce-43d6-b35e-e9d7abd0f19a">
After:
<img width="338" alt="Screenshot 2024-01-22 at 1 28 57 PM" src="https://github.com/minio/console/assets/11819101/95d2b7a5-c5ae-4961-9cb1-a8c01c769f3a">
