### PR TITLE
Log error if it exists while serving APIs

### DIFF
--- a/cmd/console/app_commands.go
+++ b/cmd/console/app_commands.go
@@ -86,5 +86,10 @@ func StartServer(ctx *cli.Context) error {
 
 	defer server.Shutdown()
 
-	return server.Serve()
+	if err = server.Serve(); err != nil {
+		server.Logf("error serving API: %v", err)
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
If there's an error while serving the APIs, there's no way to know what went wrong.
This helps a bit with it.

Before:
```
√ console(master) % make && CONSOLE_ACCESS_KEY=minioadmin CONSOLE_SECRET_KEY=minioadmin CONSOLE_MINIO_SERVER=http://localhost:9009 CONSOLE_DEV_MODE=on ./console server
Building Console binary to './console'
?1 console(master) % 
```

After:
```
√ console(master) % make && CONSOLE_ACCESS_KEY=minioadmin CONSOLE_SECRET_KEY=minioadmin CONSOLE_MINIO_SERVER=http://localhost:9009 CONSOLE_DEV_MODE=on ./console server
Building Console binary to './console'
error serving API: listen tcp :9090: bind: address already in use
?1 console(master) % 
```