### PR TITLE
Return header with error idp logout

### DIFF
--- a/api/user_logout.go
+++ b/api/user_logout.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"github.com/go-openapi/errors"
 	"net/http"
 	"net/url"
 	"time"
@@ -37,10 +39,13 @@ func registerLogoutHandlers(api *operations.ConsoleAPI) {
 	api.AuthLogoutHandler = authApi.LogoutHandlerFunc(func(params authApi.LogoutParams, session *models.Principal) middleware.Responder {
 		err := getLogoutResponse(session, params)
 		if err != nil {
-			api.Logger("IDP logout failed: %v", err.APIError)
+			api.Logger("IDP logout failed: %v", err.APIError.DetailedMessage)
 		}
 		// Custom response writer to expire the session cookies
 		return middleware.ResponderFunc(func(w http.ResponseWriter, p runtime.Producer) {
+			if err != nil {
+				w.Header().Set("IDP-Logout", fmt.Sprintf("%v", err.APIError.DetailedMessage))
+			}
 			expiredCookie := ExpireSessionCookie()
 			// this will tell the browser to clear the cookie and invalidate user session
 			// additionally we are deleting the cookie from the client side
@@ -104,10 +109,14 @@ func logoutFromIDPProvider(r *http.Request, state string) error {
 		client := &http.Client{
 			Transport: GlobalTransport,
 		}
-		_, err := client.PostForm(providerCfg.EndSessionEndpoint, params)
+		result, err := client.PostForm(providerCfg.EndSessionEndpoint, params)
 		if err != nil {
-			return err
+			return errors.New(500, "failed to logout: %v", err.Error())
+		}
+		if result.StatusCode != 204 {
+			return errors.New(int32(result.StatusCode), "failed to logout")
 		}
 	}
+
 	return nil
 }

--- a/api/user_logout.go
+++ b/api/user_logout.go
@@ -21,10 +21,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/go-openapi/errors"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/go-openapi/errors"
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"


### PR DESCRIPTION
fixes #3225 

## What does this do?

The problem with Logout from IDP is that we are silently failing if for some external reason non related to Console the `end_session_endpoint` cannot be reached, this PR adds a way to get insights on the problem without sacrifice the idempotence of logout.

Add a response header to the `api/v1/logout` endpoint when the underneath call to logout from the IDP fails.
The header will not be shown when IDP logout is success.

## How does it look?

<img width="1016" alt="Screenshot 2024-05-10 at 4 05 12 PM" src="https://github.com/minio/console/assets/1334362/0f053b46-a6d5-4d3e-a4b0-73d49102703c">
