### PR TITLE
To enable spaces in policy names

### DIFF
--- a/api/admin_policies.go
+++ b/api/admin_policies.go
@@ -550,9 +550,6 @@ func getAddPolicyResponse(session *models.Principal, params policyApi.AddPolicyP
 	if params.Body == nil {
 		return nil, ErrorWithContext(ctx, ErrPolicyBodyNotInRequest)
 	}
-	if strings.Contains(*params.Body.Name, " ") {
-		return nil, ErrorWithContext(ctx, ErrPolicyNameContainsSpace)
-	}
 	mAdmin, err := NewMinioAdminClient(params.HTTPRequest.Context(), session)
 	if err != nil {
 		return nil, ErrorWithContext(ctx, err)

--- a/api/errors.go
+++ b/api/errors.go
@@ -43,7 +43,6 @@ var (
 	ErrGroupNameNotInRequest            = errors.New("error group name not in request")
 	ErrPolicyNameNotInRequest           = errors.New("error policy name not in request")
 	ErrPolicyBodyNotInRequest           = errors.New("error policy body not in request")
-	ErrPolicyNameContainsSpace          = errors.New("error policy name cannot contain spaces")
 	ErrInvalidEncryptionAlgorithm       = errors.New("error invalid encryption algorithm")
 	ErrSSENotConfigured                 = errors.New("error server side encryption configuration not found")
 	ErrBucketLifeCycleNotConfigured     = errors.New("error bucket life cycle configuration not found")
@@ -160,10 +159,6 @@ func ErrorWithContext(ctx context.Context, err ...interface{}) *CodedAPIError {
 			if errors.Is(err1, ErrPolicyBodyNotInRequest) {
 				errorCode = 400
 				errorMessage = ErrPolicyBodyNotInRequest.Error()
-			}
-			if errors.Is(err1, ErrPolicyNameContainsSpace) {
-				errorCode = 400
-				errorMessage = ErrPolicyNameContainsSpace.Error()
 			}
 			// console invalid session errors
 			if errors.Is(err1, ErrInvalidSession) {

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -176,7 +176,7 @@ func Test_AddPolicyAPI(t *testing.T) {
   ]
 }`),
 			},
-			expectedStatus: 400,
+			expectedStatus: 201, // Changed the expected status from 400 to 201, as spaces are now allowed in policy names.
 			expectedError:  nil,
 		},
 		{

--- a/web-app/src/screens/Console/Policies/AddPolicyScreen.tsx
+++ b/web-app/src/screens/Console/Policies/AddPolicyScreen.tsx
@@ -52,7 +52,7 @@ const AddPolicyScreen = () => {
     setAddLoading(true);
     api.policies
       .addPolicy({
-        name: policyName,
+        name: policyName.trim(),
         policy: policyDefinition,
       })
       .then((res) => {
@@ -79,15 +79,12 @@ const AddPolicyScreen = () => {
   };
 
   const validatePolicyname = (policyName: string) => {
-    if (policyName.indexOf(" ") !== -1) {
-      return "Policy name cannot contain spaces";
+    if (policyName.trim() === "") {
+      return "Policy name cannot be empty";
     } else return "";
   };
 
-  const validSave =
-    policyName.trim() !== "" &&
-    policyName.indexOf(" ") === -1 &&
-    policyDefinition.trim() !== "";
+  const validSave = policyName.trim() !== "" && policyDefinition.trim() !== "";
 
   useEffect(() => {
     dispatch(setHelpName("add_policy"));


### PR DESCRIPTION
Since `mc` allows them:

```shell
mc admin policy create play "1Password IT" mypolicy.json
```