### PR TITLE
Check the blob size instead of the progress reports

### DIFF
--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
@@ -78,7 +78,6 @@ export const download = (
   toastCallback: () => void,
 ) => {
   let basename = document.baseURI.replace(window.location.origin, "");
-  let bytesLoaded = 0;
   const state = store.getState();
   const anonymousMode = state.system.anonymousMode;
 
@@ -107,7 +106,6 @@ export const download = (
     "progress",
     function (evt) {
       let percentComplete = Math.round((evt.loaded / fileSize) * 100);
-      bytesLoaded = evt.loaded;
       if (progressCallback) {
         progressCallback(percentComplete);
       }
@@ -118,7 +116,7 @@ export const download = (
   req.responseType = "blob";
   req.onreadystatechange = () => {
     if (req.readyState === XMLHttpRequest.DONE) {
-      let completeDownload = bytesLoaded === fileSize;
+      let completeDownload = req.response.size === fileSize;
 
       if (req.status === StatusCodes.OK && completeDownload) {
         const rspHeader = req.getResponseHeader("Content-Disposition");


### PR DESCRIPTION
Fixes #3243 

I just had the epiphany to just simply check the size of the blob which carries the downloaded content, since that has already been decompressed by the browser.