### PR TITLE
Fix Web App workflows

### DIFF
--- a/web-app/Makefile
+++ b/web-app/Makefile
@@ -3,12 +3,12 @@ default: build-static
 build-static:
 	@echo "Building frontend static assets to 'build'"
 	@if [ -f "${NVM_DIR}/nvm.sh" ]; then \. "${NVM_DIR}/nvm.sh" && nvm install && nvm use; fi && \
-	  NODE_OPTIONS=--openssl-legacy-provider yarn build
+	  yarn build
 
 build-static-istanbul-coverage:
 	@echo "Building frontend static assets to 'build'"
 	@if [ -f "${NVM_DIR}/nvm.sh" ]; then \. "${NVM_DIR}/nvm.sh" && nvm install && nvm use; fi && \
-	  NODE_OPTIONS=--openssl-legacy-provider yarn buildistanbulcoverage
+	  yarn buildistanbulcoverage
 
 test-warnings:
 	./check-warnings.sh

--- a/web-app/check-warnings-istanbul-coverage.sh
+++ b/web-app/check-warnings-istanbul-coverage.sh
@@ -11,7 +11,7 @@ die() {
 try() { "$@" &> yarn.log || die "cannot $*"; }
 
 rm -f yarn.log
-try make build-static-istanbul-coverage
+try yarn buildistanbulcoverage
 
 if cat yarn.log | grep "Compiled with warnings"; then
   echo "There are warnings in the code"

--- a/web-app/check-warnings.sh
+++ b/web-app/check-warnings.sh
@@ -11,7 +11,7 @@ die() {
 try() { "$@" &> yarn.log || die "cannot $*"; }
 
 rm -f yarn.log
-try make build-static
+try yarn build
 
 if cat yarn.log | grep "Compiled with warnings"; then
   echo "There are warnings in the code"

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -93,5 +93,5 @@
     "semver": "^7.5.2"
   },
   "main": "index.js",
-  "packageManager": "yarn@4.3.0"
+  "packageManager": "yarn@4.4.0"
 }

--- a/web-app/yarn.lock
+++ b/web-app/yarn.lock
@@ -17244,11 +17244,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.5.3#optional!builtin<compat/typescript>":
   version: 5.5.3
-  resolution: "typescript@patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>::version=5.5.3&hash=b45daf"
+  resolution: "typescript@patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>::version=5.5.3&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5a437c416251334deeaf29897157032311f3f126547cfdc4b133768b606cb0e62bcee733bb97cf74c42fe7268801aea1392d8e40988cdef112e9546eba4c03c5
+  checksum: 10c0/911c7811d61f57f07df79c4a35f56a0f426a65426a020e5fcd792f66559f399017205f5f10255329ab5a3d8c2d1f1d19530aeceffda70758a521fae1d469432e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this do

- Run `yarn` commands directly instead of calling the Makefile
- Remove `NODE_OPTIONS=--openssl-legacy-provider` flag
- Update Yarn to v4.4.0