### PR TITLE
clean up text preview support which was removed earlier

### DIFF
--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
@@ -113,9 +113,6 @@ const PreviewFile = ({
               "&.image": {
                 height: 500,
               },
-              "&.text": {
-                height: 700,
-              },
               "&.audio": {
                 height: 150,
               },

--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
@@ -194,13 +194,7 @@ class BrowserDownload {
   }
 }
 
-export type AllowedPreviews =
-  | "image"
-  | "pdf"
-  | "text"
-  | "audio"
-  | "video"
-  | "none";
+export type AllowedPreviews = "image" | "pdf" | "audio" | "video" | "none";
 export const contentTypePreview = (contentType: string): AllowedPreviews => {
   if (contentType) {
     const mimeObjectType = (contentType || "").toLowerCase();
@@ -210,9 +204,6 @@ export const contentTypePreview = (contentType: string): AllowedPreviews => {
     }
     if (mimeObjectType.includes("pdf")) {
       return "pdf";
-    }
-    if (mimeObjectType.includes("text")) {
-      return "text";
     }
     if (mimeObjectType.includes("audio")) {
       return "audio";
@@ -243,7 +234,6 @@ export const extensionPreview = (fileName: string): AllowedPreviews => {
     "png",
     "heic",
   ];
-  const textExtensions = ["txt"];
   const pdfExtensions = ["pdf"];
   const audioExtensions = ["wav", "mp3", "alac", "aiff", "dsd", "pcm"];
   const videoExtensions = [
@@ -273,10 +263,6 @@ export const extensionPreview = (fileName: string): AllowedPreviews => {
 
   if (pdfExtensions.includes(fileExtension)) {
     return "pdf";
-  }
-
-  if (textExtensions.includes(fileExtension)) {
-    return "text";
   }
 
   if (audioExtensions.includes(fileExtension)) {


### PR DESCRIPTION
clean up text preview support which was removed earlier

Support for Preview of text/text mimetype was removed. 

References:

https://github.com/minio/console/pull/2680

more discussions earlier around this https://github.com/minio/console/issues/2021#issuecomment-1132942518