### PR TITLE
Fix URL of inspect object API

### DIFF
--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/InspectObject.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/InspectObject.tsx
@@ -67,7 +67,7 @@ const InspectObject = ({
     const volume = encodeURLString(volumeName);
 
     let basename = document.baseURI.replace(window.location.origin, "");
-    const urlOfInspectApi = `${basename}/api/v1/admin/inspect?volume=${volume}&file=${file}&encrypt=${isEncrypt}`;
+    const urlOfInspectApi = `${window.location.origin}${basename}/api/v1/admin/inspect?volume=${volume}&file=${file}&encrypt=${isEncrypt}`;
 
     makeRequest(urlOfInspectApi)
       .then(async (res) => {

--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/InspectObject.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/InspectObject.tsx
@@ -66,10 +66,8 @@ const InspectObject = ({
     const file = encodeURLString(inspectPath + "/xl.meta");
     const volume = encodeURLString(volumeName);
 
-    const urlOfInspectApi = new URL(
-      `/api/v1/admin/inspect?volume=${volume}&file=${file}&encrypt=${isEncrypt}`,
-      document.baseURI,
-    ).href;
+    let basename = document.baseURI.replace(window.location.origin, "");
+    const urlOfInspectApi = `${window.location.origin}${basename}/api/v1/admin/inspect?volume=${volume}&file=${file}&encrypt=${isEncrypt}`;
 
     makeRequest(urlOfInspectApi)
       .then(async (res) => {

--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/InspectObject.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/InspectObject.tsx
@@ -66,8 +66,10 @@ const InspectObject = ({
     const file = encodeURLString(inspectPath + "/xl.meta");
     const volume = encodeURLString(volumeName);
 
-    let basename = document.baseURI.replace(window.location.origin, "");
-    const urlOfInspectApi = `${window.location.origin}${basename}/api/v1/admin/inspect?volume=${volume}&file=${file}&encrypt=${isEncrypt}`;
+    const urlOfInspectApi = new URL(
+      `/api/v1/admin/inspect?volume=${volume}&file=${file}&encrypt=${isEncrypt}`,
+      document.baseURI,
+    ).href;
 
     makeRequest(urlOfInspectApi)
       .then(async (res) => {


### PR DESCRIPTION
This PR adds the missing `window.location.origin` to the URL generated for the inspect object API