### PR TITLE
Add ability to disable the share redirect feature

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -307,3 +307,7 @@ func getConsoleAnimatedLogin() bool {
 func getConsoleBrowserRedirectURL() string {
 	return env.Get(ConsoleBrowserRedirectURL, "")
 }
+
+func getConsoleBrowserRedirect() bool {
+	return strings.ToLower(env.Get(ConsoleBrowserRedirect, "on")) == "on"
+}

--- a/api/consts.go
+++ b/api/consts.go
@@ -57,6 +57,7 @@ const (
 	ConsoleDevMode                               = "CONSOLE_DEV_MODE"
 	ConsoleAnimatedLogin                         = "CONSOLE_ANIMATED_LOGIN"
 	ConsoleBrowserRedirectURL                    = "CONSOLE_BROWSER_REDIRECT_URL"
+	ConsoleBrowserRedirect                       = "CONSOLE_BROWSER_REDIRECT"
 	LogSearchQueryAuthToken                      = "LOGSEARCH_QUERY_AUTH_TOKEN"
 	SlashSeparator                               = "/"
 	LocalAddress                                 = "127.0.0.1"

--- a/api/user_objects.go
+++ b/api/user_objects.go
@@ -1100,10 +1100,14 @@ func getShareObjectURL(ctx context.Context, client MCClient, r *http.Request, ve
 		return nil, pErr.Cause
 	}
 
-	encodedMinIOURL := b64.URLEncoding.EncodeToString([]byte(minioURL))
-	requestURL := getRequestURLWithScheme(r)
-	objURL := fmt.Sprintf("%s/api/v1/download-shared-object/%s", requestURL, encodedMinIOURL)
-	return &objURL, nil
+	if getConsoleBrowserRedirect() {
+		encodedMinIOURL := b64.URLEncoding.EncodeToString([]byte(minioURL))
+		requestURL := getRequestURLWithScheme(r)
+		objURL := fmt.Sprintf("%s/api/v1/download-shared-object/%s", requestURL, encodedMinIOURL)
+		return &objURL, nil
+	}
+
+	return &minioURL, nil
 }
 
 func getRequestURLWithScheme(r *http.Request) string {

--- a/api/user_objects_test.go
+++ b/api/user_objects_test.go
@@ -1062,6 +1062,25 @@ func Test_shareObject(t *testing.T) {
 			wantError: nil,
 			expected:  "http://proxy-url.com:9012/console/subpath/api/v1/download-shared-object/aHR0cDovL3NvbWV1cmw=",
 		},
+		{
+			test: "returns minio url without share link if redirect env variable set to off",
+			setEnvVars: func() {
+				t.Setenv(ConsoleBrowserRedirect, "off")
+			},
+			args: args{
+				r: &http.Request{
+					TLS:  nil,
+					Host: "localhost:9090",
+				},
+				versionID: "2121434",
+				expires:   "30s",
+				shareFunc: func(_ context.Context, _ string, _ time.Duration) (string, *probe.Error) {
+					return "http://someurl", nil
+				},
+			},
+			wantError: nil,
+			expected:  "http://someurl",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Introduces the ENV variable `CONSOLE_BROWSER_REDIRECT` to disable the feature introduced in #3348 since it is only needed when the MinIO server is not publically reachable.

It defaults to `on` to keep current behaviour.

Resolves #3348.