### PR TITLE
Changed default Replicate Existing Objects behavior in MinIO UI

### DIFF
--- a/api/embedded_spec.go
+++ b/api/embedded_spec.go
@@ -7225,6 +7225,9 @@ func init() {
         "replicateDeletes": {
           "type": "boolean"
         },
+        "replicateExistingObjects": {
+          "type": "boolean"
+        },
         "replicateMetadata": {
           "type": "boolean"
         },
@@ -16624,6 +16627,9 @@ func init() {
           "type": "boolean"
         },
         "replicateDeletes": {
+          "type": "boolean"
+        },
+        "replicateExistingObjects": {
           "type": "boolean"
         },
         "replicateMetadata": {

--- a/models/multi_bucket_replication.go
+++ b/models/multi_bucket_replication.go
@@ -68,6 +68,9 @@ type MultiBucketReplication struct {
 	// replicate deletes
 	ReplicateDeletes bool `json:"replicateDeletes,omitempty"`
 
+	// replicate existing objects
+	ReplicateExistingObjects bool `json:"replicateExistingObjects,omitempty"`
+
 	// replicate metadata
 	ReplicateMetadata bool `json:"replicateMetadata,omitempty"`
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -4219,6 +4219,8 @@ definitions:
         type: string
       tags:
         type: string
+      replicateExistingObjects:
+        type: boolean
       replicateDeleteMarkers:
         type: boolean
       replicateDeletes:

--- a/web-app/src/api/consoleApi.ts
+++ b/web-app/src/api/consoleApi.ts
@@ -385,6 +385,7 @@ export interface MultiBucketReplication {
   healthCheckPeriod?: number;
   prefix?: string;
   tags?: string;
+  replicateExistingObjects?: boolean;
   replicateDeleteMarkers?: boolean;
   replicateDeletes?: boolean;
   replicateMetadata?: boolean;

--- a/web-app/src/screens/Console/Buckets/BucketDetails/AddBucketReplication.tsx
+++ b/web-app/src/screens/Console/Buckets/BucketDetails/AddBucketReplication.tsx
@@ -60,7 +60,7 @@ const AddBucketReplication = () => {
   const [repDeleteMarker, setRepDeleteMarker] = useState<boolean>(true);
   const [repDelete, setRepDelete] = useState<boolean>(true);
   const [metadataSync, setMetadataSync] = useState<boolean>(true);
-  const [repExisting, setRepExisting] = useState<boolean>(false);
+  const [repExisting, setRepExisting] = useState<boolean>(true);
   const [tags, setTags] = useState<string>("");
   const [replicationMode, setReplicationMode] = useState<"async" | "sync">(
     "async",
@@ -124,8 +124,8 @@ const AddBucketReplication = () => {
           if (itemVal.errorString && itemVal.errorString !== "") {
             dispatch(
               setErrorSnackMessage({
-                errorMessage: itemVal.errorString,
-                detailedError: "There was an error",
+                errorMessage: "There was an error",
+                detailedError: itemVal.errorString,
               }),
             );
             // navigate(backLink);
@@ -201,11 +201,10 @@ const AddBucketReplication = () => {
                   </Box>
                   <Box sx={{ paddingTop: "10px" }}>
                     MinIO supports automatically replicating existing objects in
-                    a bucket, however it does not enable existing object
-                    replication by default. Objects created before replication
-                    was configured or while replication is disabled are not
-                    synchronized to the target deployment unless replication of
-                    existing objects is enabled.
+                    a bucket; this setting is enabled by default. Please note
+                    that objects created before replication was configured or
+                    while replication is disabled are not synchronized to the
+                    target deployment in case this setting is not enabled.
                   </Box>
                   <Box sx={{ paddingTop: "10px" }}>
                     MinIO supports replicating delete operations, where MinIO


### PR DESCRIPTION
fixes https://github.com/minio/console/issues/3181

## What does this do?

- Fixed replicate existing objects configuration saving
- Displayed full error message if error case ocurrs.
- Changed wording for this feature & enabled by default this setting

## How does it look?

<img width="495" alt="Screenshot 2024-05-05 at 12 19 49 a m" src="https://github.com/minio/console/assets/33497058/d911ca15-d778-462e-86a4-cc3ce940fe42">
<img width="1113" alt="Screenshot 2024-05-05 at 12 24 14 a m" src="https://github.com/minio/console/assets/33497058/842547ae-9291-44fd-9ce3-17e026c210e8">


