### PR TITLE
Fix typo in User DN Search Filter example

### DIFF
--- a/web-app/src/screens/Console/IDP/utils.tsx
+++ b/web-app/src/screens/Console/IDP/utils.tsx
@@ -221,7 +221,7 @@ export const ldapFormFields = {
     },
     label: "User DN Search Filter",
     tooltip: "",
-    placeholder: "(sAMAcountName=%s)",
+    placeholder: "(sAMAccountName=%s)",
     type: "text",
     editOnly: false,
   },


### PR DESCRIPTION
Hello, I noticed this typo in the example text while setting up LDAP for my company's implementation