### PR TITLE
Enable console to set expired-object-all-versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ lint:
 	@GO111MODULE=on ${GOPATH}/bin/golangci-lint cache clean
 	@GO111MODULE=on ${GOPATH}/bin/golangci-lint run --timeout=5m --config ./.golangci.yml
 
+lint-fix: getdeps ## runs golangci-lint suite of linters with automatic fixes
+	@echo "Running $@ check"
+	@GO111MODULE=on ${GOPATH}/bin/golangci-lint run --timeout=5m --config ./.golangci.yml --fix
+
 install: console
 	@echo "Installing console binary to '$(GOPATH)/bin/console'"
 	@mkdir -p $(GOPATH)/bin && cp -f $(PWD)/console $(GOPATH)/bin/console

--- a/api/embedded_spec.go
+++ b/api/embedded_spec.go
@@ -5373,6 +5373,10 @@ func init() {
           "description": "Non required, toggle to disable or enable rule",
           "type": "boolean"
         },
+        "expired_object_delete_all": {
+          "description": "Non required, toggle to disable or enable rule",
+          "type": "boolean"
+        },
         "expired_object_delete_marker": {
           "description": "Non required, toggle to disable or enable rule",
           "type": "boolean"
@@ -5474,6 +5478,10 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "expired_object_delete_all": {
+          "description": "Non required, toggle to disable or enable rule",
+          "type": "boolean"
         },
         "expired_object_delete_marker": {
           "description": "Non required, toggle to disable or enable rule",
@@ -6179,6 +6187,9 @@ func init() {
         "days": {
           "type": "integer",
           "format": "int64"
+        },
+        "delete_all": {
+          "type": "boolean"
         },
         "delete_marker": {
           "type": "boolean"
@@ -8835,6 +8846,10 @@ func init() {
       ],
       "properties": {
         "disable": {
+          "description": "Non required, toggle to disable or enable rule",
+          "type": "boolean"
+        },
+        "expired_object_delete_all": {
           "description": "Non required, toggle to disable or enable rule",
           "type": "boolean"
         },
@@ -14729,6 +14744,10 @@ func init() {
           "description": "Non required, toggle to disable or enable rule",
           "type": "boolean"
         },
+        "expired_object_delete_all": {
+          "description": "Non required, toggle to disable or enable rule",
+          "type": "boolean"
+        },
         "expired_object_delete_marker": {
           "description": "Non required, toggle to disable or enable rule",
           "type": "boolean"
@@ -14830,6 +14849,10 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "expired_object_delete_all": {
+          "description": "Non required, toggle to disable or enable rule",
+          "type": "boolean"
         },
         "expired_object_delete_marker": {
           "description": "Non required, toggle to disable or enable rule",
@@ -15530,6 +15553,9 @@ func init() {
         "days": {
           "type": "integer",
           "format": "int64"
+        },
+        "delete_all": {
+          "type": "boolean"
         },
         "delete_marker": {
           "type": "boolean"
@@ -18169,6 +18195,10 @@ func init() {
       ],
       "properties": {
         "disable": {
+          "description": "Non required, toggle to disable or enable rule",
+          "type": "boolean"
+        },
+        "expired_object_delete_all": {
           "description": "Non required, toggle to disable or enable rule",
           "type": "boolean"
         },

--- a/api/user_buckets_lifecycle.go
+++ b/api/user_buckets_lifecycle.go
@@ -117,6 +117,7 @@ func getBucketLifecycle(ctx context.Context, client MinioClient, bucketName stri
 				Date:                              rule.Expiration.Date.Format(time.RFC3339),
 				Days:                              int64(rule.Expiration.Days),
 				DeleteMarker:                      rule.Expiration.DeleteMarker.IsEnabled(),
+				DeleteAll:                         bool(rule.Expiration.DeleteAll),
 				NoncurrentExpirationDays:          int64(rule.NoncurrentVersionExpiration.NoncurrentDays),
 				NewerNoncurrentExpirationVersions: int64(rule.NoncurrentVersionExpiration.NewerNoncurrentVersions),
 			},
@@ -188,6 +189,7 @@ func addBucketLifecycle(ctx context.Context, client MinioClient, params bucketAp
 			Status:                    &status,
 			Tags:                      &params.Body.Tags,
 			ExpiredObjectDeleteMarker: &params.Body.ExpiredObjectDeleteMarker,
+			ExpiredObjectAllversions:  &params.Body.ExpiredObjectDeleteAll,
 		}
 
 		if params.Body.NoncurrentversionTransitionDays > 0 {
@@ -219,6 +221,7 @@ func addBucketLifecycle(ctx context.Context, client MinioClient, params bucketAp
 			Status:                    &status,
 			Tags:                      &params.Body.Tags,
 			ExpiredObjectDeleteMarker: &params.Body.ExpiredObjectDeleteMarker,
+			ExpiredObjectAllversions:  &params.Body.ExpiredObjectDeleteAll,
 		}
 
 		if params.Body.NewerNoncurrentversionExpirationVersions > 0 {
@@ -298,6 +301,7 @@ func editBucketLifecycle(ctx context.Context, client MinioClient, params bucketA
 			Status:                    &status,
 			Tags:                      &params.Body.Tags,
 			ExpiredObjectDeleteMarker: &params.Body.ExpiredObjectDeleteMarker,
+			ExpiredObjectAllversions:  &params.Body.ExpiredObjectDeleteAll,
 		}
 
 		if params.Body.NoncurrentversionTransitionDays > 0 {
@@ -328,6 +332,7 @@ func editBucketLifecycle(ctx context.Context, client MinioClient, params bucketA
 			Status:                    &status,
 			Tags:                      &params.Body.Tags,
 			ExpiredObjectDeleteMarker: &params.Body.ExpiredObjectDeleteMarker,
+			ExpiredObjectAllversions:  &params.Body.ExpiredObjectDeleteAll,
 		}
 
 		if params.Body.NoncurrentversionExpirationDays > 0 {
@@ -456,6 +461,7 @@ func addMultiBucketLifecycle(ctx context.Context, client MinioClient, params buc
 			ExpiryDays:                              params.Body.ExpiryDays,
 			Disable:                                 false,
 			ExpiredObjectDeleteMarker:               params.Body.ExpiredObjectDeleteMarker,
+			ExpiredObjectDeleteAll:                  params.Body.ExpiredObjectDeleteMarker,
 		}
 
 		go func() {

--- a/go.mod
+++ b/go.mod
@@ -158,3 +158,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/minio/mc v0.0.0-20240209221824-669cb0a9a475 => github.com/shtripat/mc v0.0.0-20240212061450-03c9dfe77107

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes v0.23.0
 	github.com/minio/madmin-go/v3 v3.0.46
-	github.com/minio/mc v0.0.0-20240209221824-669cb0a9a475
+	github.com/minio/mc v0.0.0-20240224013320-f17313e7ab89
 	github.com/minio/minio-go/v7 v7.0.67
 	github.com/minio/selfupdate v0.6.0
 	github.com/minio/websocket v1.6.0
@@ -158,5 +158,3 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/minio/mc v0.0.0-20240209221824-669cb0a9a475 => github.com/shtripat/mc v0.0.0-20240212061450-03c9dfe77107

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,6 @@ github.com/minio/kes-go v0.2.1 h1:KnqS+p6xoSFJZbQhmJaz/PbxeA6nQyRqT/ywrn5lU2o=
 github.com/minio/kes-go v0.2.1/go.mod h1:76xf7l41Wrh+IifisABXK2S8uZWYgWV1IGBKC3GdOJk=
 github.com/minio/madmin-go/v3 v3.0.46 h1:DabFt+aUph5Vu/SOat2RWN/xVagPBU7qzxhAQ03hH/k=
 github.com/minio/madmin-go/v3 v3.0.46/go.mod h1:ZDF7kf5fhmxLhbGTqyq5efs4ao0v4eWf7nOuef/ljJs=
-github.com/minio/mc v0.0.0-20240209221824-669cb0a9a475 h1:yfLzMougcV2xkVlWgwYwVRoT8pnXrcCV4oOQW+pI2EQ=
-github.com/minio/mc v0.0.0-20240209221824-669cb0a9a475/go.mod h1:MmDLdb7NWd/OYhcKcXKvwErq2GNa/Zq6xtTWuhdC4II=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.67 h1:BeBvZWAS+kRJm1vGTMJYVjKUNoo0FoEt/wUWdUtfmh8=
@@ -282,6 +280,8 @@ github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFt
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shtripat/mc v0.0.0-20240212061450-03c9dfe77107 h1:pDFlsezd+kxeohWXZW/X6mmqXO8yDBFvB5RgWGlHi68=
+github.com/shtripat/mc v0.0.0-20240212061450-03c9dfe77107/go.mod h1:9opeL9Qw8zh5u6Vl2Dn87F0pRGxwBbWr2liWbf/7afU=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/minio/kes-go v0.2.1 h1:KnqS+p6xoSFJZbQhmJaz/PbxeA6nQyRqT/ywrn5lU2o=
 github.com/minio/kes-go v0.2.1/go.mod h1:76xf7l41Wrh+IifisABXK2S8uZWYgWV1IGBKC3GdOJk=
 github.com/minio/madmin-go/v3 v3.0.46 h1:DabFt+aUph5Vu/SOat2RWN/xVagPBU7qzxhAQ03hH/k=
 github.com/minio/madmin-go/v3 v3.0.46/go.mod h1:ZDF7kf5fhmxLhbGTqyq5efs4ao0v4eWf7nOuef/ljJs=
+github.com/minio/mc v0.0.0-20240224013320-f17313e7ab89 h1:XM7YTVWU46a1P+8h7+xMCQXJEIdU+MEFp9BZM7ImeVI=
+github.com/minio/mc v0.0.0-20240224013320-f17313e7ab89/go.mod h1:RBhdjMeCia7yxC9jQ2onV7kPvruzWBgtSa/h2zm1egc=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.67 h1:BeBvZWAS+kRJm1vGTMJYVjKUNoo0FoEt/wUWdUtfmh8=
@@ -280,8 +282,6 @@ github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFt
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
-github.com/shtripat/mc v0.0.0-20240212061450-03c9dfe77107 h1:pDFlsezd+kxeohWXZW/X6mmqXO8yDBFvB5RgWGlHi68=
-github.com/shtripat/mc v0.0.0-20240212061450-03c9dfe77107/go.mod h1:9opeL9Qw8zh5u6Vl2Dn87F0pRGxwBbWr2liWbf/7afU=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/models/add_bucket_lifecycle.go
+++ b/models/add_bucket_lifecycle.go
@@ -41,6 +41,9 @@ type AddBucketLifecycle struct {
 	Disable bool `json:"disable,omitempty"`
 
 	// Non required, toggle to disable or enable rule
+	ExpiredObjectDeleteAll bool `json:"expired_object_delete_all,omitempty"`
+
+	// Non required, toggle to disable or enable rule
 	ExpiredObjectDeleteMarker bool `json:"expired_object_delete_marker,omitempty"`
 
 	// Required in case of expiry_date or transition fields are not set. it defines an expiry days for ILM

--- a/models/add_multi_bucket_lifecycle.go
+++ b/models/add_multi_bucket_lifecycle.go
@@ -42,6 +42,9 @@ type AddMultiBucketLifecycle struct {
 	Buckets []string `json:"buckets"`
 
 	// Non required, toggle to disable or enable rule
+	ExpiredObjectDeleteAll bool `json:"expired_object_delete_all,omitempty"`
+
+	// Non required, toggle to disable or enable rule
 	ExpiredObjectDeleteMarker bool `json:"expired_object_delete_marker,omitempty"`
 
 	// Required in case of expiry_date or transition fields are not set. it defines an expiry days for ILM

--- a/models/expiration_response.go
+++ b/models/expiration_response.go
@@ -40,6 +40,9 @@ type ExpirationResponse struct {
 	// days
 	Days int64 `json:"days,omitempty"`
 
+	// delete all
+	DeleteAll bool `json:"delete_all,omitempty"`
+
 	// delete marker
 	DeleteMarker bool `json:"delete_marker,omitempty"`
 

--- a/models/update_bucket_lifecycle.go
+++ b/models/update_bucket_lifecycle.go
@@ -41,6 +41,9 @@ type UpdateBucketLifecycle struct {
 	Disable bool `json:"disable,omitempty"`
 
 	// Non required, toggle to disable or enable rule
+	ExpiredObjectDeleteAll bool `json:"expired_object_delete_all,omitempty"`
+
+	// Non required, toggle to disable or enable rule
 	ExpiredObjectDeleteMarker bool `json:"expired_object_delete_marker,omitempty"`
 
 	// Required in case of expiry_date or transition fields are not set. it defines an expiry days for ILM

--- a/swagger.yml
+++ b/swagger.yml
@@ -5109,6 +5109,8 @@ definitions:
         format: int64
       delete_marker:
         type: boolean
+      delete_all:
+        type: boolean
       noncurrent_expiration_days:
         type: integer
         format: int64
@@ -5192,6 +5194,9 @@ definitions:
       expired_object_delete_marker:
         description: Non required, toggle to disable or enable rule
         type: boolean
+      expired_object_delete_all:
+        description: Non required, toggle to disable or enable rule
+        type: boolean
       noncurrentversion_expiration_days:
         description: Non required, can be set in case of expiration is enabled
         type: integer
@@ -5247,6 +5252,9 @@ definitions:
       expired_object_delete_marker:
         description: Non required, toggle to disable or enable rule
         type: boolean
+      expired_object_delete_all:
+        description: Non required, toggle to disable or enable rule
+        type: boolean
       noncurrentversion_expiration_days:
         description: Non required, can be set in case of expiration is enabled
         type: integer
@@ -5297,6 +5305,9 @@ definitions:
         description: Required only in case of transition is set. it refers to a tier
         type: string
       expired_object_delete_marker:
+        description: Non required, toggle to disable or enable rule
+        type: boolean
+      expired_object_delete_all:
         description: Non required, toggle to disable or enable rule
         type: boolean
       noncurrentversion_expiration_days:

--- a/web-app/src/api/consoleApi.ts
+++ b/web-app/src/api/consoleApi.ts
@@ -468,11 +468,7 @@ export interface SetBucketQuota {
 }
 
 export interface LoginDetails {
-  loginStrategy?:
-    | "form"
-    | "redirect"
-    | "service-account"
-    | "redirect-service-account";
+  loginStrategy?: "form" | "redirect" | "service-account" | "redirect-service-account";
   redirectRules?: RedirectRule[];
   isK8S?: boolean;
   animatedLogin?: boolean;
@@ -903,6 +899,7 @@ export interface ExpirationResponse {
   /** @format int64 */
   days?: number;
   delete_marker?: boolean;
+  delete_all?: boolean;
   /** @format int64 */
   noncurrent_expiration_days?: number;
   /** @format int64 */
@@ -958,6 +955,8 @@ export interface AddBucketLifecycle {
   disable?: boolean;
   /** Non required, toggle to disable or enable rule */
   expired_object_delete_marker?: boolean;
+  /** Non required, toggle to disable or enable rule */
+  expired_object_delete_all?: boolean;
   /**
    * Non required, can be set in case of expiration is enabled
    * @format int32
@@ -1005,6 +1004,8 @@ export interface UpdateBucketLifecycle {
   disable?: boolean;
   /** Non required, toggle to disable or enable rule */
   expired_object_delete_marker?: boolean;
+  /** Non required, toggle to disable or enable rule */
+  expired_object_delete_all?: boolean;
   /**
    * Non required, can be set in case of expiration is enabled
    * @format int32
@@ -1045,6 +1046,8 @@ export interface AddMultiBucketLifecycle {
   storage_class?: string;
   /** Non required, toggle to disable or enable rule */
   expired_object_delete_marker?: boolean;
+  /** Non required, toggle to disable or enable rule */
+  expired_object_delete_all?: boolean;
   /**
    * Non required, can be set in case of expiration is enabled
    * @format int32
@@ -1561,22 +1564,16 @@ export interface FullRequestParams extends Omit<RequestInit, "body"> {
   cancelToken?: CancelToken;
 }
 
-export type RequestParams = Omit<
-  FullRequestParams,
-  "body" | "method" | "query" | "path"
->;
+export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
 
 export interface ApiConfig<SecurityDataType = unknown> {
   baseUrl?: string;
   baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
-  securityWorker?: (
-    securityData: SecurityDataType | null,
-  ) => Promise<RequestParams | void> | RequestParams | void;
+  securityWorker?: (securityData: SecurityDataType | null) => Promise<RequestParams | void> | RequestParams | void;
   customFetch?: typeof fetch;
 }
 
-export interface HttpResponse<D extends unknown, E extends unknown = unknown>
-  extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }
@@ -1595,8 +1592,7 @@ export class HttpClient<SecurityDataType = unknown> {
   private securityData: SecurityDataType | null = null;
   private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();
-  private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
-    fetch(...fetchParams);
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) => fetch(...fetchParams);
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -1629,15 +1625,9 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected toQueryString(rawQuery?: QueryParamsType): string {
     const query = rawQuery || {};
-    const keys = Object.keys(query).filter(
-      (key) => "undefined" !== typeof query[key],
-    );
+    const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
     return keys
-      .map((key) =>
-        Array.isArray(query[key])
-          ? this.addArrayQueryParam(query, key)
-          : this.addQueryParam(query, key),
-      )
+      .map((key) => (Array.isArray(query[key]) ? this.addArrayQueryParam(query, key) : this.addQueryParam(query, key)))
       .join("&");
   }
 
@@ -1648,13 +1638,8 @@ export class HttpClient<SecurityDataType = unknown> {
 
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
-      input !== null && (typeof input === "object" || typeof input === "string")
-        ? JSON.stringify(input)
-        : input,
-    [ContentType.Text]: (input: any) =>
-      input !== null && typeof input !== "string"
-        ? JSON.stringify(input)
-        : input,
+      input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
+    [ContentType.Text]: (input: any) => (input !== null && typeof input !== "string" ? JSON.stringify(input) : input),
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
@@ -1663,18 +1648,15 @@ export class HttpClient<SecurityDataType = unknown> {
           property instanceof Blob
             ? property
             : typeof property === "object" && property !== null
-              ? JSON.stringify(property)
-              : `${property}`,
+            ? JSON.stringify(property)
+            : `${property}`,
         );
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
   };
 
-  protected mergeRequestParams(
-    params1: RequestParams,
-    params2?: RequestParams,
-  ): RequestParams {
+  protected mergeRequestParams(params1: RequestParams, params2?: RequestParams): RequestParams {
     return {
       ...this.baseApiParams,
       ...params1,
@@ -1687,9 +1669,7 @@ export class HttpClient<SecurityDataType = unknown> {
     };
   }
 
-  protected createAbortSignal = (
-    cancelToken: CancelToken,
-  ): AbortSignal | undefined => {
+  protected createAbortSignal = (cancelToken: CancelToken): AbortSignal | undefined => {
     if (this.abortControllers.has(cancelToken)) {
       const abortController = this.abortControllers.get(cancelToken);
       if (abortController) {
@@ -1788,9 +1768,7 @@ export class HttpClient<SecurityDataType = unknown> {
  * @version 0.1.0
  * @baseUrl /api/v1
  */
-export class Api<
-  SecurityDataType extends unknown,
-> extends HttpClient<SecurityDataType> {
+export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDataType> {
   login = {
     /**
      * No description
@@ -1833,10 +1811,7 @@ export class Api<
      * @summary Identity Provider oauth2 callback endpoint.
      * @request POST:/login/oauth2/auth
      */
-    loginOauth2Auth: (
-      body: LoginOauth2AuthRequest,
-      params: RequestParams = {},
-    ) =>
+    loginOauth2Auth: (body: LoginOauth2AuthRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/login/oauth2/auth`,
         method: "POST",
@@ -1894,10 +1869,7 @@ export class Api<
      * @request POST:/account/change-password
      * @secure
      */
-    accountChangePassword: (
-      body: AccountChangePasswordRequest,
-      params: RequestParams = {},
-    ) =>
+    accountChangePassword: (body: AccountChangePasswordRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/account/change-password`,
         method: "POST",
@@ -1916,10 +1888,7 @@ export class Api<
      * @request POST:/account/change-user-password
      * @secure
      */
-    changeUserPassword: (
-      body: ChangeUserPasswordRequest,
-      params: RequestParams = {},
-    ) =>
+    changeUserPassword: (body: ChangeUserPasswordRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/account/change-user-password`,
         method: "POST",
@@ -2012,10 +1981,7 @@ export class Api<
      * @request GET:/buckets/{bucket_name}/retention
      * @secure
      */
-    getBucketRetentionConfig: (
-      bucketName: string,
-      params: RequestParams = {},
-    ) =>
+    getBucketRetentionConfig: (bucketName: string, params: RequestParams = {}) =>
       this.request<GetBucketRetentionConfig, ApiError>({
         path: `/buckets/${bucketName}/retention`,
         method: "GET",
@@ -2033,11 +1999,7 @@ export class Api<
      * @request PUT:/buckets/{bucket_name}/retention
      * @secure
      */
-    setBucketRetentionConfig: (
-      bucketName: string,
-      body: PutBucketRetentionRequest,
-      params: RequestParams = {},
-    ) =>
+    setBucketRetentionConfig: (bucketName: string, body: PutBucketRetentionRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/retention`,
         method: "PUT",
@@ -2173,11 +2135,7 @@ export class Api<
      * @request POST:/buckets/{bucket_name}/objects/download-multiple
      * @secure
      */
-    downloadMultipleObjects: (
-      bucketName: string,
-      objectList: SelectedUsers,
-      params: RequestParams = {},
-    ) =>
+    downloadMultipleObjects: (bucketName: string, objectList: SelectedUsers, params: RequestParams = {}) =>
       this.request<File, ApiError>({
         path: `/buckets/${bucketName}/objects/download-multiple`,
         method: "POST",
@@ -2411,11 +2369,7 @@ export class Api<
      * @request PUT:/buckets/{bucket_name}/tags
      * @secure
      */
-    putBucketTags: (
-      bucketName: string,
-      body: PutBucketTagsRequest,
-      params: RequestParams = {},
-    ) =>
+    putBucketTags: (bucketName: string, body: PutBucketTagsRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/tags`,
         method: "PUT",
@@ -2434,11 +2388,7 @@ export class Api<
      * @request PUT:/buckets/{name}/set-policy
      * @secure
      */
-    bucketSetPolicy: (
-      name: string,
-      body: SetBucketPolicyRequest,
-      params: RequestParams = {},
-    ) =>
+    bucketSetPolicy: (name: string, body: SetBucketPolicyRequest, params: RequestParams = {}) =>
       this.request<Bucket, ApiError>({
         path: `/buckets/${name}/set-policy`,
         method: "PUT",
@@ -2476,11 +2426,7 @@ export class Api<
      * @request PUT:/buckets/{name}/quota
      * @secure
      */
-    setBucketQuota: (
-      name: string,
-      body: SetBucketQuota,
-      params: RequestParams = {},
-    ) =>
+    setBucketQuota: (name: string, body: SetBucketQuota, params: RequestParams = {}) =>
       this.request<Bucket, ApiError>({
         path: `/buckets/${name}/quota`,
         method: "PUT",
@@ -2534,11 +2480,7 @@ export class Api<
      * @request POST:/buckets/{bucket_name}/events
      * @secure
      */
-    createBucketEvent: (
-      bucketName: string,
-      body: BucketEventRequest,
-      params: RequestParams = {},
-    ) =>
+    createBucketEvent: (bucketName: string, body: BucketEventRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/events`,
         method: "POST",
@@ -2557,12 +2499,7 @@ export class Api<
      * @request DELETE:/buckets/{bucket_name}/events/{arn}
      * @secure
      */
-    deleteBucketEvent: (
-      bucketName: string,
-      arn: string,
-      body: NotificationDeleteRequest,
-      params: RequestParams = {},
-    ) =>
+    deleteBucketEvent: (bucketName: string, arn: string, body: NotificationDeleteRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/events/${arn}`,
         method: "DELETE",
@@ -2599,11 +2536,7 @@ export class Api<
      * @request GET:/buckets/{bucket_name}/replication/{rule_id}
      * @secure
      */
-    getBucketReplicationRule: (
-      bucketName: string,
-      ruleId: string,
-      params: RequestParams = {},
-    ) =>
+    getBucketReplicationRule: (bucketName: string, ruleId: string, params: RequestParams = {}) =>
       this.request<BucketReplicationRule, ApiError>({
         path: `/buckets/${bucketName}/replication/${ruleId}`,
         method: "GET",
@@ -2645,11 +2578,7 @@ export class Api<
      * @request DELETE:/buckets/{bucket_name}/replication/{rule_id}
      * @secure
      */
-    deleteBucketReplicationRule: (
-      bucketName: string,
-      ruleId: string,
-      params: RequestParams = {},
-    ) =>
+    deleteBucketReplicationRule: (bucketName: string, ruleId: string, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/replication/${ruleId}`,
         method: "DELETE",
@@ -2666,10 +2595,7 @@ export class Api<
      * @request DELETE:/buckets/{bucket_name}/delete-all-replication-rules
      * @secure
      */
-    deleteAllReplicationRules: (
-      bucketName: string,
-      params: RequestParams = {},
-    ) =>
+    deleteAllReplicationRules: (bucketName: string, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/delete-all-replication-rules`,
         method: "DELETE",
@@ -2727,11 +2653,7 @@ export class Api<
      * @request PUT:/buckets/{bucket_name}/versioning
      * @secure
      */
-    setBucketVersioning: (
-      bucketName: string,
-      body: SetBucketVersioning,
-      params: RequestParams = {},
-    ) =>
+    setBucketVersioning: (bucketName: string, body: SetBucketVersioning, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/versioning`,
         method: "PUT",
@@ -2750,10 +2672,7 @@ export class Api<
      * @request GET:/buckets/{bucket_name}/object-locking
      * @secure
      */
-    getBucketObjectLockingStatus: (
-      bucketName: string,
-      params: RequestParams = {},
-    ) =>
+    getBucketObjectLockingStatus: (bucketName: string, params: RequestParams = {}) =>
       this.request<BucketObLockingResponse, ApiError>({
         path: `/buckets/${bucketName}/object-locking`,
         method: "GET",
@@ -2771,11 +2690,7 @@ export class Api<
      * @request POST:/buckets/{bucket_name}/encryption/enable
      * @secure
      */
-    enableBucketEncryption: (
-      bucketName: string,
-      body: BucketEncryptionRequest,
-      params: RequestParams = {},
-    ) =>
+    enableBucketEncryption: (bucketName: string, body: BucketEncryptionRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/encryption/enable`,
         method: "POST",
@@ -2847,11 +2762,7 @@ export class Api<
      * @request POST:/buckets/{bucket_name}/lifecycle
      * @secure
      */
-    addBucketLifecycle: (
-      bucketName: string,
-      body: AddBucketLifecycle,
-      params: RequestParams = {},
-    ) =>
+    addBucketLifecycle: (bucketName: string, body: AddBucketLifecycle, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/lifecycle`,
         method: "POST",
@@ -2870,10 +2781,7 @@ export class Api<
      * @request POST:/buckets/multi-lifecycle
      * @secure
      */
-    addMultiBucketLifecycle: (
-      body: AddMultiBucketLifecycle,
-      params: RequestParams = {},
-    ) =>
+    addMultiBucketLifecycle: (body: AddMultiBucketLifecycle, params: RequestParams = {}) =>
       this.request<MultiLifecycleResult, ApiError>({
         path: `/buckets/multi-lifecycle`,
         method: "POST",
@@ -2917,11 +2825,7 @@ export class Api<
      * @request DELETE:/buckets/{bucket_name}/lifecycle/{lifecycle_id}
      * @secure
      */
-    deleteBucketLifecycleRule: (
-      bucketName: string,
-      lifecycleId: string,
-      params: RequestParams = {},
-    ) =>
+    deleteBucketLifecycleRule: (bucketName: string, lifecycleId: string, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/lifecycle/${lifecycleId}`,
         method: "DELETE",
@@ -2983,10 +2887,7 @@ export class Api<
      * @request POST:/list-external-buckets
      * @secure
      */
-    listExternalBuckets: (
-      body: ListExternalBucketsParams,
-      params: RequestParams = {},
-    ) =>
+    listExternalBuckets: (body: ListExternalBucketsParams, params: RequestParams = {}) =>
       this.request<ListBucketsResponse, ApiError>({
         path: `/list-external-buckets`,
         method: "POST",
@@ -3007,10 +2908,7 @@ export class Api<
      * @request POST:/buckets-replication
      * @secure
      */
-    setMultiBucketReplication: (
-      body: MultiBucketReplication,
-      params: RequestParams = {},
-    ) =>
+    setMultiBucketReplication: (body: MultiBucketReplication, params: RequestParams = {}) =>
       this.request<MultiBucketResponseState, ApiError>({
         path: `/buckets-replication`,
         method: "POST",
@@ -3064,10 +2962,7 @@ export class Api<
      * @request POST:/service-accounts
      * @secure
      */
-    createServiceAccount: (
-      body: ServiceAccountRequest,
-      params: RequestParams = {},
-    ) =>
+    createServiceAccount: (body: ServiceAccountRequest, params: RequestParams = {}) =>
       this.request<ServiceAccountCreds, ApiError>({
         path: `/service-accounts`,
         method: "POST",
@@ -3086,10 +2981,7 @@ export class Api<
      * @request DELETE:/service-accounts/delete-multi
      * @secure
      */
-    deleteMultipleServiceAccounts: (
-      selectedSA: SelectedSAs,
-      params: RequestParams = {},
-    ) =>
+    deleteMultipleServiceAccounts: (selectedSA: SelectedSAs, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/service-accounts/delete-multi`,
         method: "DELETE",
@@ -3126,11 +3018,7 @@ export class Api<
      * @request PUT:/service-accounts/{access_key}
      * @secure
      */
-    updateServiceAccount: (
-      accessKey: string,
-      body: UpdateServiceAccountRequest,
-      params: RequestParams = {},
-    ) =>
+    updateServiceAccount: (accessKey: string, body: UpdateServiceAccountRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/service-accounts/${accessKey}`,
         method: "PUT",
@@ -3167,10 +3055,7 @@ export class Api<
      * @request POST:/service-account-credentials
      * @secure
      */
-    createServiceAccountCreds: (
-      body: ServiceAccountRequestCreds,
-      params: RequestParams = {},
-    ) =>
+    createServiceAccountCreds: (body: ServiceAccountRequestCreds, params: RequestParams = {}) =>
       this.request<ServiceAccountCreds, ApiError>({
         path: `/service-account-credentials`,
         method: "POST",
@@ -3243,10 +3128,7 @@ export class Api<
      * @request POST:/users/service-accounts
      * @secure
      */
-    checkUserServiceAccounts: (
-      selectedUsers: SelectedUsers,
-      params: RequestParams = {},
-    ) =>
+    checkUserServiceAccounts: (selectedUsers: SelectedUsers, params: RequestParams = {}) =>
       this.request<UserServiceAccountSummary, ApiError>({
         path: `/users/service-accounts`,
         method: "POST",
@@ -3285,11 +3167,7 @@ export class Api<
      * @request PUT:/user/{name}
      * @secure
      */
-    updateUserInfo: (
-      name: string,
-      body: UpdateUser,
-      params: RequestParams = {},
-    ) =>
+    updateUserInfo: (name: string, body: UpdateUser, params: RequestParams = {}) =>
       this.request<User, ApiError>({
         path: `/user/${name}`,
         method: "PUT",
@@ -3326,11 +3204,7 @@ export class Api<
      * @request PUT:/user/{name}/groups
      * @secure
      */
-    updateUserGroups: (
-      name: string,
-      body: UpdateUserGroups,
-      params: RequestParams = {},
-    ) =>
+    updateUserGroups: (name: string, body: UpdateUserGroups, params: RequestParams = {}) =>
       this.request<User, ApiError>({
         path: `/user/${name}/groups`,
         method: "PUT",
@@ -3404,11 +3278,7 @@ export class Api<
      * @request POST:/user/{name}/service-accounts
      * @secure
      */
-    createAUserServiceAccount: (
-      name: string,
-      body: ServiceAccountRequest,
-      params: RequestParams = {},
-    ) =>
+    createAUserServiceAccount: (name: string, body: ServiceAccountRequest, params: RequestParams = {}) =>
       this.request<ServiceAccountCreds, ApiError>({
         path: `/user/${name}/service-accounts`,
         method: "POST",
@@ -3427,11 +3297,7 @@ export class Api<
      * @request POST:/user/{name}/service-account-credentials
      * @secure
      */
-    createServiceAccountCredentials: (
-      name: string,
-      body: ServiceAccountRequestCreds,
-      params: RequestParams = {},
-    ) =>
+    createServiceAccountCredentials: (name: string, body: ServiceAccountRequestCreds, params: RequestParams = {}) =>
       this.request<ServiceAccountCreds, ApiError>({
         path: `/user/${name}/service-account-credentials`,
         method: "POST",
@@ -3559,11 +3425,7 @@ export class Api<
      * @request PUT:/group/{name}
      * @secure
      */
-    updateGroup: (
-      name: string,
-      body: UpdateGroupRequest,
-      params: RequestParams = {},
-    ) =>
+    updateGroup: (name: string, body: UpdateGroupRequest, params: RequestParams = {}) =>
       this.request<Group, ApiError>({
         path: `/group/${name}`,
         method: "PUT",
@@ -3709,11 +3571,7 @@ export class Api<
      * @request PUT:/bucket/{bucket}/access-rules
      * @secure
      */
-    setAccessRuleWithBucket: (
-      bucket: string,
-      prefixaccess: PrefixAccessPair,
-      params: RequestParams = {},
-    ) =>
+    setAccessRuleWithBucket: (bucket: string, prefixaccess: PrefixAccessPair, params: RequestParams = {}) =>
       this.request<boolean, ApiError>({
         path: `/bucket/${bucket}/access-rules`,
         method: "PUT",
@@ -3767,11 +3625,7 @@ export class Api<
      * @request DELETE:/bucket/{bucket}/access-rules
      * @secure
      */
-    deleteAccessRuleWithBucket: (
-      bucket: string,
-      prefix: PrefixWrapper,
-      params: RequestParams = {},
-    ) =>
+    deleteAccessRuleWithBucket: (bucket: string, prefix: PrefixWrapper, params: RequestParams = {}) =>
       this.request<boolean, ApiError>({
         path: `/bucket/${bucket}/access-rules`,
         method: "DELETE",
@@ -3914,11 +3768,7 @@ export class Api<
      * @request PUT:/configs/{name}
      * @secure
      */
-    setConfig: (
-      name: string,
-      body: SetConfigRequest,
-      params: RequestParams = {},
-    ) =>
+    setConfig: (name: string, body: SetConfigRequest, params: RequestParams = {}) =>
       this.request<SetConfigResponse, ApiError>({
         path: `/configs/${name}`,
         method: "PUT",
@@ -4020,10 +3870,7 @@ export class Api<
      * @request PUT:/set-policy-multi
      * @secure
      */
-    setPolicyMultiple: (
-      body: SetPolicyMultipleNameRequest,
-      params: RequestParams = {},
-    ) =>
+    setPolicyMultiple: (body: SetPolicyMultipleNameRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/set-policy-multi`,
         method: "PUT",
@@ -4308,10 +4155,7 @@ export class Api<
      * @request POST:/admin/notification_endpoints
      * @secure
      */
-    addNotificationEndpoint: (
-      body: NotificationEndpoint,
-      params: RequestParams = {},
-    ) =>
+    addNotificationEndpoint: (body: NotificationEndpoint, params: RequestParams = {}) =>
       this.request<SetNotificationEndpointResponse, ApiError>({
         path: `/admin/notification_endpoints`,
         method: "POST",
@@ -4349,10 +4193,7 @@ export class Api<
      * @request POST:/admin/site-replication
      * @secure
      */
-    siteReplicationInfoAdd: (
-      body: SiteReplicationAddRequest,
-      params: RequestParams = {},
-    ) =>
+    siteReplicationInfoAdd: (body: SiteReplicationAddRequest, params: RequestParams = {}) =>
       this.request<SiteReplicationAddResponse, ApiError>({
         path: `/admin/site-replication`,
         method: "POST",
@@ -4496,11 +4337,7 @@ export class Api<
      * @request GET:/admin/tiers/{type}/{name}
      * @secure
      */
-    getTier: (
-      type: "s3" | "gcs" | "azure" | "minio",
-      name: string,
-      params: RequestParams = {},
-    ) =>
+    getTier: (type: "s3" | "gcs" | "azure" | "minio", name: string, params: RequestParams = {}) =>
       this.request<Tier, ApiError>({
         path: `/admin/tiers/${type}/${name}`,
         method: "GET",
@@ -4642,11 +4479,7 @@ export class Api<
      * @request DELETE:/remote-buckets/{source-bucket-name}/{arn}
      * @secure
      */
-    deleteRemoteBucket: (
-      sourceBucketName: string,
-      arn: string,
-      params: RequestParams = {},
-    ) =>
+    deleteRemoteBucket: (sourceBucketName: string, arn: string, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/remote-buckets/${sourceBucketName}/${arn}`,
         method: "DELETE",
@@ -4855,11 +4688,7 @@ export class Api<
      * @request POST:/kms/keys/{name}/import
      * @secure
      */
-    kmsImportKey: (
-      name: string,
-      body: KmsImportKeyRequest,
-      params: RequestParams = {},
-    ) =>
+    kmsImportKey: (name: string, body: KmsImportKeyRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/kms/keys/${name}/import`,
         method: "POST",
@@ -4957,11 +4786,7 @@ export class Api<
      * @request POST:/kms/policies/{name}/assign
      * @secure
      */
-    kmsAssignPolicy: (
-      name: string,
-      body: KmsAssignPolicyRequest,
-      params: RequestParams = {},
-    ) =>
+    kmsAssignPolicy: (name: string, body: KmsAssignPolicyRequest, params: RequestParams = {}) =>
       this.request<void, ApiError>({
         path: `/kms/policies/${name}/assign`,
         method: "POST",
@@ -5077,11 +4902,7 @@ export class Api<
      * @request POST:/idp/{type}
      * @secure
      */
-    createConfiguration: (
-      type: string,
-      body: IdpServerConfiguration,
-      params: RequestParams = {},
-    ) =>
+    createConfiguration: (type: string, body: IdpServerConfiguration, params: RequestParams = {}) =>
       this.request<SetIDPResponse, ApiError>({
         path: `/idp/${type}`,
         method: "POST",
@@ -5119,11 +4940,7 @@ export class Api<
      * @request GET:/idp/{type}/{name}
      * @secure
      */
-    getConfiguration: (
-      name: string,
-      type: string,
-      params: RequestParams = {},
-    ) =>
+    getConfiguration: (name: string, type: string, params: RequestParams = {}) =>
       this.request<IdpServerConfiguration, ApiError>({
         path: `/idp/${type}/${name}`,
         method: "GET",
@@ -5141,11 +4958,7 @@ export class Api<
      * @request DELETE:/idp/{type}/{name}
      * @secure
      */
-    deleteConfiguration: (
-      name: string,
-      type: string,
-      params: RequestParams = {},
-    ) =>
+    deleteConfiguration: (name: string, type: string, params: RequestParams = {}) =>
       this.request<SetIDPResponse, ApiError>({
         path: `/idp/${type}/${name}`,
         method: "DELETE",
@@ -5163,12 +4976,7 @@ export class Api<
      * @request PUT:/idp/{type}/{name}
      * @secure
      */
-    updateConfiguration: (
-      name: string,
-      type: string,
-      body: IdpServerConfiguration,
-      params: RequestParams = {},
-    ) =>
+    updateConfiguration: (name: string, type: string, body: IdpServerConfiguration, params: RequestParams = {}) =>
       this.request<SetIDPResponse, ApiError>({
         path: `/idp/${type}/${name}`,
         method: "PUT",

--- a/web-app/src/api/consoleApi.ts
+++ b/web-app/src/api/consoleApi.ts
@@ -468,7 +468,11 @@ export interface SetBucketQuota {
 }
 
 export interface LoginDetails {
-  loginStrategy?: "form" | "redirect" | "service-account" | "redirect-service-account";
+  loginStrategy?:
+    | "form"
+    | "redirect"
+    | "service-account"
+    | "redirect-service-account";
   redirectRules?: RedirectRule[];
   isK8S?: boolean;
   animatedLogin?: boolean;
@@ -1564,16 +1568,22 @@ export interface FullRequestParams extends Omit<RequestInit, "body"> {
   cancelToken?: CancelToken;
 }
 
-export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
+export type RequestParams = Omit<
+  FullRequestParams,
+  "body" | "method" | "query" | "path"
+>;
 
 export interface ApiConfig<SecurityDataType = unknown> {
   baseUrl?: string;
   baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
-  securityWorker?: (securityData: SecurityDataType | null) => Promise<RequestParams | void> | RequestParams | void;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<RequestParams | void> | RequestParams | void;
   customFetch?: typeof fetch;
 }
 
-export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown>
+  extends Response {
   data: D;
   error: E;
 }
@@ -1592,7 +1602,8 @@ export class HttpClient<SecurityDataType = unknown> {
   private securityData: SecurityDataType | null = null;
   private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();
-  private customFetch = (...fetchParams: Parameters<typeof fetch>) => fetch(...fetchParams);
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
+    fetch(...fetchParams);
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -1625,9 +1636,15 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected toQueryString(rawQuery?: QueryParamsType): string {
     const query = rawQuery || {};
-    const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
+    const keys = Object.keys(query).filter(
+      (key) => "undefined" !== typeof query[key],
+    );
     return keys
-      .map((key) => (Array.isArray(query[key]) ? this.addArrayQueryParam(query, key) : this.addQueryParam(query, key)))
+      .map((key) =>
+        Array.isArray(query[key])
+          ? this.addArrayQueryParam(query, key)
+          : this.addQueryParam(query, key),
+      )
       .join("&");
   }
 
@@ -1638,8 +1655,13 @@ export class HttpClient<SecurityDataType = unknown> {
 
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
-      input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
-    [ContentType.Text]: (input: any) => (input !== null && typeof input !== "string" ? JSON.stringify(input) : input),
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.Text]: (input: any) =>
+      input !== null && typeof input !== "string"
+        ? JSON.stringify(input)
+        : input,
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
@@ -1648,15 +1670,18 @@ export class HttpClient<SecurityDataType = unknown> {
           property instanceof Blob
             ? property
             : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
+              ? JSON.stringify(property)
+              : `${property}`,
         );
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
   };
 
-  protected mergeRequestParams(params1: RequestParams, params2?: RequestParams): RequestParams {
+  protected mergeRequestParams(
+    params1: RequestParams,
+    params2?: RequestParams,
+  ): RequestParams {
     return {
       ...this.baseApiParams,
       ...params1,
@@ -1669,7 +1694,9 @@ export class HttpClient<SecurityDataType = unknown> {
     };
   }
 
-  protected createAbortSignal = (cancelToken: CancelToken): AbortSignal | undefined => {
+  protected createAbortSignal = (
+    cancelToken: CancelToken,
+  ): AbortSignal | undefined => {
     if (this.abortControllers.has(cancelToken)) {
       const abortController = this.abortControllers.get(cancelToken);
       if (abortController) {
@@ -1768,7 +1795,9 @@ export class HttpClient<SecurityDataType = unknown> {
  * @version 0.1.0
  * @baseUrl /api/v1
  */
-export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDataType> {
+export class Api<
+  SecurityDataType extends unknown,
+> extends HttpClient<SecurityDataType> {
   login = {
     /**
      * No description
@@ -1811,7 +1840,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @summary Identity Provider oauth2 callback endpoint.
      * @request POST:/login/oauth2/auth
      */
-    loginOauth2Auth: (body: LoginOauth2AuthRequest, params: RequestParams = {}) =>
+    loginOauth2Auth: (
+      body: LoginOauth2AuthRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/login/oauth2/auth`,
         method: "POST",
@@ -1869,7 +1901,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/account/change-password
      * @secure
      */
-    accountChangePassword: (body: AccountChangePasswordRequest, params: RequestParams = {}) =>
+    accountChangePassword: (
+      body: AccountChangePasswordRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/account/change-password`,
         method: "POST",
@@ -1888,7 +1923,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/account/change-user-password
      * @secure
      */
-    changeUserPassword: (body: ChangeUserPasswordRequest, params: RequestParams = {}) =>
+    changeUserPassword: (
+      body: ChangeUserPasswordRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/account/change-user-password`,
         method: "POST",
@@ -1981,7 +2019,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/buckets/{bucket_name}/retention
      * @secure
      */
-    getBucketRetentionConfig: (bucketName: string, params: RequestParams = {}) =>
+    getBucketRetentionConfig: (
+      bucketName: string,
+      params: RequestParams = {},
+    ) =>
       this.request<GetBucketRetentionConfig, ApiError>({
         path: `/buckets/${bucketName}/retention`,
         method: "GET",
@@ -1999,7 +2040,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/buckets/{bucket_name}/retention
      * @secure
      */
-    setBucketRetentionConfig: (bucketName: string, body: PutBucketRetentionRequest, params: RequestParams = {}) =>
+    setBucketRetentionConfig: (
+      bucketName: string,
+      body: PutBucketRetentionRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/retention`,
         method: "PUT",
@@ -2135,7 +2180,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/buckets/{bucket_name}/objects/download-multiple
      * @secure
      */
-    downloadMultipleObjects: (bucketName: string, objectList: SelectedUsers, params: RequestParams = {}) =>
+    downloadMultipleObjects: (
+      bucketName: string,
+      objectList: SelectedUsers,
+      params: RequestParams = {},
+    ) =>
       this.request<File, ApiError>({
         path: `/buckets/${bucketName}/objects/download-multiple`,
         method: "POST",
@@ -2369,7 +2418,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/buckets/{bucket_name}/tags
      * @secure
      */
-    putBucketTags: (bucketName: string, body: PutBucketTagsRequest, params: RequestParams = {}) =>
+    putBucketTags: (
+      bucketName: string,
+      body: PutBucketTagsRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/tags`,
         method: "PUT",
@@ -2388,7 +2441,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/buckets/{name}/set-policy
      * @secure
      */
-    bucketSetPolicy: (name: string, body: SetBucketPolicyRequest, params: RequestParams = {}) =>
+    bucketSetPolicy: (
+      name: string,
+      body: SetBucketPolicyRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<Bucket, ApiError>({
         path: `/buckets/${name}/set-policy`,
         method: "PUT",
@@ -2426,7 +2483,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/buckets/{name}/quota
      * @secure
      */
-    setBucketQuota: (name: string, body: SetBucketQuota, params: RequestParams = {}) =>
+    setBucketQuota: (
+      name: string,
+      body: SetBucketQuota,
+      params: RequestParams = {},
+    ) =>
       this.request<Bucket, ApiError>({
         path: `/buckets/${name}/quota`,
         method: "PUT",
@@ -2480,7 +2541,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/buckets/{bucket_name}/events
      * @secure
      */
-    createBucketEvent: (bucketName: string, body: BucketEventRequest, params: RequestParams = {}) =>
+    createBucketEvent: (
+      bucketName: string,
+      body: BucketEventRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/events`,
         method: "POST",
@@ -2499,7 +2564,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request DELETE:/buckets/{bucket_name}/events/{arn}
      * @secure
      */
-    deleteBucketEvent: (bucketName: string, arn: string, body: NotificationDeleteRequest, params: RequestParams = {}) =>
+    deleteBucketEvent: (
+      bucketName: string,
+      arn: string,
+      body: NotificationDeleteRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/events/${arn}`,
         method: "DELETE",
@@ -2536,7 +2606,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/buckets/{bucket_name}/replication/{rule_id}
      * @secure
      */
-    getBucketReplicationRule: (bucketName: string, ruleId: string, params: RequestParams = {}) =>
+    getBucketReplicationRule: (
+      bucketName: string,
+      ruleId: string,
+      params: RequestParams = {},
+    ) =>
       this.request<BucketReplicationRule, ApiError>({
         path: `/buckets/${bucketName}/replication/${ruleId}`,
         method: "GET",
@@ -2578,7 +2652,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request DELETE:/buckets/{bucket_name}/replication/{rule_id}
      * @secure
      */
-    deleteBucketReplicationRule: (bucketName: string, ruleId: string, params: RequestParams = {}) =>
+    deleteBucketReplicationRule: (
+      bucketName: string,
+      ruleId: string,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/replication/${ruleId}`,
         method: "DELETE",
@@ -2595,7 +2673,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request DELETE:/buckets/{bucket_name}/delete-all-replication-rules
      * @secure
      */
-    deleteAllReplicationRules: (bucketName: string, params: RequestParams = {}) =>
+    deleteAllReplicationRules: (
+      bucketName: string,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/delete-all-replication-rules`,
         method: "DELETE",
@@ -2653,7 +2734,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/buckets/{bucket_name}/versioning
      * @secure
      */
-    setBucketVersioning: (bucketName: string, body: SetBucketVersioning, params: RequestParams = {}) =>
+    setBucketVersioning: (
+      bucketName: string,
+      body: SetBucketVersioning,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/versioning`,
         method: "PUT",
@@ -2672,7 +2757,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/buckets/{bucket_name}/object-locking
      * @secure
      */
-    getBucketObjectLockingStatus: (bucketName: string, params: RequestParams = {}) =>
+    getBucketObjectLockingStatus: (
+      bucketName: string,
+      params: RequestParams = {},
+    ) =>
       this.request<BucketObLockingResponse, ApiError>({
         path: `/buckets/${bucketName}/object-locking`,
         method: "GET",
@@ -2690,7 +2778,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/buckets/{bucket_name}/encryption/enable
      * @secure
      */
-    enableBucketEncryption: (bucketName: string, body: BucketEncryptionRequest, params: RequestParams = {}) =>
+    enableBucketEncryption: (
+      bucketName: string,
+      body: BucketEncryptionRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/encryption/enable`,
         method: "POST",
@@ -2762,7 +2854,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/buckets/{bucket_name}/lifecycle
      * @secure
      */
-    addBucketLifecycle: (bucketName: string, body: AddBucketLifecycle, params: RequestParams = {}) =>
+    addBucketLifecycle: (
+      bucketName: string,
+      body: AddBucketLifecycle,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/lifecycle`,
         method: "POST",
@@ -2781,7 +2877,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/buckets/multi-lifecycle
      * @secure
      */
-    addMultiBucketLifecycle: (body: AddMultiBucketLifecycle, params: RequestParams = {}) =>
+    addMultiBucketLifecycle: (
+      body: AddMultiBucketLifecycle,
+      params: RequestParams = {},
+    ) =>
       this.request<MultiLifecycleResult, ApiError>({
         path: `/buckets/multi-lifecycle`,
         method: "POST",
@@ -2825,7 +2924,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request DELETE:/buckets/{bucket_name}/lifecycle/{lifecycle_id}
      * @secure
      */
-    deleteBucketLifecycleRule: (bucketName: string, lifecycleId: string, params: RequestParams = {}) =>
+    deleteBucketLifecycleRule: (
+      bucketName: string,
+      lifecycleId: string,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/buckets/${bucketName}/lifecycle/${lifecycleId}`,
         method: "DELETE",
@@ -2887,7 +2990,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/list-external-buckets
      * @secure
      */
-    listExternalBuckets: (body: ListExternalBucketsParams, params: RequestParams = {}) =>
+    listExternalBuckets: (
+      body: ListExternalBucketsParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ListBucketsResponse, ApiError>({
         path: `/list-external-buckets`,
         method: "POST",
@@ -2908,7 +3014,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/buckets-replication
      * @secure
      */
-    setMultiBucketReplication: (body: MultiBucketReplication, params: RequestParams = {}) =>
+    setMultiBucketReplication: (
+      body: MultiBucketReplication,
+      params: RequestParams = {},
+    ) =>
       this.request<MultiBucketResponseState, ApiError>({
         path: `/buckets-replication`,
         method: "POST",
@@ -2962,7 +3071,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/service-accounts
      * @secure
      */
-    createServiceAccount: (body: ServiceAccountRequest, params: RequestParams = {}) =>
+    createServiceAccount: (
+      body: ServiceAccountRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<ServiceAccountCreds, ApiError>({
         path: `/service-accounts`,
         method: "POST",
@@ -2981,7 +3093,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request DELETE:/service-accounts/delete-multi
      * @secure
      */
-    deleteMultipleServiceAccounts: (selectedSA: SelectedSAs, params: RequestParams = {}) =>
+    deleteMultipleServiceAccounts: (
+      selectedSA: SelectedSAs,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/service-accounts/delete-multi`,
         method: "DELETE",
@@ -3018,7 +3133,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/service-accounts/{access_key}
      * @secure
      */
-    updateServiceAccount: (accessKey: string, body: UpdateServiceAccountRequest, params: RequestParams = {}) =>
+    updateServiceAccount: (
+      accessKey: string,
+      body: UpdateServiceAccountRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/service-accounts/${accessKey}`,
         method: "PUT",
@@ -3055,7 +3174,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/service-account-credentials
      * @secure
      */
-    createServiceAccountCreds: (body: ServiceAccountRequestCreds, params: RequestParams = {}) =>
+    createServiceAccountCreds: (
+      body: ServiceAccountRequestCreds,
+      params: RequestParams = {},
+    ) =>
       this.request<ServiceAccountCreds, ApiError>({
         path: `/service-account-credentials`,
         method: "POST",
@@ -3128,7 +3250,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/users/service-accounts
      * @secure
      */
-    checkUserServiceAccounts: (selectedUsers: SelectedUsers, params: RequestParams = {}) =>
+    checkUserServiceAccounts: (
+      selectedUsers: SelectedUsers,
+      params: RequestParams = {},
+    ) =>
       this.request<UserServiceAccountSummary, ApiError>({
         path: `/users/service-accounts`,
         method: "POST",
@@ -3167,7 +3292,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/user/{name}
      * @secure
      */
-    updateUserInfo: (name: string, body: UpdateUser, params: RequestParams = {}) =>
+    updateUserInfo: (
+      name: string,
+      body: UpdateUser,
+      params: RequestParams = {},
+    ) =>
       this.request<User, ApiError>({
         path: `/user/${name}`,
         method: "PUT",
@@ -3204,7 +3333,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/user/{name}/groups
      * @secure
      */
-    updateUserGroups: (name: string, body: UpdateUserGroups, params: RequestParams = {}) =>
+    updateUserGroups: (
+      name: string,
+      body: UpdateUserGroups,
+      params: RequestParams = {},
+    ) =>
       this.request<User, ApiError>({
         path: `/user/${name}/groups`,
         method: "PUT",
@@ -3278,7 +3411,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/user/{name}/service-accounts
      * @secure
      */
-    createAUserServiceAccount: (name: string, body: ServiceAccountRequest, params: RequestParams = {}) =>
+    createAUserServiceAccount: (
+      name: string,
+      body: ServiceAccountRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<ServiceAccountCreds, ApiError>({
         path: `/user/${name}/service-accounts`,
         method: "POST",
@@ -3297,7 +3434,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/user/{name}/service-account-credentials
      * @secure
      */
-    createServiceAccountCredentials: (name: string, body: ServiceAccountRequestCreds, params: RequestParams = {}) =>
+    createServiceAccountCredentials: (
+      name: string,
+      body: ServiceAccountRequestCreds,
+      params: RequestParams = {},
+    ) =>
       this.request<ServiceAccountCreds, ApiError>({
         path: `/user/${name}/service-account-credentials`,
         method: "POST",
@@ -3425,7 +3566,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/group/{name}
      * @secure
      */
-    updateGroup: (name: string, body: UpdateGroupRequest, params: RequestParams = {}) =>
+    updateGroup: (
+      name: string,
+      body: UpdateGroupRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<Group, ApiError>({
         path: `/group/${name}`,
         method: "PUT",
@@ -3571,7 +3716,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/bucket/{bucket}/access-rules
      * @secure
      */
-    setAccessRuleWithBucket: (bucket: string, prefixaccess: PrefixAccessPair, params: RequestParams = {}) =>
+    setAccessRuleWithBucket: (
+      bucket: string,
+      prefixaccess: PrefixAccessPair,
+      params: RequestParams = {},
+    ) =>
       this.request<boolean, ApiError>({
         path: `/bucket/${bucket}/access-rules`,
         method: "PUT",
@@ -3625,7 +3774,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request DELETE:/bucket/{bucket}/access-rules
      * @secure
      */
-    deleteAccessRuleWithBucket: (bucket: string, prefix: PrefixWrapper, params: RequestParams = {}) =>
+    deleteAccessRuleWithBucket: (
+      bucket: string,
+      prefix: PrefixWrapper,
+      params: RequestParams = {},
+    ) =>
       this.request<boolean, ApiError>({
         path: `/bucket/${bucket}/access-rules`,
         method: "DELETE",
@@ -3768,7 +3921,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/configs/{name}
      * @secure
      */
-    setConfig: (name: string, body: SetConfigRequest, params: RequestParams = {}) =>
+    setConfig: (
+      name: string,
+      body: SetConfigRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<SetConfigResponse, ApiError>({
         path: `/configs/${name}`,
         method: "PUT",
@@ -3870,7 +4027,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/set-policy-multi
      * @secure
      */
-    setPolicyMultiple: (body: SetPolicyMultipleNameRequest, params: RequestParams = {}) =>
+    setPolicyMultiple: (
+      body: SetPolicyMultipleNameRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/set-policy-multi`,
         method: "PUT",
@@ -4155,7 +4315,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/admin/notification_endpoints
      * @secure
      */
-    addNotificationEndpoint: (body: NotificationEndpoint, params: RequestParams = {}) =>
+    addNotificationEndpoint: (
+      body: NotificationEndpoint,
+      params: RequestParams = {},
+    ) =>
       this.request<SetNotificationEndpointResponse, ApiError>({
         path: `/admin/notification_endpoints`,
         method: "POST",
@@ -4193,7 +4356,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/admin/site-replication
      * @secure
      */
-    siteReplicationInfoAdd: (body: SiteReplicationAddRequest, params: RequestParams = {}) =>
+    siteReplicationInfoAdd: (
+      body: SiteReplicationAddRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<SiteReplicationAddResponse, ApiError>({
         path: `/admin/site-replication`,
         method: "POST",
@@ -4337,7 +4503,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/admin/tiers/{type}/{name}
      * @secure
      */
-    getTier: (type: "s3" | "gcs" | "azure" | "minio", name: string, params: RequestParams = {}) =>
+    getTier: (
+      type: "s3" | "gcs" | "azure" | "minio",
+      name: string,
+      params: RequestParams = {},
+    ) =>
       this.request<Tier, ApiError>({
         path: `/admin/tiers/${type}/${name}`,
         method: "GET",
@@ -4479,7 +4649,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request DELETE:/remote-buckets/{source-bucket-name}/{arn}
      * @secure
      */
-    deleteRemoteBucket: (sourceBucketName: string, arn: string, params: RequestParams = {}) =>
+    deleteRemoteBucket: (
+      sourceBucketName: string,
+      arn: string,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/remote-buckets/${sourceBucketName}/${arn}`,
         method: "DELETE",
@@ -4688,7 +4862,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/kms/keys/{name}/import
      * @secure
      */
-    kmsImportKey: (name: string, body: KmsImportKeyRequest, params: RequestParams = {}) =>
+    kmsImportKey: (
+      name: string,
+      body: KmsImportKeyRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/kms/keys/${name}/import`,
         method: "POST",
@@ -4786,7 +4964,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/kms/policies/{name}/assign
      * @secure
      */
-    kmsAssignPolicy: (name: string, body: KmsAssignPolicyRequest, params: RequestParams = {}) =>
+    kmsAssignPolicy: (
+      name: string,
+      body: KmsAssignPolicyRequest,
+      params: RequestParams = {},
+    ) =>
       this.request<void, ApiError>({
         path: `/kms/policies/${name}/assign`,
         method: "POST",
@@ -4902,7 +5084,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/idp/{type}
      * @secure
      */
-    createConfiguration: (type: string, body: IdpServerConfiguration, params: RequestParams = {}) =>
+    createConfiguration: (
+      type: string,
+      body: IdpServerConfiguration,
+      params: RequestParams = {},
+    ) =>
       this.request<SetIDPResponse, ApiError>({
         path: `/idp/${type}`,
         method: "POST",
@@ -4940,7 +5126,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/idp/{type}/{name}
      * @secure
      */
-    getConfiguration: (name: string, type: string, params: RequestParams = {}) =>
+    getConfiguration: (
+      name: string,
+      type: string,
+      params: RequestParams = {},
+    ) =>
       this.request<IdpServerConfiguration, ApiError>({
         path: `/idp/${type}/${name}`,
         method: "GET",
@@ -4958,7 +5148,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request DELETE:/idp/{type}/{name}
      * @secure
      */
-    deleteConfiguration: (name: string, type: string, params: RequestParams = {}) =>
+    deleteConfiguration: (
+      name: string,
+      type: string,
+      params: RequestParams = {},
+    ) =>
       this.request<SetIDPResponse, ApiError>({
         path: `/idp/${type}/${name}`,
         method: "DELETE",
@@ -4976,7 +5170,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request PUT:/idp/{type}/{name}
      * @secure
      */
-    updateConfiguration: (name: string, type: string, body: IdpServerConfiguration, params: RequestParams = {}) =>
+    updateConfiguration: (
+      name: string,
+      type: string,
+      body: IdpServerConfiguration,
+      params: RequestParams = {},
+    ) =>
       this.request<SetIDPResponse, ApiError>({
         path: `/idp/${type}/${name}`,
         method: "PUT",

--- a/web-app/src/screens/Console/Buckets/BucketDetails/AddLifecycleModal.tsx
+++ b/web-app/src/screens/Console/Buckets/BucketDetails/AddLifecycleModal.tsx
@@ -73,6 +73,7 @@ const AddLifecycleModal = ({
   const [lifecycleDays, setLifecycleDays] = useState<string>("");
   const [isFormValid, setIsFormValid] = useState<boolean>(false);
   const [expiredObjectDM, setExpiredObjectDM] = useState<boolean>(false);
+  const [expiredAllVersionsDM, setExpiredAllVersionsDM] = useState<boolean>(false);
   const [loadingVersioning, setLoadingVersioning] = useState<boolean>(true);
   const [expandedAdv, setExpandedAdv] = useState<boolean>(false);
   const [expanded, setExpanded] = useState<boolean>(false);
@@ -183,6 +184,7 @@ const AddLifecycleModal = ({
       prefix,
       tags,
       expired_object_delete_marker: expiredObjectDM,
+      expired_object_delete_all: expiredAllVersionsDM,
       ...rules,
     };
 
@@ -435,6 +437,21 @@ const AddLifecycleModal = ({
                       label={"Expire Delete Marker"}
                       description={
                         "Remove the reference to the object if no versions are left"
+                      }
+                    />
+                    <Switch
+                      value="expired_delete_all"
+                      id="expired_delete_all"
+                      name="expired_delete_all"
+                      checked={expiredAllVersionsDM}
+                      onChange={(
+                        event: React.ChangeEvent<HTMLInputElement>,
+                      ) => {
+                        setExpiredAllVersionsDM(event.target.checked);
+                      }}
+                      label={"Expire All Versions"}
+                      description={
+                        "Removes all the versions of the object already expired"
                       }
                     />
                   </Grid>

--- a/web-app/src/screens/Console/Buckets/BucketDetails/AddLifecycleModal.tsx
+++ b/web-app/src/screens/Console/Buckets/BucketDetails/AddLifecycleModal.tsx
@@ -73,7 +73,8 @@ const AddLifecycleModal = ({
   const [lifecycleDays, setLifecycleDays] = useState<string>("");
   const [isFormValid, setIsFormValid] = useState<boolean>(false);
   const [expiredObjectDM, setExpiredObjectDM] = useState<boolean>(false);
-  const [expiredAllVersionsDM, setExpiredAllVersionsDM] = useState<boolean>(false);
+  const [expiredAllVersionsDM, setExpiredAllVersionsDM] =
+    useState<boolean>(false);
   const [loadingVersioning, setLoadingVersioning] = useState<boolean>(true);
   const [expandedAdv, setExpandedAdv] = useState<boolean>(false);
   const [expanded, setExpanded] = useState<boolean>(false);

--- a/web-app/src/screens/Console/Buckets/BucketDetails/EditLifecycleConfiguration.tsx
+++ b/web-app/src/screens/Console/Buckets/BucketDetails/EditLifecycleConfiguration.tsx
@@ -62,7 +62,8 @@ const EditLifecycleConfiguration = ({
   const [storageClass, setStorageClass] = useState("");
   const [NCTransitionSC, setNCTransitionSC] = useState("");
   const [expiredObjectDM, setExpiredObjectDM] = useState<boolean>(false);
-  const [expiredAllVersionsDM, setExpiredAllVersionsDM] = useState<boolean>(false);
+  const [expiredAllVersionsDM, setExpiredAllVersionsDM] =
+    useState<boolean>(false);
   const [NCExpirationDays, setNCExpirationDays] = useState<string>("0");
   const [NCTransitionDays, setNCTransitionDays] = useState<string>("0");
   const [ilmType, setIlmType] = useState<"transition" | "expiry">("expiry");
@@ -506,7 +507,9 @@ const EditLifecycleConfiguration = ({
                       id="expired_delete_all"
                       name="expired_delete_all"
                       checked={expiredAllVersionsDM}
-                      onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                      onChange={(
+                        event: React.ChangeEvent<HTMLInputElement>,
+                      ) => {
                         setExpiredAllVersionsDM(event.target.checked);
                       }}
                       label={"Expired All Versions"}

--- a/web-app/src/screens/Console/Buckets/BucketDetails/EditLifecycleConfiguration.tsx
+++ b/web-app/src/screens/Console/Buckets/BucketDetails/EditLifecycleConfiguration.tsx
@@ -62,6 +62,7 @@ const EditLifecycleConfiguration = ({
   const [storageClass, setStorageClass] = useState("");
   const [NCTransitionSC, setNCTransitionSC] = useState("");
   const [expiredObjectDM, setExpiredObjectDM] = useState<boolean>(false);
+  const [expiredAllVersionsDM, setExpiredAllVersionsDM] = useState<boolean>(false);
   const [NCExpirationDays, setNCExpirationDays] = useState<string>("0");
   const [NCTransitionDays, setNCTransitionDays] = useState<string>("0");
   const [ilmType, setIlmType] = useState<"transition" | "expiry">("expiry");
@@ -199,6 +200,7 @@ const EditLifecycleConfiguration = ({
     }
 
     setExpiredObjectDM(!!lifecycleRule.expiration?.delete_marker);
+    setExpiredAllVersionsDM(!!lifecycleRule.expiration?.delete_all);
     setPrefix(lifecycleRule.prefix || "");
 
     if (lifecycleRule.tags) {
@@ -270,6 +272,7 @@ const EditLifecycleConfiguration = ({
         prefix,
         tags,
         expired_object_delete_marker: expiredObjectDM,
+        expired_object_delete_all: expiredAllVersionsDM,
         ...rules,
       };
 
@@ -497,6 +500,16 @@ const EditLifecycleConfiguration = ({
                         setExpiredObjectDM(event.target.checked);
                       }}
                       label={"Expired Object Delete Marker"}
+                    />
+                    <Switch
+                      value="expired_delete_all"
+                      id="expired_delete_all"
+                      name="expired_delete_all"
+                      checked={expiredAllVersionsDM}
+                      onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                        setExpiredAllVersionsDM(event.target.checked);
+                      }}
+                      label={"Expired All Versions"}
                     />
                   </Accordion>
                 </Grid>

--- a/web-app/src/screens/Console/Buckets/ListBuckets/BulkLifecycleModal.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/BulkLifecycleModal.tsx
@@ -59,7 +59,8 @@ const AddBulkReplicationModal = ({
   const [storageClass, setStorageClass] = useState("");
   const [NCTransitionSC, setNCTransitionSC] = useState("");
   const [expiredObjectDM, setExpiredObjectDM] = useState<boolean>(false);
-  const [expiredAllVersionsDM, setExpiredAllVersionsDM] = useState<boolean>(false);
+  const [expiredAllVersionsDM, setExpiredAllVersionsDM] =
+    useState<boolean>(false);
   const [NCExpirationDays, setNCExpirationDays] = useState<string>("0");
   const [NCTransitionDays, setNCTransitionDays] = useState<string>("0");
   const [ilmType, setIlmType] = useState<"expiry" | "transition">("expiry");

--- a/web-app/src/screens/Console/Buckets/ListBuckets/BulkLifecycleModal.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/BulkLifecycleModal.tsx
@@ -59,6 +59,7 @@ const AddBulkReplicationModal = ({
   const [storageClass, setStorageClass] = useState("");
   const [NCTransitionSC, setNCTransitionSC] = useState("");
   const [expiredObjectDM, setExpiredObjectDM] = useState<boolean>(false);
+  const [expiredAllVersionsDM, setExpiredAllVersionsDM] = useState<boolean>(false);
   const [NCExpirationDays, setNCExpirationDays] = useState<string>("0");
   const [NCTransitionDays, setNCTransitionDays] = useState<string>("0");
   const [ilmType, setIlmType] = useState<"expiry" | "transition">("expiry");
@@ -172,6 +173,7 @@ const AddBulkReplicationModal = ({
       prefix,
       tags,
       expired_object_delete_marker: expiredObjectDM,
+      expired_object_delete_all: expiredAllVersionsDM,
       ...rules,
     };
 
@@ -343,6 +345,18 @@ const AddBulkReplicationModal = ({
                         setExpiredObjectDM(event.target.checked);
                       }}
                       label={"Expired Object Delete Marker"}
+                    />
+                    <Switch
+                      value="expired_delete_all"
+                      id="expired_delete_all"
+                      name="expired_delete_all"
+                      checked={expiredAllVersionsDM}
+                      onChange={(
+                        event: React.ChangeEvent<HTMLInputElement>,
+                      ) => {
+                        setExpiredAllVersionsDM(event.target.checked);
+                      }}
+                      label={"Expired All Versions"}
                     />
                   </fieldset>
                 </FormLayout>

--- a/web-app/src/screens/Console/Buckets/types.tsx
+++ b/web-app/src/screens/Console/Buckets/types.tsx
@@ -41,6 +41,7 @@ interface IExpirationLifecycle {
   days: number;
   date: string;
   delete_marker?: boolean;
+  delete_all?: boolean;
   noncurrent_expiration_days?: number;
   newer_noncurrent_expiration_versions?: number;
 }


### PR DESCRIPTION
This PR enables console to set bucket ILM rule for deleting all versions of expired object.

Steps to test:
Create a bucket and enable versioning for the same.
Try to create ILM rule and select option for delete all versions.
Make sure listing of rules works fine.