### PR TITLE
Fixed disabled Create User button if policy has no resource

### DIFF
--- a/web-app/src/screens/Console/Users/ListUsers.tsx
+++ b/web-app/src/screens/Console/Users/ListUsers.tsx
@@ -279,7 +279,7 @@ const ListUsers = () => {
               <TooltipWrapper
                 tooltip={
                   hasPermission(
-                    "console",
+                    "console-ui",
                     [
                       IAM_SCOPES.ADMIN_CREATE_USER,
                       IAM_SCOPES.ADMIN_LIST_USER_POLICIES,
@@ -310,7 +310,7 @@ const ListUsers = () => {
                   variant={"callAction"}
                   disabled={
                     !hasPermission(
-                      "console",
+                      "console-ui",
                       [
                         IAM_SCOPES.ADMIN_CREATE_USER,
                         IAM_SCOPES.ADMIN_LIST_USER_POLICIES,


### PR DESCRIPTION
To test:
- Create the following Policy and apply it to a Console User:  
```{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "admin:ListUserPolicies",
                "admin:ListUsers",
                "admin:AttachUserOrGroupPolicy",
                "admin:CreateUser",
                "admin:ListGroups"
            ]
        }
    ]
}
```
- Log into Console as User with the above policy and go to List Users screen, Create User button is enabled


fixes https://github.com/minio/console/issues/3228