### PR TITLE
Show epoch expiry as `no-expiry`

### DIFF
--- a/web-app/src/screens/Console/Account/AccountUtils.tsx
+++ b/web-app/src/screens/Console/Account/AccountUtils.tsx
@@ -23,14 +23,15 @@ export const ACCOUNT_TABLE_COLUMNS = [
     label: "Expiry",
     elementKey: "expiration",
     renderFunction: (expTime: string) => {
-      if (expTime) {
+      if (expTime !== "1970-01-01T00:00:00Z") {
         const fmtDate = DateTime.fromISO(expTime)
           .toUTC()
           .toFormat("y/M/d hh:mm:ss z");
 
         return <span title={fmtDate}>{fmtDate}</span>;
+      } else {
+        return <span>never</span>;
       }
-      return "";
     },
   },
   {

--- a/web-app/src/screens/Console/Account/AccountUtils.tsx
+++ b/web-app/src/screens/Console/Account/AccountUtils.tsx
@@ -30,7 +30,7 @@ export const ACCOUNT_TABLE_COLUMNS = [
 
         return <span title={fmtDate}>{fmtDate}</span>;
       } else {
-        return <span>never</span>;
+        return <span>no-expiry</span>;
       }
     },
   },


### PR DESCRIPTION
If no expiration was set, then this showed up as:
![image](https://github.com/user-attachments/assets/79e1f8f5-603d-4b72-bc19-b70c6d432370)

Instead of showing Epoch date, it will now show `no-expiry`.