### PR TITLE
Fix URL safe string decoding for DownloadPublicObject API

### DIFF
--- a/api/public_objects.go
+++ b/api/public_objects.go
@@ -93,7 +93,7 @@ func getDownloadPublicObjectResponse(params public.DownloadSharedObjectParams) (
 
 // b64toMinIOStringURL decodes url and validates is a MinIO url endpoint
 func b64toMinIOStringURL(inputEncodedURL string) (*string, error) {
-	inputURLDecoded, err := b64.StdEncoding.DecodeString(inputEncodedURL)
+	inputURLDecoded, err := b64.URLEncoding.DecodeString(inputEncodedURL)
 	if err != nil {
 		return nil, err
 	}

--- a/api/public_objects_test.go
+++ b/api/public_objects_test.go
@@ -76,6 +76,14 @@ func Test_b64toMinIOStringURL(t *testing.T) {
 			wantError: swag.String("unexpected scheme found "),
 			expected:  nil,
 		},
+		{
+			test: "encoded url is url safe decoded",
+			args: args{
+				encodedURL: "aHR0cHM6Ly9sb2NhbGhvc3Q6OTAwMC9jZXN0ZXN0L0F1ZGlvJTIwaWNvbi5zdmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTY=",
+			},
+			wantError: nil,
+			expected:  swag.String("https://localhost:9000/cestest/Audio%20icon.svg?X-Amz-Algorithm=AWS4-HMAC-SHA256"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -84,16 +92,16 @@ func Test_b64toMinIOStringURL(t *testing.T) {
 			if tt.wantError != nil {
 				if err != nil {
 					if err.Error() != *tt.wantError {
-						t.Errorf("b64toMinIOStringURL() error: `%v`, wantErr: `%s`", err, *tt.wantError)
+						t.Errorf("b64toMinIOStringURL() error: `%v`, wantErr: `%s`, input: `%s`", err, *tt.wantError, tt.args.encodedURL)
 						return
 					}
 				} else {
-					t.Errorf("b64toMinIOStringURL() error: `%v`, wantErr: `%s`", err, *tt.wantError)
+					t.Errorf("b64toMinIOStringURL() error: `%v`, wantErr: `%s`, input: `%s`", err, *tt.wantError, tt.args.encodedURL)
 					return
 				}
 			} else {
 				if err != nil {
-					t.Errorf("b64toMinIOStringURL() error: `%s`, wantErr: `%v`", err, tt.wantError)
+					t.Errorf("b64toMinIOStringURL() error: `%s`, wantErr: `%v`, input: `%s`", err, tt.wantError, tt.args.encodedURL)
 					return
 				}
 				tAssert.Equal(*tt.expected, *url)


### PR DESCRIPTION
fixes: https://github.com/minio/console/issues/3327

Similar to https://github.com/minio/console/pull/3305 it uses url safe base64 decoding for the download of the object. Used in Share File functionality. The previous PR fixed the creation of the URL (encoding), this fixes the decoding of it.

Includes unittest.

### Test steps:
With an existing bucket, folder and objects.

- With different filenames e,.g. `with .jpg, .svg, .png, spaces, etc`
- Click share file
- Copy and paste the new url in the browser
- The url should contain same url as Object browser
- Object should be downloaded
- Test injecting wrong urls (base64encoded)
- Should return error or forbidden errors if url doesn't point to internal MinIO server