### PR TITLE
Use url-safe base64 encoding for download-shared-object api

### DIFF
--- a/api/user_objects.go
+++ b/api/user_objects.go
@@ -1100,7 +1100,7 @@ func getShareObjectURL(ctx context.Context, client MCClient, r *http.Request, ve
 		return nil, pErr.Cause
 	}
 
-	encodedMinIOURL := b64.StdEncoding.EncodeToString([]byte(minioURL))
+	encodedMinIOURL := b64.URLEncoding.EncodeToString([]byte(minioURL))
 	requestURL := getRequestURLWithScheme(r)
 	objURL := fmt.Sprintf("%s/api/v1/download-shared-object/%s", requestURL, encodedMinIOURL)
 	return &objURL, nil


### PR DESCRIPTION
fixes: https://github.com/minio/console/issues/3304

Uses URLEncoding  instead of StdEncoding to ensure url-safe strings.
Includes test.

### Test steps:
With an existing bucket, folder and objects.

- With different filenames e,.g. `with .jpg, .svg, .png, spaces, etc`
- Click share file
- Copy and paste the new url in the browser
- The url should contain same url as Object browser
- Object should be downloaded
- Test injecting wrong urls (base64encoded)
- Should return error or forbidden errors if url doesn't point to internal MinIO server