### PR TITLE
fix regex pattern in webhook management

### DIFF
--- a/web-app/src/screens/Console/EventDestinations/WebhookSettings/AddEndpointModal.tsx
+++ b/web-app/src/screens/Console/EventDestinations/WebhookSettings/AddEndpointModal.tsx
@@ -189,7 +189,7 @@ const AddEndpointModal = ({ open, type, onCloseEndpoint }: IEndpointModal) => {
             label="Endpoint"
             value={endpoint}
             pattern={
-              "^(https?):\\/\\/([a-zA-Z0-9\\-.]+)(:[0-9]+)?(\\/[a-zA-Z0-9\\-.\\/]*)?$"
+              "^(https?):\\/\\/([a-zA-Z0-9\\-.]+)(:[0-9]+)?(\\/[a-zA-Z0-9_\\-.\\/]*)?$"
             }
             required
           />

--- a/web-app/src/screens/Console/EventDestinations/WebhookSettings/EditWebhookEndpoint.tsx
+++ b/web-app/src/screens/Console/EventDestinations/WebhookSettings/EditWebhookEndpoint.tsx
@@ -325,7 +325,7 @@ const EditEndpointModal = ({
                 label="Endpoint"
                 value={endpoint}
                 pattern={
-                  "^(https?):\\/\\/([a-zA-Z0-9\\-.]+)(:[0-9]+)?(\\/[a-zA-Z0-9\\-.\\/]*)?$"
+                  "^(https?):\\/\\/([a-zA-Z0-9\\-.]+)(:[0-9]+)?(\\/[a-zA-Z0-9_\\-.\\/]*)?$"
                 }
                 required
               />


### PR DESCRIPTION
Hello,

I've just noticed that the regex in Minio's ui for configuring webhooks doesn't accept underscores. Here is the PR adding the missing character. 
