### PR TITLE
fix sanitize file path while drag and drop

### DIFF
--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/ListObjects.tsx
@@ -122,6 +122,7 @@ import TooltipWrapper from "../../../../Common/TooltipWrapper/TooltipWrapper";
 import ListObjectsTable from "./ListObjectsTable";
 import FilterObjectsSB from "../../../../ObjectBrowser/FilterObjectsSB";
 import AddAccessRule from "../../../BucketDetails/AddAccessRule";
+import { sanitizeFilePath } from "./utils";
 
 const DeleteMultipleObjects = withSuspense(
   React.lazy(() => import("./DeleteMultipleObjects")),
@@ -506,7 +507,7 @@ const ListObjects = () => {
 
             const blobFile = new Blob([file], { type: file.type });
 
-            const filePath = get(file, "path", "");
+            const filePath = sanitizeFilePath(get(file, "path", ""));
             const fileWebkitRelativePath = get(file, "webkitRelativePath", "");
 
             let relativeFolderPath = folderPath;

--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/utils.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/ListObjects/utils.tsx
@@ -134,3 +134,8 @@ export const displayFileIconName = (
 
   return <IconWithLabel icon={icon} strings={splitItem} />;
 };
+
+export const sanitizeFilePath = (filePath: string) => {
+  // Replace `./` at the start of the path or preceded by `/` - happens when drag drop upload of files (not folders !) in chrome
+  return filePath.replace(/(^|\/)\.\//g, "/");
+};


### PR DESCRIPTION
fix sanitize file path while drag and drop

In chrome, when files are dragged and dropped it adds `./` to the path.  it makes the uploads fail. 

this fix sanitizes the path so the uploads will go through. 

Tested in Linux :
Chrome, 
Firefox. 
IE Edge

Bug:
[console_dnd_upload_bug.webm](https://github.com/user-attachments/assets/48ed9e31-c4f7-4fc4-8cfb-a49cc4e5a1f9)

Fix:
[console_dnd_upload_fix.webm](https://github.com/user-attachments/assets/dbf16f1c-5cb1-4cf7-b695-290851469f57)
