### PR TITLE
fix nested directory object display

### DIFF
--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjectsTable.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjectsTable.tsx
@@ -84,20 +84,14 @@ const ListObjectsTable = () => {
     IAM_SCOPES.S3_ALL_LIST_BUCKET,
   ]);
 
-  const filteredRecords = records.filter((b: BucketObjectItem) => {
+  const plSelect = records.filter((b: BucketObjectItem) => {
     if (searchObjects === "") {
       return true;
     } else {
       const objectName = b.name.toLowerCase();
-      if (objectName.indexOf(searchObjects.toLowerCase()) >= 0) {
-        return true;
-      } else {
-        return false;
-      }
+      return objectName.indexOf(searchObjects.toLowerCase()) >= 0;
     }
   });
-
-  const plSelect = filteredRecords;
   const sortASC = plSelect.sort(sortListObjects(currentSortField));
 
   let payload: BucketObjectItem[] = [];


### PR DESCRIPTION
fix nested directory object display
```
➜ mc ls local22/demo -r                                              
[2024-08-01 10:07:41 IST]     2B STANDARD 2
[2024-08-01 10:40:01 IST]     2B STANDARD gopitestfolder/3.txt
[2024-08-01 10:26:13 IST]     2B STANDARD gopitestfolder/ingest-2/1.txt
[2024-08-01 08:41:58 IST]     0B STANDARD gopitestfolder/ingest/             # This must be skipped. 
[2024-08-01 10:23:45 IST]     2B STANDARD gopitestfolder/ingest/1.txt
[2024-08-01 10:08:40 IST]     2B STANDARD gopitestfolder/ingest/2
[2024-08-01 11:05:08 IST]     2B STANDARD gopitestfolder/ingest/ingest/ingest/9.txt
[2024-08-01 08:41:58 IST] 7.4MiB STANDARD gopitestfolder/ingest/minio_test_file-2024-08-01 08:41:58.166090.parquet

```

How does it look

Current issue vs Fixed.

![issue_vs_fixed](https://github.com/user-attachments/assets/a8997be9-e03c-44eb-84a4-ed142805732b)


