### PR TITLE
Return full value of client in trace message

### DIFF
--- a/api/admin_trace.go
+++ b/api/admin_trace.go
@@ -146,8 +146,7 @@ func shortTrace(info *madmin.ServiceTraceInfo) shortTraceMsg {
 		if host, ok := t.HTTP.ReqInfo.Headers["Host"]; ok {
 			s.Host = strings.Join(host, "")
 		}
-		cSlice := strings.Split(t.HTTP.ReqInfo.Client, ":")
-		s.Client = cSlice[0]
+		s.Client = t.HTTP.ReqInfo.Client
 	}
 
 	return s

--- a/web-app/src/screens/Console/Trace/Trace.tsx
+++ b/web-app/src/screens/Console/Trace/Trace.tsx
@@ -135,7 +135,6 @@ const Trace = () => {
 
   useEffect(() => {
     if (lastJsonMessage) {
-      console.info("Received message", lastJsonMessage);
       lastJsonMessage.ptime = DateTime.fromISO(lastJsonMessage.time).toJSDate();
       lastJsonMessage.key = Math.random();
       dispatch(traceMessageReceived(lastJsonMessage));

--- a/web-app/src/screens/Console/Trace/Trace.tsx
+++ b/web-app/src/screens/Console/Trace/Trace.tsx
@@ -135,6 +135,7 @@ const Trace = () => {
 
   useEffect(() => {
     if (lastJsonMessage) {
+      console.info("Received message", lastJsonMessage);
       lastJsonMessage.ptime = DateTime.fromISO(lastJsonMessage.time).toJSDate();
       lastJsonMessage.key = Math.random();
       dispatch(traceMessageReceived(lastJsonMessage));


### PR DESCRIPTION
Values like this one ```my-console-pool-0-3.my-aistor-hl.my-console.svc.cluster.local:9000/ [::1]``` when you run ```mc admin trace``` are being displayed in the UI as ```[```