### PR TITLE
Fix remove tier error handling

### DIFF
--- a/web-app/src/screens/Console/Configurations/TiersConfiguration/DeleteTierConfirmModal.tsx
+++ b/web-app/src/screens/Console/Configurations/TiersConfiguration/DeleteTierConfirmModal.tsx
@@ -17,8 +17,10 @@
 import React from "react";
 import { ConfirmModalIcon } from "mds";
 import { api } from "api";
-import { errorToHandler } from "api/errors";
-import { setModalErrorSnackMessage } from "../../../../systemSlice";
+import {
+  setErrorSnackMessage,
+  setModalErrorSnackMessage,
+} from "../../../../systemSlice";
 import { useAppDispatch } from "../../../../store";
 import ConfirmDialog from "screens/Console/Common/ModalWrapper/ConfirmDialog";
 
@@ -43,7 +45,15 @@ const DeleteTierConfirmModal = ({
           closeModalAndRefresh(true);
         })
         .catch((err) => {
-          dispatch(setModalErrorSnackMessage(errorToHandler(err.error)));
+          err.json().then((body: any) => {
+            dispatch(
+              setErrorSnackMessage({
+                errorMessage: body.message,
+                detailedError: body.detailedMessage,
+              }),
+            );
+          });
+          closeModalAndRefresh(false);
         });
     } else {
       setModalErrorSnackMessage({

--- a/web-app/src/screens/Console/Configurations/TiersConfiguration/DeleteTierConfirmModal.tsx
+++ b/web-app/src/screens/Console/Configurations/TiersConfiguration/DeleteTierConfirmModal.tsx
@@ -17,10 +17,7 @@
 import React from "react";
 import { ConfirmModalIcon } from "mds";
 import { api } from "api";
-import {
-  setErrorSnackMessage,
-  setModalErrorSnackMessage,
-} from "../../../../systemSlice";
+import { setErrorSnackMessage } from "../../../../systemSlice";
 import { useAppDispatch } from "../../../../store";
 import ConfirmDialog from "screens/Console/Common/ModalWrapper/ConfirmDialog";
 
@@ -56,7 +53,7 @@ const DeleteTierConfirmModal = ({
           closeModalAndRefresh(false);
         });
     } else {
-      setModalErrorSnackMessage({
+      setErrorSnackMessage({
         errorMessage: "There was an error deleting the tier",
         detailedError: "",
       });


### PR DESCRIPTION
Displays error and clears modal on error.

PLAY3 is an empty tier, which can be deleted.
TEST3 is not empty, and displays an error, is not deleted.


https://github.com/minio/console/assets/65002498/eacef9d6-6209-4e59-90dc-310ac3f8c36f

