### PR TITLE
Updated Add Bucket Replication rule page

### DIFF
--- a/web-app/src/screens/Console/Buckets/BucketDetails/AddBucketReplication.tsx
+++ b/web-app/src/screens/Console/Buckets/BucketDetails/AddBucketReplication.tsx
@@ -60,7 +60,7 @@ const AddBucketReplication = () => {
   const [repDeleteMarker, setRepDeleteMarker] = useState<boolean>(true);
   const [repDelete, setRepDelete] = useState<boolean>(true);
   const [metadataSync, setMetadataSync] = useState<boolean>(true);
-  const [repExisting, setRepExisting] = useState<boolean>(false);
+  const [repExisting, setRepExisting] = useState<boolean>(true);
   const [tags, setTags] = useState<string>("");
   const [replicationMode, setReplicationMode] = useState<"async" | "sync">(
     "async",
@@ -124,8 +124,8 @@ const AddBucketReplication = () => {
           if (itemVal.errorString && itemVal.errorString !== "") {
             dispatch(
               setErrorSnackMessage({
-                errorMessage: itemVal.errorString,
-                detailedError: "There was an error",
+                errorMessage: "There was an error",
+                detailedError: itemVal.errorString,
               }),
             );
             // navigate(backLink);
@@ -200,12 +200,7 @@ const AddBucketReplication = () => {
                     matching rule with highest configured priority.
                   </Box>
                   <Box sx={{ paddingTop: "10px" }}>
-                    MinIO supports automatically replicating existing objects in
-                    a bucket, however it does not enable existing object
-                    replication by default. Objects created before replication
-                    was configured or while replication is disabled are not
-                    synchronized to the target deployment unless replication of
-                    existing objects is enabled.
+                    By default, MinIO will enable the replication for existing objects in the bucket automatically. This setting can be changed once the replication rule is configured.
                   </Box>
                   <Box sx={{ paddingTop: "10px" }}>
                     MinIO supports replicating delete operations, where MinIO
@@ -402,6 +397,7 @@ const AddBucketReplication = () => {
                   setRepExisting(e.target.checked);
                 }}
                 description={"Replicate existing objects"}
+                disabled
               />
               <Switch
                 checked={metadataSync}


### PR DESCRIPTION
fixes #3181 

## What does this do?

- Changed wording in Add replication rule page
- Changed default setting for replication existing objects
- Displayed full error message in case en error ocurs

## How does it look?
<img width="517" alt="Screenshot 2024-05-05 at 12 07 48 a m" src="https://github.com/minio/console/assets/33497058/172cff7b-aa8a-432b-b56e-7cd94e61e581">
<img width="1046" alt="Screenshot 2024-05-05 at 12 07 43 a m" src="https://github.com/minio/console/assets/33497058/403e1943-3eae-467c-9c9c-8fc4360929b5">

