### PR TITLE
Use redirect URL in share link if env variable set

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -303,3 +303,7 @@ func getConsoleDevMode() bool {
 func getConsoleAnimatedLogin() bool {
 	return strings.ToLower(env.Get(ConsoleAnimatedLogin, "on")) == "on"
 }
+
+func getConsoleBrowserRedirectURL() string {
+	return env.Get(ConsoleBrowserRedirectURL, "")
+}

--- a/api/consts.go
+++ b/api/consts.go
@@ -56,6 +56,7 @@ const (
 	ConsoleMaxConcurrentDownloads                = "CONSOLE_MAX_CONCURRENT_DOWNLOADS"
 	ConsoleDevMode                               = "CONSOLE_DEV_MODE"
 	ConsoleAnimatedLogin                         = "CONSOLE_ANIMATED_LOGIN"
+	ConsoleBrowserRedirectURL                    = "CONSOLE_BROWSER_REDIRECT_URL"
 	LogSearchQueryAuthToken                      = "LOGSEARCH_QUERY_AUTH_TOKEN"
 	SlashSeparator                               = "/"
 	LocalAddress                                 = "127.0.0.1"

--- a/api/user_objects.go
+++ b/api/user_objects.go
@@ -1112,6 +1112,11 @@ func getRequestURLWithScheme(r *http.Request) string {
 		scheme = "https"
 	}
 
+	redirectURL := getConsoleBrowserRedirectURL()
+	if redirectURL != "" {
+		return strings.TrimSuffix(redirectURL, "/")
+	}
+
 	return fmt.Sprintf("%s://%s", scheme, r.Host)
 }
 

--- a/api/user_objects_test.go
+++ b/api/user_objects_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -921,10 +922,11 @@ func Test_shareObject(t *testing.T) {
 		shareFunc func(ctx context.Context, versionID string, expires time.Duration) (string, *probe.Error)
 	}
 	tests := []struct {
-		test      string
-		args      args
-		wantError error
-		expected  string
+		test       string
+		args       args
+		setEnvVars func()
+		wantError  error
+		expected   string
 	}{
 		{
 			test: "return sharefunc url base64 encoded with host name",
@@ -1023,11 +1025,52 @@ func Test_shareObject(t *testing.T) {
 			wantError: nil,
 			expected:  "http://localhost:9090/api/v1/download-shared-object/aHR0cHM6Ly8xMjcuMC4wLjE6OTAwMC9jZXN0ZXN0L0F1ZGlvJTIwaWNvbi5zdmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTY=",
 		},
+		{
+			test: "returns redirect url with share link if redirect url env variable set",
+			setEnvVars: func() {
+				os.Setenv(ConsoleBrowserRedirectURL, "http://proxy-url.com:9012/console/subpath")
+			},
+			args: args{
+				r: &http.Request{
+					TLS:  nil,
+					Host: "localhost:9090",
+				},
+				versionID: "2121434",
+				expires:   "30s",
+				shareFunc: func(_ context.Context, _ string, _ time.Duration) (string, *probe.Error) {
+					return "http://someurl", nil
+				},
+			},
+			wantError: nil,
+			expected:  "http://proxy-url.com:9012/console/subpath/api/v1/download-shared-object/aHR0cDovL3NvbWV1cmw=",
+		},
+		{
+			test: "returns redirect url with share link if redirect url env variable set with trailing slash",
+			setEnvVars: func() {
+				os.Setenv(ConsoleBrowserRedirectURL, "http://proxy-url.com:9012/console/subpath/")
+			},
+			args: args{
+				r: &http.Request{
+					TLS:  nil,
+					Host: "localhost:9090",
+				},
+				versionID: "2121434",
+				expires:   "30s",
+				shareFunc: func(_ context.Context, _ string, _ time.Duration) (string, *probe.Error) {
+					return "http://someurl", nil
+				},
+			},
+			wantError: nil,
+			expected:  "http://proxy-url.com:9012/console/subpath/api/v1/download-shared-object/aHR0cDovL3NvbWV1cmw=",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.test, func(_ *testing.T) {
 			mcShareDownloadMock = tt.args.shareFunc
+			if tt.setEnvVars != nil {
+				tt.setEnvVars()
+			}
 			url, err := getShareObjectURL(ctx, client, tt.args.r, tt.args.versionID, tt.args.expires)
 			if tt.wantError != nil {
 				if !reflect.DeepEqual(err, tt.wantError) {


### PR DESCRIPTION
needs: https://github.com/minio/minio/pull/19683
fixes: https://github.com/minio/console/issues/3331

Uses MINIO_BROWSER_REDIRECT_URL to generate the share URL link if it's set.

<img width="932" alt="Screenshot 2024-05-06 at 5 37 40 PM" src="https://github.com/minio/console/assets/11819101/95de8b90-4c7d-440c-8932-770d4e1fdbf5">



### Test Steps with Ngnix

Assuming we are exposing the console under `http://localhost:8000/console/subpath/`

1. Build MinIO with [this](https://github.com/minio/minio/pull/19683) change with this branch of console
2. Start MinIO for a given Subpath
```bash
CI=true;MINIO_BROWSER_REDIRECT_URL=http://localhost:8000/console/subpath/;MINIO_SERVER_URL=http://localhost:9000 minio --console-address ":9090"
```
3. Start `nginx` with the following configuraiton
```
events { worker_connections 1024; }

http {

server {
    listen 8000;

    location /console/subpath/ {
        rewrite   ^/console/subpath/(.*) /$1 break;
        proxy_pass http://localhost:9090;
        
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "Upgrade";
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
        
        # This allows WebSocket connections
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
    }
}
}
```
with the command
```
nginx -c /PATH/TO/nginx.conf -g "daemon off;"
```
4. Go to bucket(create if needed), e.g. `http://localhost:8000/console/subpath/browser/bucket1`
5. Click on a file and click Share
6. URL generated should contain the Subpath

