### PR TITLE
update logo as per mineos plans

### DIFF
--- a/api/license.go
+++ b/api/license.go
@@ -30,6 +30,8 @@ const (
 	PlanAGPL SubnetPlan = iota
 	PlanStandard
 	PlanEnterprise
+	PlanEnterpriseLite
+	PlanEnterprisePlus
 )
 
 func (sp SubnetPlan) String() string {
@@ -38,6 +40,10 @@ func (sp SubnetPlan) String() string {
 		return "standard"
 	case PlanEnterprise:
 		return "enterprise"
+	case PlanEnterpriseLite:
+		return "enterprise-lite"
+	case PlanEnterprisePlus:
+		return "enterprise-plus"
 	default:
 		return "agpl"
 	}
@@ -65,6 +71,10 @@ func fetchLicensePlan() {
 		InstanceLicensePlan = PlanStandard
 	case "ENTERPRISE":
 		InstanceLicensePlan = PlanEnterprise
+	case "ENTERPRISE-LITE":
+		InstanceLicensePlan = PlanEnterpriseLite
+	case "ENTERPRISE-PLUS":
+		InstanceLicensePlan = PlanEnterprisePlus
 	default:
 		InstanceLicensePlan = PlanAGPL
 	}

--- a/web-app/src/config.ts
+++ b/web-app/src/config.ts
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import { ApplicationLogoProps } from "mds";
+
 export const MinIOPlan =
   (
     document.head.querySelector(
@@ -21,11 +23,25 @@ export const MinIOPlan =
     ) as HTMLMetaElement
   )?.content || "AGPL";
 
-type LogoVar = "simple" | "AGPL" | "standard" | "enterprise";
+type LogoVar =
+  | "AGPL"
+  | "simple"
+  | "standard"
+  | "enterprise"
+  | "new"
+  | "enterpriseos"
+  | "enterpriseosvertical"
+  | undefined;
 
 export const getLogoVar = (): LogoVar => {
   let logoVar: LogoVar = "AGPL";
   switch (MinIOPlan.toLowerCase()) {
+    case "enterprise-lite":
+      logoVar = "enterpriseos";
+      break;
+    case "enterprise-plus":
+      logoVar = "enterpriseos";
+      break;
     case "enterprise":
       logoVar = "enterprise";
       break;
@@ -39,7 +55,26 @@ export const getLogoVar = (): LogoVar => {
   return logoVar;
 };
 
+export const getLogoApplicationVariant =
+  (): ApplicationLogoProps["applicationName"] => {
+    switch (MinIOPlan.toLowerCase()) {
+      case "enterprise-lite":
+      case "enterprise-plus":
+        return "minio";
+      default:
+        return "console";
+    }
+  };
+
 export const registeredCluster = (): boolean => {
   const plan = getLogoVar();
-  return plan === "standard" || plan === "enterprise";
+  return [
+    "AGPL",
+    "simple",
+    "standard",
+    "enterprise",
+    "new",
+    "enterpriseos",
+    "enterpriseosvertical",
+  ].includes(plan || "AGPL");
 };

--- a/web-app/src/screens/AnonymousAccess/AnonymousAccess.tsx
+++ b/web-app/src/screens/AnonymousAccess/AnonymousAccess.tsx
@@ -21,7 +21,7 @@ import { IAM_PAGES } from "../../common/SecureComponent/permissions";
 import { resetSession } from "../Console/consoleSlice";
 import { useAppDispatch } from "../../store";
 import { resetSystem } from "../../systemSlice";
-import { getLogoVar } from "../../config";
+import { getLogoApplicationVariant, getLogoVar } from "../../config";
 import ObjectBrowser from "../Console/ObjectBrowser/ObjectBrowser";
 import LoadingComponent from "../../common/LoadingComponent";
 import ObjectManager from "../Console/Common/ObjectManager/ObjectManager";
@@ -46,7 +46,7 @@ const AnonymousAccess = () => {
       >
         <div style={{ width: 200, flexShrink: 1 }}>
           <ApplicationLogo
-            applicationName={"console"}
+            applicationName={getLogoApplicationVariant()}
             subVariant={getLogoVar()}
             inverse={true}
           />

--- a/web-app/src/screens/Console/License/License.tsx
+++ b/web-app/src/screens/Console/License/License.tsx
@@ -89,7 +89,11 @@ const License = () => {
         if (res) {
           if (res.plan === "STANDARD") {
             setCurrentPlanID(1);
-          } else if (res.plan === "ENTERPRISE") {
+          } else if (
+            ["ENTERPRISE", "ENTERPRISE-LITE", "ENTERPRISE-PLUS"].includes(
+              res.plan,
+            )
+          ) {
             setCurrentPlanID(2);
           } else {
             setCurrentPlanID(1);

--- a/web-app/src/screens/Console/License/LicensePlans.tsx
+++ b/web-app/src/screens/Console/License/LicensePlans.tsx
@@ -385,7 +385,11 @@ const LicensePlans = ({ licenseInfo }: IRegisterStatus) => {
 
   const isCommunityPlan = currentPlan === LICENSE_PLANS.COMMUNITY;
   const isStandardPlan = currentPlan === LICENSE_PLANS.STANDARD;
-  const isEnterprisePlan = currentPlan === LICENSE_PLANS.ENTERPRISE;
+  const isEnterprisePlan = [
+    LICENSE_PLANS.ENTERPRISE,
+    LICENSE_PLANS.ENTERPRISE_LITE,
+    LICENSE_PLANS.ENTERPRISE_PLUS,
+  ].includes(currentPlan);
 
   const isPaidPlan = PAID_PLANS.includes(currentPlan);
 
@@ -393,7 +397,11 @@ const LicensePlans = ({ licenseInfo }: IRegisterStatus) => {
   const [xsPlanView, setXsPlanView] = useState("");
   let isXsViewCommunity = xsPlanView === LICENSE_PLANS.COMMUNITY;
   let isXsViewStandard = xsPlanView === LICENSE_PLANS.STANDARD;
-  let isXsViewEnterprise = xsPlanView === LICENSE_PLANS.ENTERPRISE;
+  let isXsViewEnterprise = [
+    LICENSE_PLANS.ENTERPRISE,
+    LICENSE_PLANS.ENTERPRISE_LITE,
+    LICENSE_PLANS.ENTERPRISE_PLUS,
+  ].includes(xsPlanView);
 
   const getCommunityPlanHeader = () => {
     return (

--- a/web-app/src/screens/Console/License/utils.tsx
+++ b/web-app/src/screens/Console/License/utils.tsx
@@ -24,6 +24,8 @@ export const LICENSE_PLANS = {
   COMMUNITY: "community",
   STANDARD: "standard",
   ENTERPRISE: "enterprise",
+  ENTERPRISE_LITE: "enterprise-lite",
+  ENTERPRISE_PLUS: "enterprise-plus",
 };
 
 type FeatureItem = {
@@ -439,7 +441,12 @@ export const ENTERPRISE_PLAN_FEATURES = [
   },
 ];
 
-export const PAID_PLANS = [LICENSE_PLANS.STANDARD, LICENSE_PLANS.ENTERPRISE];
+export const PAID_PLANS = [
+  LICENSE_PLANS.STANDARD,
+  LICENSE_PLANS.ENTERPRISE,
+  LICENSE_PLANS.ENTERPRISE_LITE,
+  LICENSE_PLANS.ENTERPRISE_PLUS,
+];
 
 export const getRenderValue = (val: any) => {
   return typeof val === "function" ? val() : val;

--- a/web-app/src/screens/Console/Menu/MenuWrapper.tsx
+++ b/web-app/src/screens/Console/Menu/MenuWrapper.tsx
@@ -21,7 +21,11 @@ import { AppState, useAppDispatch } from "../../../store";
 import { validRoutes } from "../valid-routes";
 import { menuOpen } from "../../../systemSlice";
 import { selFeatures } from "../consoleSlice";
-import { getLogoVar, registeredCluster } from "../../../config";
+import {
+  getLogoApplicationVariant,
+  getLogoVar,
+  registeredCluster,
+} from "../../../config";
 import { useLocation, useNavigate } from "react-router-dom";
 import { getLicenseConsent } from "../License/utils";
 
@@ -55,7 +59,10 @@ const MenuWrapper = () => {
       isOpen={sidebarOpen}
       displayGroupTitles
       options={allowedMenuItems}
-      applicationLogo={{ applicationName: "console", subVariant: getLogoVar() }}
+      applicationLogo={{
+        applicationName: getLogoApplicationVariant(),
+        subVariant: getLogoVar(),
+      }}
       callPathAction={(path) => {
         navigate(path);
       }}

--- a/web-app/src/screens/LoginPage/Login.tsx
+++ b/web-app/src/screens/LoginPage/Login.tsx
@@ -24,7 +24,7 @@ import { useSelector } from "react-redux";
 import { getFetchConfigurationAsync } from "./loginThunks";
 import { resetForm } from "./loginSlice";
 import StrategyForm from "./StrategyForm";
-import { getLogoVar } from "../../config";
+import { getLogoApplicationVariant, getLogoVar } from "../../config";
 import { RedirectRule } from "api/consoleApi";
 import { redirectRules } from "./login.utils";
 import { setHelpName } from "../../systemSlice";
@@ -149,7 +149,10 @@ const Login = () => {
     <Fragment>
       <MainError />
       <LoginWrapper
-        logoProps={{ applicationName: "console", subVariant: getLogoVar() }}
+        logoProps={{
+          applicationName: getLogoApplicationVariant(),
+          subVariant: getLogoVar(),
+        }}
         form={loginComponent}
         formFooter={
           <Box

--- a/web-app/src/screens/LoginPage/LoginCallback.tsx
+++ b/web-app/src/screens/LoginPage/LoginCallback.tsx
@@ -20,7 +20,7 @@ import { useNavigate } from "react-router-dom";
 import api from "../../common/api";
 import { baseUrl } from "../../history";
 import { Box, Button, LoginWrapper, WarnIcon } from "mds";
-import { getLogoVar } from "../../config";
+import { getLogoApplicationVariant, getLogoVar } from "../../config";
 import get from "lodash/get";
 
 const CallBackContainer = styled.div(({ theme }) => ({
@@ -107,7 +107,10 @@ const LoginCallback = () => {
   return error !== "" || errorDescription !== "" ? (
     <Fragment>
       <LoginWrapper
-        logoProps={{ applicationName: "console", subVariant: getLogoVar() }}
+        logoProps={{
+          applicationName: getLogoApplicationVariant(),
+          subVariant: getLogoVar(),
+        }}
         form={
           <CallBackContainer>
             <div className={"errorTitle"}>


### PR DESCRIPTION
update logo as per mineos plans

Note:
`ENTERPRIS-PLUS` `ENTERPRIS-LITE` would show minio eos logos.

`ENTERPRIS-PLUS` `ENTERPRIS-LITE` , `ENTERPRISE` would display `Enterprise` in License Page.  
We do not have UX finalised for this page update. 


How does it look:
E.g: EOS
![EOS_Log_In](https://github.com/minio/console/assets/23444145/a71b4f08-c19a-4f34-9c3e-7f8cdac9d2c0)

![EOS_License_logged_In](https://github.com/minio/console/assets/23444145/755dfd02-ded2-4d5c-8492-2af9f2ab9519)


E.g: minio
![image](https://github.com/minio/console/assets/23444145/87d9cc0e-5b6f-46ab-9a35-174f8ae3b379)

![image](https://github.com/minio/console/assets/23444145/832e9d1b-1174-44e4-b071-460ad1eca156)


### Build/Test
Checkout this PR
`make assets && make install` 

In case of console static assets build, issues, try `web-app/Makefile` line 5: replace with the below 
```shell
@if [ -f "${NVM_DIR}/nvm.sh" ]; then \. "${NVM_DIR}/nvm.sh" && nvm install && nvm use; YARN_CHECKSUM_BEHAVIOR=reset yarn install ; fi && \
and then try make assets && make build
```

### replace console build in mineos or minio  accordingly  in `go.mod` file.

`replace github.com/minio/console => /home/prakash/MinIO/GIT/go/src/github.com/prakashsvmx/console` 
**Note : Update the replace path as per the local dev setup.**

### Test MinIO
```shell
make build && make install && sudo cp minio /usr/local/bin/minio
CI=true MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 minio server --address ":22000" --console-address ":10000" /tmp/minio-upstream/s1/data{1...4}
```

#### Test `mineos` 
checkout mineos repo
```shell
make build && make install && sudo cp minio /usr/local/bin/minio-es
 CI=true MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 minio-es server --address ":32000" --console-address ":12000" /tmp/minio-es/s1/data{1...4}
```


