### PR TITLE
Updated golang to 1.21 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN make build-static
 
 USER node
 
-FROM golang:1.19 as golayer
+FROM golang:1.21 as golayer
 
 RUN apt-get update -y && apt-get install -y ca-certificates
 


### PR DESCRIPTION
The current Dockerfile uses golang:1.19, which doesn't match either go.mod or the libraries in use, and doesn't build correctly. This should be updated to Go 1.21 at a minimum.