### PR TITLE
Fail request when error occurs during download

### DIFF
--- a/api/admin_inspect.go
+++ b/api/admin_inspect.go
@@ -120,7 +120,7 @@ func processInspectResponse(params *inspectApi.InspectParams, k []byte, r io.Rea
 
 		_, err := io.Copy(w, r)
 		if err != nil {
-			LogError("Unable to write all the data: %v", err)
+			LogError("unable to write all the data: %v", err)
 		}
 	}
 }

--- a/api/user_objects.go
+++ b/api/user_objects.go
@@ -448,7 +448,8 @@ func getDownloadObjectResponse(session *models.Principal, params objectApi.Downl
 		// override filename is set
 		decodeOverride, err := base64.StdEncoding.DecodeString(*params.OverrideFileName)
 		if err != nil {
-			return
+			ErrorWithContext(ctx, fmt.Errorf("unable to decode OverrideFileName: %v", err))
+			panic(err)
 		}
 
 		overrideName := string(decodeOverride)
@@ -472,17 +473,15 @@ func getDownloadObjectResponse(session *models.Principal, params objectApi.Downl
 		stat, err := resp.Stat()
 		if err != nil {
 			minErr := minio.ToErrorResponse(err)
-			rw.WriteHeader(minErr.StatusCode)
-			ErrorWithContext(ctx, fmt.Errorf("Failed to get Stat() response from server for %s (version %s): %v", prefix, opts.VersionID, minErr.Error()))
-			return
+			ErrorWithContext(ctx, fmt.Errorf("failed to get Stat() response from server for %s (version %s): %v", prefix, opts.VersionID, minErr.Error()))
+			panic(err)
 		}
 
 		// if we are getting a Range Request (video) handle that specially
 		ranges, err := parseRange(params.HTTPRequest.Header.Get("Range"), stat.Size)
 		if err != nil {
-			ErrorWithContext(ctx, fmt.Errorf("Unable to parse range header input %s: %v", params.HTTPRequest.Header.Get("Range"), err))
-			rw.WriteHeader(400)
-			return
+			ErrorWithContext(ctx, fmt.Errorf("unable to parse range header input %s: %v", params.HTTPRequest.Header.Get("Range"), err))
+			panic(err)
 		}
 		contentType := stat.ContentType
 		rw.Header().Set("X-XSS-Protection", "1; mode=block")
@@ -510,9 +509,8 @@ func getDownloadObjectResponse(session *models.Principal, params objectApi.Downl
 
 			_, err = resp.Seek(start, io.SeekStart)
 			if err != nil {
-				ErrorWithContext(ctx, fmt.Errorf("Unable to seek at offset %d: %v", start, err))
-				rw.WriteHeader(400)
-				return
+				ErrorWithContext(ctx, fmt.Errorf("unable to seek at offset %d: %v", start, err))
+				panic(err)
 			}
 
 			rw.Header().Set("Accept-Ranges", "bytes")
@@ -524,8 +522,8 @@ func getDownloadObjectResponse(session *models.Principal, params objectApi.Downl
 		rw.Header().Set("Content-Length", fmt.Sprintf("%d", length))
 		_, err = io.Copy(rw, io.LimitReader(resp, length))
 		if err != nil {
-			ErrorWithContext(ctx, fmt.Errorf("Unable to write all data to client: %v", err))
-			return
+			ErrorWithContext(ctx, fmt.Errorf("unable to write all data to client: %v", err))
+			panic(err)
 		}
 	}), nil
 }
@@ -610,8 +608,8 @@ func getDownloadFolderResponse(session *models.Principal, params objectApi.Downl
 			encodedPrefix := SanitizeEncodedPrefix(params.Prefix)
 			decodedPrefix, err := base64.StdEncoding.DecodeString(encodedPrefix)
 			if err != nil {
-				ErrorWithContext(ctx, fmt.Errorf("Unable to parse encoded prefix %s: %v", encodedPrefix, err))
-				return
+				ErrorWithContext(ctx, fmt.Errorf("unable to parse encoded prefix %s: %v", encodedPrefix, err))
+				panic(err)
 			}
 
 			prefixPath = string(decodedPrefix)
@@ -632,7 +630,8 @@ func getDownloadFolderResponse(session *models.Principal, params objectApi.Downl
 		// Copy the stream
 		_, err := io.Copy(rw, resp)
 		if err != nil {
-			ErrorWithContext(ctx, fmt.Errorf("Unable to write all the requested data: %v", err))
+			ErrorWithContext(ctx, fmt.Errorf("unable to write all the requested data: %v", err))
+			panic(err)
 		}
 	}), nil
 }
@@ -754,7 +753,8 @@ func getMultipleFilesDownloadResponse(session *models.Principal, params objectAp
 		// Copy the stream
 		_, err := io.Copy(rw, resp)
 		if err != nil {
-			ErrorWithContext(ctx, fmt.Errorf("Unable to write all the requested data: %v", err))
+			ErrorWithContext(ctx, fmt.Errorf("unable to write all the requested data: %v", err))
+			panic(err)
 		}
 	}), nil
 }


### PR DESCRIPTION
fixes: https://github.com/minio/console/issues/3006


Checks whether the download was complete in the frontend.
In the backend, setting the headers doesn't work if it fails during io.Copy cause it already starterd writing to the body. So we just log it and handle it in the client layer.

On error:
After:
![Screenshot 2024-01-24 at 5 06 38 PM](https://github.com/minio/console/assets/11819101/60b33a97-1805-41ed-9879-0da08fe01739)

### Test Steps:
- Deploy a distributed minio e.g. using kind 4 nodes
- expose the service 
- Upload a big object e.g. 100Mb
- Go to the Browser UI
- Cordon one of the nodes
- Download the object (enabling throttling in your browser to emulate slow speed)
- Delete one of the minio pods (it won't start since we cordoned a node)
- In the UI the object download should eventually fail (before it was downloading an inclomplete object)

/// Other tests
- Test downloading multiple files (selecting multiple)
- Test downloading multiple files (selecting one, then download, then only other one and click download) so that the download box appears.
