### PR TITLE
Changed License plans validation to not allow AGPL as a registered plan

### DIFF
--- a/web-app/src/config.ts
+++ b/web-app/src/config.ts
@@ -68,13 +68,5 @@ export const getLogoApplicationVariant =
 
 export const registeredCluster = (): boolean => {
   const plan = getLogoVar();
-  return [
-    "AGPL",
-    "simple",
-    "standard",
-    "enterprise",
-    "new",
-    "enterpriseos",
-    "enterpriseosvertical",
-  ].includes(plan || "AGPL");
+  return ["standard", "enterprise", "enterpriseos"].includes(plan || "AGPL");
 };


### PR DESCRIPTION
## What does it do?

Removed AGPL license as part of the registered clusters validation

## How does it look?

<img width="1506" alt="Screenshot 2024-06-13 at 2 23 13 p m" src="https://github.com/minio/console/assets/33497058/969376db-573d-41a5-8a30-028b9dca6976">
<img width="1503" alt="Screenshot 2024-06-13 at 2 23 03 p m" src="https://github.com/minio/console/assets/33497058/6023e2b5-ea03-40fa-994c-af54cdacc90f">
