### PR TITLE
Use native WebSocket API

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -28,8 +28,7 @@
     "recharts": "^2.10.3",
     "styled-components": "^5.3.11",
     "superagent": "^8.0.8",
-    "tinycolor2": "^1.6.0",
-    "websocket": "^1.0.31"
+    "tinycolor2": "^1.6.0"
   },
   "scripts": {
     "start": "PORT=5005 react-scripts start",
@@ -76,7 +75,6 @@
     "@types/recharts": "^1.8.29",
     "@types/superagent": "^4.1.24",
     "@types/webpack-env": "^1.18.2",
-    "@types/websocket": "^1.0.10",
     "babel-plugin-istanbul": "^6.1.1",
     "customize-cra": "^1.0.0",
     "minio": "^7.1.3",
@@ -103,7 +101,6 @@
     "react-scripts/**/json5": "^2.2.2",
     "react-scripts/**/debug": "^3.1.0",
     "recharts/**/d3-color": "^3.1.0",
-    "websocket/debug": "^3.1.0",
     "fast-xml-parser": "^4.3.4",
     "semver": "^7.5.2",
     "testcafe/**/tough-cookie": "^4.1.3",

--- a/web-app/src/screens/Console/HealthInfo/HealthInfo.tsx
+++ b/web-app/src/screens/Console/HealthInfo/HealthInfo.tsx
@@ -134,23 +134,23 @@ const HealthInfo = () => {
       const baseLocation = new URL(document.baseURI);
       const baseUrl = baseLocation.pathname;
 
-      const c = new WebSocket(
+      const socket = new WebSocket(
         `${wsProt}://${url.hostname}:${port}${baseUrl}ws/health-info?deadline=1h`,
       );
       let interval: any | null = null;
-      if (c !== null) {
-        c.onopen = () => {
+      if (socket !== null) {
+        socket.onopen = () => {
           console.log("WebSocket Client Connected");
-          c.send("ok");
+          socket.send("ok");
           interval = setInterval(() => {
-            c.send("ok");
+            socket.send("ok");
           }, 10 * 1000);
           setMessage(
             "Health Report started. Please do not refresh page during diagnosis.",
           );
           dispatch(setServerDiagStat(DiagStatInProgress));
         };
-        c.onmessage = (message: MessageEvent) => {
+        socket.onmessage = (message: MessageEvent) => {
           let m: ReportMessage = JSON.parse(message.data.toString());
           if (m.serverHealthInfo) {
             dispatch(healthInfoMessageReceived(m.serverHealthInfo));
@@ -162,13 +162,13 @@ const HealthInfo = () => {
             setSubnetResponse(m.subnetResponse);
           }
         };
-        c.onerror = (error) => {
+        socket.onerror = (error) => {
           console.error("error closing websocket:", error);
-          c.close(1000);
+          socket.close(1000);
           clearInterval(interval);
           dispatch(setServerDiagStat(DiagStatError));
         };
-        c.onclose = (event: CloseEvent) => {
+        socket.onclose = (event: CloseEvent) => {
           clearInterval(interval);
           if (
             event.code === WSCloseInternalServerErr ||

--- a/web-app/src/screens/Console/HealthInfo/HealthInfo.tsx
+++ b/web-app/src/screens/Console/HealthInfo/HealthInfo.tsx
@@ -14,11 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import React, { Fragment, useEffect, useState } from "react";
-import {
-  ICloseEvent,
-  IMessageEvent,
-  w3cwebsocket as W3CWebSocket,
-} from "websocket";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { Box, Button, Grid, HelpBox, InfoIcon, Loader, PageLayout } from "mds";
@@ -139,7 +134,7 @@ const HealthInfo = () => {
       const baseLocation = new URL(document.baseURI);
       const baseUrl = baseLocation.pathname;
 
-      const c = new W3CWebSocket(
+      const c = new WebSocket(
         `${wsProt}://${url.hostname}:${port}${baseUrl}ws/health-info?deadline=1h`,
       );
       let interval: any | null = null;
@@ -155,12 +150,9 @@ const HealthInfo = () => {
           );
           dispatch(setServerDiagStat(DiagStatInProgress));
         };
-        c.onmessage = (message: IMessageEvent) => {
+        c.onmessage = (message: MessageEvent) => {
           let m: ReportMessage = JSON.parse(message.data.toString());
           if (m.serverHealthInfo) {
-            m.serverHealthInfo.timestamp = new Date(
-              m.serverHealthInfo.timestamp.toString(),
-            );
             dispatch(healthInfoMessageReceived(m.serverHealthInfo));
           }
           if (m.encoded !== "") {
@@ -170,13 +162,13 @@ const HealthInfo = () => {
             setSubnetResponse(m.subnetResponse);
           }
         };
-        c.onerror = (error: Error) => {
-          console.log("error closing websocket:", error.message);
+        c.onerror = (error) => {
+          console.error("error closing websocket:", error);
           c.close(1000);
           clearInterval(interval);
           dispatch(setServerDiagStat(DiagStatError));
         };
-        c.onclose = (event: ICloseEvent) => {
+        c.onclose = (event: CloseEvent) => {
           clearInterval(interval);
           if (
             event.code === WSCloseInternalServerErr ||

--- a/web-app/src/screens/Console/HealthInfo/types.ts
+++ b/web-app/src/screens/Console/HealthInfo/types.ts
@@ -19,7 +19,7 @@ export const DiagStatSuccess = "success";
 export const DiagStatInProgress = "inProgress";
 
 export interface HealthInfoMessage {
-  timestamp: Date;
+  timestamp: string;
   error: string;
   perf: perfInfo;
   minio: minioHealthInfo;

--- a/web-app/src/screens/Console/Logs/ErrorLogs/ErrorLogs.tsx
+++ b/web-app/src/screens/Console/Logs/ErrorLogs/ErrorLogs.tsx
@@ -32,7 +32,7 @@ import LogLine from "./LogLine";
 import PageHeaderWrapper from "../../Common/PageHeaderWrapper/PageHeaderWrapper";
 import HelpMenu from "../../HelpMenu";
 
-var c: any = null;
+var socket: any = null;
 
 const ErrorLogs = () => {
   const dispatch = useAppDispatch();
@@ -60,7 +60,7 @@ const ErrorLogs = () => {
     const baseLocation = new URL(document.baseURI);
     const baseUrl = baseLocation.pathname;
 
-    c = new WebSocket(
+    socket = new WebSocket(
       `${wsProt}://${
         url.hostname
       }:${port}${baseUrl}ws/console/?logType=${logType}&node=${
@@ -68,16 +68,16 @@ const ErrorLogs = () => {
       }`,
     );
     let interval: any | null = null;
-    if (c !== null) {
-      c.onopen = () => {
+    if (socket !== null) {
+      socket.onopen = () => {
         console.log("WebSocket Client Connected");
         dispatch(setLogsStarted(true));
-        c.send("ok");
+        socket.send("ok");
         interval = setInterval(() => {
-          c.send("ok");
+          socket.send("ok");
         }, 10 * 1000);
       };
-      c.onmessage = (message: MessageEvent) => {
+      socket.onmessage = (message: MessageEvent) => {
         // console.log(message.data.toString())
         // FORMAT: 00:35:17 UTC 01/01/2021
 
@@ -103,13 +103,13 @@ const ErrorLogs = () => {
           dispatch(logMessageReceived(m));
         }
       };
-      c.onclose = () => {
+      socket.onclose = () => {
         clearInterval(interval);
         console.log("connection closed by server");
         dispatch(setLogsStarted(false));
       };
       return () => {
-        c.close(1000);
+        socket.close(1000);
         clearInterval(interval);
         console.log("closing websockets");
         dispatch(setLogsStarted(false));
@@ -118,8 +118,8 @@ const ErrorLogs = () => {
   };
 
   const stopLogs = () => {
-    if (c !== null && c !== undefined) {
-      c.close(1000);
+    if (socket !== null && socket !== undefined) {
+      socket.close(1000);
       dispatch(setLogsStarted(false));
     }
   };

--- a/web-app/src/screens/Console/Logs/ErrorLogs/ErrorLogs.tsx
+++ b/web-app/src/screens/Console/Logs/ErrorLogs/ErrorLogs.tsx
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Fragment, useEffect, useState } from "react";
-import { IMessageEvent, w3cwebsocket as W3CWebSocket } from "websocket";
 import { Box, Button, Grid, PageLayout, Select, Table, TableBody } from "mds";
 import { useSelector } from "react-redux";
 import { ErrorResponseHandler } from "../../../../common/types";
@@ -61,7 +60,7 @@ const ErrorLogs = () => {
     const baseLocation = new URL(document.baseURI);
     const baseUrl = baseLocation.pathname;
 
-    c = new W3CWebSocket(
+    c = new WebSocket(
       `${wsProt}://${
         url.hostname
       }:${port}${baseUrl}ws/console/?logType=${logType}&node=${
@@ -78,7 +77,7 @@ const ErrorLogs = () => {
           c.send("ok");
         }, 10 * 1000);
       };
-      c.onmessage = (message: IMessageEvent) => {
+      c.onmessage = (message: MessageEvent) => {
         // console.log(message.data.toString())
         // FORMAT: 00:35:17 UTC 01/01/2021
 

--- a/web-app/src/screens/Console/Speedtest/Speedtest.tsx
+++ b/web-app/src/screens/Console/Speedtest/Speedtest.tsx
@@ -16,7 +16,6 @@
 
 import React, { Fragment, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
-import { IMessageEvent, w3cwebsocket as W3CWebSocket } from "websocket";
 import { useNavigate } from "react-router-dom";
 import {
   Box,
@@ -77,7 +76,7 @@ const Speedtest = () => {
       const baseUrl = baseLocation.pathname;
 
       const wsProt = wsProtocol(url.protocol);
-      const c = new W3CWebSocket(
+      const c = new WebSocket(
         `${wsProt}://${url.hostname}:${port}${baseUrl}ws/speedtest?&size=${size}${sizeUnit}&duration=${duration}s`,
       );
 
@@ -103,7 +102,7 @@ const Speedtest = () => {
             c.send("ok");
           }, 10 * 1000);
         };
-        c.onmessage = (message: IMessageEvent) => {
+        c.onmessage = (message: MessageEvent) => {
           const data: SpeedTestResponse = JSON.parse(message.data.toString());
 
           setCurrStatus((prevStatus) => {

--- a/web-app/src/screens/Console/Speedtest/Speedtest.tsx
+++ b/web-app/src/screens/Console/Speedtest/Speedtest.tsx
@@ -76,7 +76,7 @@ const Speedtest = () => {
       const baseUrl = baseLocation.pathname;
 
       const wsProt = wsProtocol(url.protocol);
-      const c = new WebSocket(
+      const socket = new WebSocket(
         `${wsProt}://${url.hostname}:${port}${baseUrl}ws/speedtest?&size=${size}${sizeUnit}&duration=${duration}s`,
       );
 
@@ -94,15 +94,15 @@ const Speedtest = () => {
       setTotalSeconds(totalSeconds);
 
       let interval: any | null = null;
-      if (c !== null) {
-        c.onopen = () => {
+      if (socket !== null) {
+        socket.onopen = () => {
           console.log("WebSocket Client Connected");
-          c.send("ok");
+          socket.send("ok");
           interval = setInterval(() => {
-            c.send("ok");
+            socket.send("ok");
           }, 10 * 1000);
         };
-        c.onmessage = (message: MessageEvent) => {
+        socket.onmessage = (message: MessageEvent) => {
           const data: SpeedTestResponse = JSON.parse(message.data.toString());
 
           setCurrStatus((prevStatus) => {
@@ -118,7 +118,7 @@ const Speedtest = () => {
           const currTime = DateTime.now().toUnixInteger() / 1000;
           setCurrentValue(currTime);
         };
-        c.onclose = () => {
+        socket.onclose = () => {
           clearInterval(interval);
           console.log("connection closed by server");
           // reset start status
@@ -126,7 +126,7 @@ const Speedtest = () => {
         };
         return () => {
           // close websocket on useEffect cleanup
-          c.close(1000);
+          socket.close(1000);
           clearInterval(interval);
           console.log("closing websockets");
         };

--- a/web-app/src/screens/Console/Support/Profile.tsx
+++ b/web-app/src/screens/Console/Support/Profile.tsx
@@ -25,7 +25,7 @@ import RegisterCluster from "./RegisterCluster";
 import PageHeaderWrapper from "../Common/PageHeaderWrapper/PageHeaderWrapper";
 import HelpMenu from "../HelpMenu";
 
-var c: any = null;
+var socket: any = null;
 
 const Profile = () => {
   const navigate = useNavigate();
@@ -69,16 +69,16 @@ const Profile = () => {
     const baseUrl = baseLocation.pathname;
 
     const wsProt = wsProtocol(url.protocol);
-    c = new WebSocket(
+    socket = new WebSocket(
       `${wsProt}://${url.hostname}:${port}${baseUrl}ws/profile?types=${typeString}`,
     );
 
-    if (c !== null) {
-      c.onopen = () => {
+    if (socket !== null) {
+      socket.onopen = () => {
         setProfilingStarted(true);
-        c.send("ok");
+        socket.send("ok");
       };
-      c.onmessage = (message: MessageEvent) => {
+      socket.onmessage = (message: MessageEvent) => {
         // process received message
         let response = new Blob([message.data], { type: "application/zip" });
         let filename = "profile.zip";
@@ -90,12 +90,12 @@ const Profile = () => {
         link.click();
         document.body.removeChild(link);
       };
-      c.onclose = () => {
+      socket.onclose = () => {
         console.log("connection closed by server");
         setProfilingStarted(false);
       };
       return () => {
-        c.close(1000);
+        socket.close(1000);
         console.log("closing websockets");
         setProfilingStarted(false);
       };
@@ -103,7 +103,7 @@ const Profile = () => {
   };
 
   const stopProfiling = () => {
-    c.close(1000);
+    socket.close(1000);
     setProfilingStarted(false);
   };
 

--- a/web-app/src/screens/Console/Support/Profile.tsx
+++ b/web-app/src/screens/Console/Support/Profile.tsx
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Fragment, useEffect, useState } from "react";
-import { IMessageEvent, w3cwebsocket as W3CWebSocket } from "websocket";
 import { Button, PageLayout, FormLayout, Box, Checkbox, InputLabel } from "mds";
 import { wsProtocol } from "../../../utils/wsUtils";
 import { useNavigate } from "react-router-dom";
@@ -70,7 +69,7 @@ const Profile = () => {
     const baseUrl = baseLocation.pathname;
 
     const wsProt = wsProtocol(url.protocol);
-    c = new W3CWebSocket(
+    c = new WebSocket(
       `${wsProt}://${url.hostname}:${port}${baseUrl}ws/profile?types=${typeString}`,
     );
 
@@ -79,7 +78,7 @@ const Profile = () => {
         setProfilingStarted(true);
         c.send("ok");
       };
-      c.onmessage = (message: IMessageEvent) => {
+      c.onmessage = (message: MessageEvent) => {
         // process received message
         let response = new Blob([message.data], { type: "application/zip" });
         let filename = "profile.zip";

--- a/web-app/src/screens/Console/Trace/Trace.tsx
+++ b/web-app/src/screens/Console/Trace/Trace.tsx
@@ -17,7 +17,6 @@
 import React, { Fragment, useEffect, useState } from "react";
 import { DateTime } from "luxon";
 import { useSelector } from "react-redux";
-import { IMessageEvent, w3cwebsocket as W3CWebSocket } from "websocket";
 import {
   Box,
   breakPoints,
@@ -85,7 +84,7 @@ const Trace = () => {
     const baseUrl = baseLocation.pathname;
 
     const wsProt = wsProtocol(url.protocol);
-    c = new W3CWebSocket(
+    c = new WebSocket(
       `${wsProt}://${
         url.hostname
       }:${port}${baseUrl}ws/trace?calls=${calls}&threshold=${threshold}&onlyErrors=${
@@ -103,7 +102,7 @@ const Trace = () => {
           c.send("ok");
         }, 10 * 1000);
       };
-      c.onmessage = (message: IMessageEvent) => {
+      c.onmessage = (message: MessageEvent) => {
         let m: TraceMessage = JSON.parse(message.data.toString());
 
         m.ptime = DateTime.fromISO(m.time).toJSDate();

--- a/web-app/src/screens/Console/Trace/Trace.tsx
+++ b/web-app/src/screens/Console/Trace/Trace.tsx
@@ -42,7 +42,7 @@ import TooltipWrapper from "../Common/TooltipWrapper/TooltipWrapper";
 import PageHeaderWrapper from "../Common/PageHeaderWrapper/PageHeaderWrapper";
 import HelpMenu from "../HelpMenu";
 
-var c: any = null;
+var socket: any = null;
 
 const Trace = () => {
   const dispatch = useAppDispatch();
@@ -84,7 +84,7 @@ const Trace = () => {
     const baseUrl = baseLocation.pathname;
 
     const wsProt = wsProtocol(url.protocol);
-    c = new WebSocket(
+    socket = new WebSocket(
       `${wsProt}://${
         url.hostname
       }:${port}${baseUrl}ws/trace?calls=${calls}&threshold=${threshold}&onlyErrors=${
@@ -93,29 +93,29 @@ const Trace = () => {
     );
 
     let interval: any | null = null;
-    if (c !== null) {
-      c.onopen = () => {
+    if (socket !== null) {
+      socket.onopen = () => {
         console.log("WebSocket Client Connected");
         dispatch(setTraceStarted(true));
-        c.send("ok");
+        socket.send("ok");
         interval = setInterval(() => {
-          c.send("ok");
+          socket.send("ok");
         }, 10 * 1000);
       };
-      c.onmessage = (message: MessageEvent) => {
+      socket.onmessage = (message: MessageEvent) => {
         let m: TraceMessage = JSON.parse(message.data.toString());
 
         m.ptime = DateTime.fromISO(m.time).toJSDate();
         m.key = Math.random();
         dispatch(traceMessageReceived(m));
       };
-      c.onclose = () => {
+      socket.onclose = () => {
         clearInterval(interval);
         console.log("connection closed by server");
         dispatch(setTraceStarted(false));
       };
       return () => {
-        c.close(1000);
+        socket.close(1000);
         clearInterval(interval);
         console.log("closing websockets");
         setTraceStarted(false);
@@ -124,7 +124,7 @@ const Trace = () => {
   };
 
   const stopTrace = () => {
-    c.close(1000);
+    socket.close(1000);
     dispatch(setTraceStarted(false));
   };
 

--- a/web-app/src/screens/Console/Watch/Watch.tsx
+++ b/web-app/src/screens/Console/Watch/Watch.tsx
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { useEffect, useState, Fragment } from "react";
-import { IMessageEvent, w3cwebsocket as W3CWebSocket } from "websocket";
 import { useSelector } from "react-redux";
 import {
   Box,
@@ -79,7 +78,7 @@ const Watch = () => {
       const baseUrl = baseLocation.pathname;
 
       const wsProt = wsProtocol(url.protocol);
-      const c = new W3CWebSocket(
+      const c = new WebSocket(
         `${wsProt}://${url.hostname}:${port}${baseUrl}ws/watch/${bucketName}?prefix=${prefix}&suffix=${suffix}`,
       );
 
@@ -92,7 +91,7 @@ const Watch = () => {
             c.send("ok");
           }, 10 * 1000);
         };
-        c.onmessage = (message: IMessageEvent) => {
+        c.onmessage = (message: MessageEvent) => {
           let m: EventInfo = JSON.parse(message.data.toString());
           m.Time = new Date(m.Time.toString());
           m.key = Math.random();

--- a/web-app/src/screens/Console/Watch/Watch.tsx
+++ b/web-app/src/screens/Console/Watch/Watch.tsx
@@ -78,26 +78,26 @@ const Watch = () => {
       const baseUrl = baseLocation.pathname;
 
       const wsProt = wsProtocol(url.protocol);
-      const c = new WebSocket(
+      const socket = new WebSocket(
         `${wsProt}://${url.hostname}:${port}${baseUrl}ws/watch/${bucketName}?prefix=${prefix}&suffix=${suffix}`,
       );
 
       let interval: any | null = null;
-      if (c !== null) {
-        c.onopen = () => {
+      if (socket !== null) {
+        socket.onopen = () => {
           console.log("WebSocket Client Connected");
-          c.send("ok");
+          socket.send("ok");
           interval = setInterval(() => {
-            c.send("ok");
+            socket.send("ok");
           }, 10 * 1000);
         };
-        c.onmessage = (message: MessageEvent) => {
+        socket.onmessage = (message: MessageEvent) => {
           let m: EventInfo = JSON.parse(message.data.toString());
           m.Time = new Date(m.Time.toString());
           m.key = Math.random();
           dispatch(watchMessageReceived(m));
         };
-        c.onclose = () => {
+        socket.onclose = () => {
           clearInterval(interval);
           console.log("connection closed by server");
           // reset start status
@@ -105,7 +105,7 @@ const Watch = () => {
         };
         return () => {
           // close websocket on useEffect cleanup
-          c.close(1000);
+          socket.close(1000);
           clearInterval(interval);
           console.log("closing websockets");
         };

--- a/web-app/yarn.lock
+++ b/web-app/yarn.lock
@@ -2571,13 +2571,6 @@
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.4.tgz#62879b0a9c653f9b1172d403b882f2045ecce032"
   integrity sha512-I6e+9+HtWADAWeeJWDFQtdk4EVSAbj6Rtz4q8fJ7mSr1M0jzlFcs8/HZ+Xb5SHzVm1dxH7aUiI+A8kA8Gcrm0A==
 
-"@types/websocket@^1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.10.tgz#804b1a02780da522f5742bc184a6d16a2eb78c7c"
-  integrity sha512-svjGZvPB7EzuYS94cI7a+qhwgGU1y89wUgjT6E2wVUfmAGIvRfT7obBvRtnhXCSsoMdlG4gBFGE7MfkIXZLoww==
-  dependencies:
-    "@types/node" "*"
-
 "@types/ws@^8.5.5":
   version "8.5.10"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.10.tgz#4acfb517970853fa6574a3a6886791d04a396787"
@@ -3626,13 +3619,6 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-bufferutil@^4.0.1:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.8.tgz#1de6a71092d65d7766c4d8a522b261a6e787e8ea"
-  integrity sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==
-  dependencies:
-    node-gyp-build "^4.3.0"
-
 builtin-modules@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
@@ -4512,14 +4498,6 @@ d3-timer@^3.0.1:
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
-
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
@@ -4534,7 +4512,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.6.0, debug@^3.1.0, debug@^3.2.7, debug@^4.3.2:
+debug@2.6.9, debug@^2.6.0, debug@^3.1.0, debug@^3.2.7, debug@^4.3.2:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -5153,36 +5131,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.50:
-  version "0.10.62"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.62.tgz#5e6adc19a6da524bf3d1e02bbc8960e5eb49a9a5"
-  integrity sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==
-  dependencies:
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.3"
-    next-tick "^1.1.0"
-
 es6-error@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
-
-es6-iterator@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-symbol@^3.1.1, es6-symbol@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
 
 escalade@^3.1.1:
   version "3.1.2"
@@ -5622,13 +5574,6 @@ express@^4.17.3:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
-
-ext@^1.1.2:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.7.0.tgz#0ea4383c0103d60e70be99e9a7f11027a33c4f5f"
-  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
-  dependencies:
-    type "^2.7.2"
 
 extend@^3.0.0:
   version "3.0.2"
@@ -8788,11 +8733,6 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next-tick@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
-  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
-
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
@@ -8812,11 +8752,6 @@ node-forge@^1, node-forge@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
-
-node-gyp-build@^4.3.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.0.tgz#3fee9c1731df4581a3f9ead74664369ff00d26dd"
-  integrity sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -12279,16 +12214,6 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.7.2.tgz#2376a15a3a28b1efa0f5350dcf72d24df6ef98d0"
-  integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
-
 typed-array-buffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.1.tgz#0608ffe6bca71bf15a45bff0ca2604107a1325f5"
@@ -12573,13 +12498,6 @@ use-sync-external-store@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
-
-utf-8-validate@^5.0.2:
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.10.tgz#d7d10ea39318171ca982718b6b96a8d2442571a2"
-  integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
-  dependencies:
-    node-gyp-build "^4.3.0"
 
 utf8-byte-length@^1.0.1:
   version "1.0.4"
@@ -12930,18 +12848,6 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
-
-websocket@^1.0.31:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
-  integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
-  dependencies:
-    bufferutil "^4.0.1"
-    debug "^2.2.0"
-    es5-ext "^0.10.50"
-    typedarray-to-buffer "^3.1.5"
-    utf-8-validate "^5.0.2"
-    yaeti "^0.0.6"
 
 whatwg-encoding@^1.0.5:
   version "1.0.5"
@@ -13341,11 +13247,6 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
-yaeti@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
-  integrity sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
This PR removes the external [websocket](https://www.npmjs.com/package/websocket) dependency and replaces it with the native WebSocket API provided by JavaScript.

It also renames `c` to `socket` according to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) for the WebSocket API and replaces HealthInfoMessage timestamp type from `Date` to `string`.