### PR TITLE
Added VersionID support to Metadata Details

### DIFF
--- a/api/embedded_spec.go
+++ b/api/embedded_spec.go
@@ -1762,6 +1762,11 @@ func init() {
             "name": "prefix",
             "in": "query",
             "required": true
+          },
+          {
+            "type": "string",
+            "name": "versionID",
+            "in": "query"
           }
         ],
         "responses": {
@@ -10974,6 +10979,11 @@ func init() {
             "name": "prefix",
             "in": "query",
             "required": true
+          },
+          {
+            "type": "string",
+            "name": "versionID",
+            "in": "query"
           }
         ],
         "responses": {

--- a/api/operations/object/get_object_metadata_parameters.go
+++ b/api/operations/object/get_object_metadata_parameters.go
@@ -59,6 +59,10 @@ type GetObjectMetadataParams struct {
 	  In: query
 	*/
 	Prefix string
+	/*
+	  In: query
+	*/
+	VersionID *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -79,6 +83,11 @@ func (o *GetObjectMetadataParams) BindRequest(r *http.Request, route *middleware
 
 	qPrefix, qhkPrefix, _ := qs.GetOK("prefix")
 	if err := o.bindPrefix(qPrefix, qhkPrefix, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qVersionID, qhkVersionID, _ := qs.GetOK("versionID")
+	if err := o.bindVersionID(qVersionID, qhkVersionID, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -118,6 +127,24 @@ func (o *GetObjectMetadataParams) bindPrefix(rawData []string, hasKey bool, form
 		return err
 	}
 	o.Prefix = raw
+
+	return nil
+}
+
+// bindVersionID binds and validates parameter VersionID from query.
+func (o *GetObjectMetadataParams) bindVersionID(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.VersionID = &raw
 
 	return nil
 }

--- a/api/operations/object/get_object_metadata_urlbuilder.go
+++ b/api/operations/object/get_object_metadata_urlbuilder.go
@@ -33,7 +33,8 @@ import (
 type GetObjectMetadataURL struct {
 	BucketName string
 
-	Prefix string
+	Prefix    string
+	VersionID *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -79,6 +80,14 @@ func (o *GetObjectMetadataURL) Build() (*url.URL, error) {
 	prefixQ := o.Prefix
 	if prefixQ != "" {
 		qs.Set("prefix", prefixQ)
+	}
+
+	var versionIDQ string
+	if o.VersionID != nil {
+		versionIDQ = *o.VersionID
+	}
+	if versionIDQ != "" {
+		qs.Set("versionID", versionIDQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/api/user_objects.go
+++ b/api/user_objects.go
@@ -1338,6 +1338,7 @@ func getObjectMetadataResponse(session *models.Principal, params objectApi.GetOb
 	// defining the client to be used
 	minioClient := minioClient{client: mClient}
 	var prefix string
+	var versionID string
 
 	if params.Prefix != "" {
 		encodedPrefix := SanitizeEncodedPrefix(params.Prefix)
@@ -1348,7 +1349,11 @@ func getObjectMetadataResponse(session *models.Principal, params objectApi.GetOb
 		prefix = string(decodedPrefix)
 	}
 
-	objectInfo, err := getObjectInfo(ctx, minioClient, params.BucketName, prefix)
+	if params.VersionID != nil {
+		versionID = *params.VersionID
+	}
+
+	objectInfo, err := getObjectInfo(ctx, minioClient, params.BucketName, prefix, versionID)
 	if err != nil {
 		return nil, ErrorWithContext(ctx, err)
 	}
@@ -1358,8 +1363,8 @@ func getObjectMetadataResponse(session *models.Principal, params objectApi.GetOb
 	return metadata, nil
 }
 
-func getObjectInfo(ctx context.Context, client MinioClient, bucketName, prefix string) (minio.ObjectInfo, error) {
-	objectData, err := client.statObject(ctx, bucketName, prefix, minio.GetObjectOptions{})
+func getObjectInfo(ctx context.Context, client MinioClient, bucketName, prefix, versionID string) (minio.ObjectInfo, error) {
+	objectData, err := client.statObject(ctx, bucketName, prefix, minio.GetObjectOptions{VersionID: versionID})
 	if err != nil {
 		return minio.ObjectInfo{}, err
 	}

--- a/api/user_objects_test.go
+++ b/api/user_objects_test.go
@@ -1293,6 +1293,7 @@ func Test_getObjectInfo(t *testing.T) {
 	type args struct {
 		bucketName string
 		prefix     string
+		versionID  string
 		statFunc   func(ctx context.Context, bucketName string, prefix string, opts minio.GetObjectOptions) (objectInfo minio.ObjectInfo, err error)
 	}
 	tests := []struct {
@@ -1305,6 +1306,7 @@ func Test_getObjectInfo(t *testing.T) {
 			args: args{
 				bucketName: "bucket1",
 				prefix:     "someprefix",
+				versionID:  "version123",
 				statFunc: func(_ context.Context, _ string, _ string, _ minio.GetObjectOptions) (minio.ObjectInfo, error) {
 					return minio.ObjectInfo{}, nil
 				},
@@ -1316,6 +1318,7 @@ func Test_getObjectInfo(t *testing.T) {
 			args: args{
 				bucketName: "bucket2",
 				prefix:     "someprefi2",
+				versionID:  "version456",
 				statFunc: func(_ context.Context, _ string, _ string, _ minio.GetObjectOptions) (minio.ObjectInfo, error) {
 					return minio.ObjectInfo{}, errors.New("new Error")
 				},
@@ -1326,7 +1329,7 @@ func Test_getObjectInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.test, func(_ *testing.T) {
 			minioStatObjectMock = tt.args.statFunc
-			_, err := getObjectInfo(ctx, client, tt.args.bucketName, tt.args.prefix)
+			_, err := getObjectInfo(ctx, client, tt.args.bucketName, tt.args.prefix, tt.args.versionID)
 			if tt.wantError != nil {
 				fmt.Println(t.Name())
 				tAssert.Equal(tt.wantError.Error(), err.Error(), fmt.Sprintf("getObjectInfo() error: `%s`, wantErr: `%s`", err, tt.wantError))

--- a/swagger.yml
+++ b/swagger.yml
@@ -703,6 +703,9 @@ paths:
           in: query
           required: true
           type: string
+        - name: versionID
+          in: query
+          type: string
       responses:
         200:
           description: A successful response.

--- a/web-app/src/api/consoleApi.ts
+++ b/web-app/src/api/consoleApi.ts
@@ -2397,6 +2397,7 @@ export class Api<
       bucketName: string,
       query: {
         prefix: string;
+        versionID?: string;
       },
       params: RequestParams = {},
     ) =>

--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ObjectDetailPanel.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ObjectDetailPanel.tsx
@@ -216,6 +216,7 @@ const ObjectDetailPanel = ({
       api.buckets
         .getObjectMetadata(bucketName, {
           prefix: internalPaths,
+          versionID: actualInfo?.version_id || "",
         })
         .then((res) => {
           let metadata = get(res.data, "objectMetadata", {});
@@ -228,7 +229,7 @@ const ObjectDetailPanel = ({
           setLoadingMetadata(false);
         });
     }
-  }, [bucketName, internalPaths, loadMetadata]);
+  }, [bucketName, internalPaths, loadMetadata, actualInfo?.version_id]);
 
   let tagKeys: string[] = [];
 

--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
@@ -51,6 +51,7 @@ const PreviewFile = ({
       api.buckets
         .getObjectMetadata(bucketName, {
           prefix: encodedPath,
+          versionID: actualInfo.version_id || "",
         })
         .then((res) => {
           let metadata = get(res.data, "objectMetadata", {});
@@ -66,7 +67,7 @@ const PreviewFile = ({
           setIsMetaDataLoaded(true);
         });
     }
-  }, [bucketName, objectName, isMetaDataLoaded]);
+  }, [bucketName, objectName, isMetaDataLoaded, actualInfo.version_id]);
 
   useEffect(() => {
     if (bucketName && objectName) {


### PR DESCRIPTION
fixes #3225 

## What does this do?

Added VersionID support to Metadata Details

## How does it look?

### Before: 

![screencapture-localhost-10000-browser-a1bucket-dGFnLnN2Zw-2024-05-06-14_02_14](https://github.com/minio/console/assets/33497058/5a81320b-e96a-4b63-a75b-816c78ed05c3)
![screencapture-localhost-10000-browser-a1bucket-dGFnLnN2Zw-2024-05-06-14_02_09](https://github.com/minio/console/assets/33497058/7853f97a-62a9-4319-bc4c-68963da6e0ed)
![screencapture-localhost-10000-browser-a1bucket-dGFnLnN2Zw-2024-05-06-14_02_03](https://github.com/minio/console/assets/33497058/5594e1b5-447c-4576-8bed-182f0f2ea16b)

### After:

![screencapture-localhost-5005-browser-a1bucket-dGFnLnN2Zw-2024-05-06-14_02_41](https://github.com/minio/console/assets/33497058/5241f153-09ed-4f6e-bf65-463e750ce749)
![screencapture-localhost-5005-browser-a1bucket-dGFnLnN2Zw-2024-05-06-14_02_31](https://github.com/minio/console/assets/33497058/c739a427-5b0d-4cc6-ae95-ed06514ea6e1)
![screencapture-localhost-5005-browser-a1bucket-dGFnLnN2Zw-2024-05-06-14_02_24](https://github.com/minio/console/assets/33497058/ef9e4627-3555-4078-a371-ff2620fa075b)

