### PR TITLE
logout state clean up

### DIFF
--- a/web-app/src/screens/LogoutPage/LogoutPage.tsx
+++ b/web-app/src/screens/LogoutPage/LogoutPage.tsx
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate} from "react-router-dom";
 import { useAppDispatch } from "../../store";
 import { ErrorResponseHandler } from "../../common/types";
 import { clearSession } from "../../common/utils";
@@ -28,25 +28,24 @@ const LogoutPage = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   useEffect(() => {
+    const deleteSession = () => {
+      dispatch(userLogged(false));
+      // Disconnect OB Websocket
+      dispatch({ type: "socket/OBDisconnect" });
+      localStorage.setItem("userLoggedIn", "");
+      localStorage.setItem("redirect-path", "");
+      dispatch(resetSession());
+      clearSession();
+
+      navigate("/login");
+      window.location.reload() //reset-all redux states etc. by force reloading.
+    };
+
     const logout = () => {
-      const deleteSession = () => {
-        clearSession();
-        dispatch(userLogged(false));
-
-        // Disconnect OB Websocket
-        dispatch({ type: "socket/OBDisconnect" });
-
-        localStorage.setItem("userLoggedIn", "");
-        localStorage.setItem("redirect-path", "");
-        dispatch(resetSession());
-        navigate(`/login`);
-      };
       const state = localStorage.getItem("auth-state");
       api
         .invoke("POST", `/api/v1/logout`, { state })
-        .then(() => {
-          deleteSession();
-        })
+        .then(deleteSession)
         .catch((err: ErrorResponseHandler) => {
           console.error(err);
           deleteSession();

--- a/web-app/src/screens/LogoutPage/LogoutPage.tsx
+++ b/web-app/src/screens/LogoutPage/LogoutPage.tsx
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { useEffect } from "react";
-import { useNavigate} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useAppDispatch } from "../../store";
 import { ErrorResponseHandler } from "../../common/types";
 import { clearSession } from "../../common/utils";
@@ -38,7 +38,7 @@ const LogoutPage = () => {
       clearSession();
 
       navigate("/login");
-      window.location.reload() //reset-all redux states etc. by force reloading.
+      window.location.reload(); //reset-all redux states etc. by force reloading.
     };
 
     const logout = () => {


### PR DESCRIPTION
Fixes https://github.com/minio/console/issues/3210

Issue Replication steps
create a  the policy as in https://github.com/minio/console/issues/3210

As an admin,

- create a bucket `clients` and some `prefixes`  like `test-user` and  `test-user-1` and upload files to each prefixes. 

- create 2 users  `test-user`  and `test-user1`  and assign the policy. 

- in a different browser, login as `test-user` and navigate to the prefix and logout.  
now in the same browser login as `test-user-1` and navigate . observe "Access Denied"  this is due to previous state  (bucket, prefix is retained) is not reset and request is made to the old state prefix. ( hard reload i.e Refresh of browser window would work as expected)

Verify the fix.
build and run the PR.
With this fix, the above steps would not result in "Access denied" error.

