### PR TITLE
Fix incorrect logic in serverHealthInfo

### DIFF
--- a/api/client-admin.go
+++ b/api/client-admin.go
@@ -383,22 +383,17 @@ func (ac AdminClient) serverHealthInfo(ctx context.Context, deadline time.Durati
 	info := madmin.HealthInfo{}
 	var healthInfo interface{}
 	var version string
-	var tryCount int
-	for info.Version == "" && tryCount < 10 {
-		var resp *http.Response
-		var err error
-		resp, version, err = ac.Client.ServerHealthInfo(ctx, madmin.HealthDataTypesList, deadline, "")
-		if err != nil {
-			return nil, version, err
+	var resp *http.Response
+	var err error
+	resp, version, err = ac.Client.ServerHealthInfo(ctx, madmin.HealthDataTypesList, deadline, "")
+	if err != nil {
+		return nil, version, err
+	}
+	decoder := json.NewDecoder(resp.Body)
+	for {
+		if err = decoder.Decode(&info); err != nil {
+			break
 		}
-		decoder := json.NewDecoder(resp.Body)
-		for {
-			if err = decoder.Decode(&info); err != nil {
-				break
-			}
-		}
-		tryCount++
-		time.Sleep(2 * time.Second)
 	}
 	if info.Version == "" {
 		return nil, "", ErrHealthReportFail


### PR DESCRIPTION
It was being assumed that whole response has been received as soon as info.Version is non-empty. This is wrong as the very first response by minio contains the version. So removed the unnecessary for loop that had this check to ensure that the whole report is received properly.