### PR TITLE
no preview message ui

### DIFF
--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
@@ -194,7 +194,6 @@ const PreviewFile = ({
           {objectType === "none" && (
             <div>
               <InformativeMessage
-                variant={"error"}
                 message=" File couldn't be previewed using file extension or mime type. Please
             try Download instead"
                 title="Preview unavailable"


### PR DESCRIPTION
Use default information ui when no preview available.

 
How does it look
### Dark mode:
![DM_NO_preview](https://github.com/minio/console/assets/23444145/f7d87e10-edf5-4d1b-9313-87a360f94c47)

### Default 
![def_No_Preview](https://github.com/minio/console/assets/23444145/3222df5a-b845-41e8-b81f-31aadc5da696)
